### PR TITLE
Use existing version of minitest in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ dependencies:
 development_dependencies:
   minitest:
     git: https://github.com/ysbaddaden/minitest.cr.git
-    version: ~> 1.0.0
+    version: ~> 0.3.1
 
 license: MIT
 ```


### PR DESCRIPTION
As a newbie to Crystal I tried to use the usage example from shards' README to get started.

It seems that `minitest`'s latest version is `0.3.1` and not `1.0.0` as stated in the README.

This commit fixes this issue. 