### PR TITLE
Fix for Crystal 0.16.0: use class vars instead of constants

### DIFF
--- a/src/commands/prune.cr
+++ b/src/commands/prune.cr
@@ -8,13 +8,13 @@ module Shards
         return unless lockfile?
         locks = Lock.from_file(lockfile_path)
 
-        Dir[File.join(INSTALL_PATH, "*")].each do |path|
+        Dir[File.join(Shards.install_path, "*")].each do |path|
           next unless Dir.exists?(path)
           name = File.basename(path)
 
           if locks.none? { |d| d.name == name }
             FileUtils.rm_rf(path)
-            Shards.logger.info "Pruned #{File.join(File.basename(INSTALL_PATH), name)}"
+            Shards.logger.info "Pruned #{File.join(File.basename(Shards.install_path), name)}"
           end
         end
       end

--- a/src/config.cr
+++ b/src/config.cr
@@ -2,9 +2,6 @@ module Shards
   SPEC_FILENAME = "shard.yml"
   LOCK_FILENAME = "shard.lock"
 
-  CACHE_DIRECTORY = ENV["SHARDS_CACHE_PATH"]? || File.join(Dir.current, ".shards")
-  INSTALL_PATH = ENV["SHARDS_INSTALL_PATH"]? || File.join(Dir.current, "libs")
-
   DEFAULT_COMMAND = "install"
   DEFAULT_VERSION = "0"
 
@@ -15,5 +12,13 @@ module Shards
   end
 
   def self.production=(@@production)
+  end
+
+  def self.cache_directory
+    @@cache_directory ||= ENV["SHARDS_CACHE_PATH"]? || File.join(Dir.current, ".shards")
+  end
+
+  def self.install_path
+    @@install_path ||= ENV["SHARDS_INSTALL_PATH"]? || File.join(Dir.current, "libs")
   end
 end

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -107,11 +107,11 @@ module Shards
     end
 
     def sha1_path
-      File.join(CACHE_DIRECTORY, "#{ dependency.name }.sha1")
+      File.join(Shards.cache_directory, "#{ dependency.name }.sha1")
     end
 
     def local_path
-      File.join(CACHE_DIRECTORY, dependency.name)
+      File.join(Shards.cache_directory, dependency.name)
     end
 
     def git_url
@@ -177,7 +177,7 @@ module Shards
     end
 
     private def clone_repository
-      Dir.mkdir_p(CACHE_DIRECTORY) unless Dir.exists?(CACHE_DIRECTORY)
+      Dir.mkdir_p(Shards.cache_directory) unless Dir.exists?(Shards.cache_directory)
       run "git clone --mirror --quiet -- #{FileUtils.escape git_url} #{dependency.name}",
         path: File.dirname(local_path)
     rescue Error

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -45,7 +45,7 @@ module Shards
     end
 
     protected def install_path
-      File.join(INSTALL_PATH, dependency.name)
+      File.join(Shards.install_path, dependency.name)
     end
 
     protected def cleanup_install_directory

--- a/test/test_helper.cr
+++ b/test/test_helper.cr
@@ -22,11 +22,11 @@ class Minitest::Test
 
   def clear_repositories
     run "rm -rf #{ tmp_path }/*"
-    run "rm -rf #{ Shards::CACHE_DIRECTORY }/*"
-    run "rm -rf #{ Shards::INSTALL_PATH }/*"
+    run "rm -rf #{ Shards.cache_directory }/*"
+    run "rm -rf #{ Shards.install_path }/*"
   end
 
   def install_path(project, *path_names)
-    File.join(Shards::INSTALL_PATH, project, *path_names)
+    File.join(Shards.install_path, project, *path_names)
   end
 end


### PR DESCRIPTION
This is because constants are now initialized before "main" code, so changing ENV before requiring code doesn't affect a constant's value.

I ran the tests and they all pass :-)

Only merge if this is the solution you also had in mind.