### PR TITLE
upgrade shard template for manastech/webmock

### DIFF
--- a/src/templates/shard.yml.ecr
+++ b/src/templates/shard.yml.ecr
@@ -14,6 +14,6 @@ version: <%= version %>
 
 # development_dependencies:
 #   webmock:
-#     github: manastech/webmock
+#     github: manastech/webmock.cr
 
 # license: MIT


### PR DESCRIPTION
For now, manastech/webmock has renamed to manastech/webmock.cr, we should upgrade the template. Details to see: https://github.com/manastech/webmock.cr