### PR TITLE
GitLab shorthand in spec

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -145,7 +145,7 @@ Example: `git: git://git.example.org/crystal-library.git`
 
 #### github
 
-A GitHub repository (String).
+A [GitHub](https://github.com) repository (String).
 
 The value is the `user/repository` sheme. Extends the `git` resolver, and acts
 exactly like it. One of the other attributes (`version`, `tag`, `branch` o
@@ -155,13 +155,23 @@ Example: `github: ysbaddaden/minitest.cr`
 
 #### bitbucket
 
-A Bitbucket repository (String).
+A [Bitbucket](https://bitbucket.org) repository (String).
 
 The value is the `user/repository` sheme. Extends the `git` resolver, and acts
 exactly like it. One of the other attributes (`version`, `tag`, `branch` o
 r `commit`) is required. When missing Shards will install the HEAD refs.
 
 Example: `bitbucket: tom/library`
+
+#### gitlab
+
+A [GitLab](https://gitlab.com) repository (String).
+
+The value is the `user/repository` scheme. Extends the `git` resolver, and acts
+exactly like it. One of the other attributes (`version`, `tag`, `branch` or
+`commit`) is required. When missing, Shards will install the HEAD refs.
+
+Example: `gitlab: thelonlyghost/minitest.cr`
 
 #### commit
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -65,14 +65,11 @@ Examples: `minitest`, `mysql2`, `battery-horse`.
 
 The version number of the library (String, required).
 
-- It should follow the [Semantic Versioning 2.0](http://semver.org/spec/v2.0.0.html) format.
+- It should follow the [Semantic Versioning](http://semver.org/) format.
 - It must contain digits.
 - It may contain dots and dashes but not consecutive ones.
 
 Examples: `0.0.1`, `1.2.3` or `2.0.0-rc1`.
-
-While Shards doesn't enforce it, following a rational versioning scheme like
-[Semantic Versioning](http://semver.org/spec/v2.0.0.html) is highly recommended.
 
 ### authors
 
@@ -138,19 +135,9 @@ required but will be used if present to validate the dependency.
 
 A Git repository URL (String).
 
-The URL may be of [any protocol supported by the git command line client](https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a),
-which may include:
-
-- `ssh://`
-- `git://`
-- `https://`
-- `http://`
-- `ftps://`
-- `ftp://`
-- implied ssh protocol (e.g., `user@example.com:subdir/repo.git`)
-
-Just the same as the local git command line client, `ssh_config` and associated
-`netrc` settings will be honored for authentication-protected repositories.
+The URL may be of [any protocol](https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a)
+supported by the git command line client, which includes `ssh`, `git`, and
+`https`.
 
 The Git repository will be cloned, the list of versions (and associated
 `shard.yml`) will be extracted from Git tags (e.g., `v1.2.3`).

--- a/SPEC.md
+++ b/SPEC.md
@@ -36,7 +36,7 @@ license: MIT
 
 Both libraries and applications will benefit from `shard.yml`.
 
-The metadata for libraries are expected to have more information (eg: list of
+The metadata for libraries are expected to have more information (e.g., list of
 authors, description, license) than applications that may only have a name and
 dependencies.
 
@@ -65,21 +65,21 @@ Examples: `minitest`, `mysql2`, `battery-horse`.
 
 The version number of the library (String, required).
 
-- It should follow the [Semantic Versioning](http://semver.org/) format.
+- It should follow the [Semantic Versioning 2.0](http://semver.org/spec/v2.0.0.html) format.
 - It must contain digits.
 - It may contain dots and dashes but not consecutive ones.
 
 Examples: `0.0.1`, `1.2.3` or `2.0.0-rc1`.
 
 While Shards doesn't enforce it, following a rational versioning scheme like
-[Semantic Versioning](http://semver.org/) is highly recommended.
+[Semantic Versioning](http://semver.org/spec/v2.0.0.html) is highly recommended.
 
 ### authors
 
 A list of authors, along with their contact email (Array of String).
 
 - Each author must have a name.
-- Each author may have an email address, within lower than (`<`) and greater than (`>`) chars.
+- Each author may have an email address, within angle bracket (`<` and `>`) chars.
 
 Example:
 
@@ -95,16 +95,19 @@ A single line description of the library (String).
 
 ### license
 
-An [OSI license](http://opensource.org/) name or an URL to a license file (String,
-recommended).
+An [OSI license](http://opensource.org/) name or an URL to a license file
+(String, recommended).
+
+For further assistance in choosing an appropriate license, refer to the [website
+curated by GitHub](http://choosealicense.com/) intended for exactly this.
 
 ### dependencies
 
 A list of required dependencies (Hash).
 
-Each dependency begins with the name of the dependency as a key (String) then
-a list of attributes (Hash) that depend on where the dependency is located
-(eg: local path, Git repository).
+Each dependency begins with the name of the dependency as a key (String) then a
+list of attributes (Hash) that depend on where the dependency is located (e.g.,
+local path, Git repository).
 
 Example:
 ```yaml
@@ -128,15 +131,29 @@ Examples: `1.2.3`, `>= 1.0.0` or `~> 2.0`.
 
 A local path (String).
 
-The library will be linked from the local path. The `version` attribute
-isn't required but will be used if present to validate the dependency.
+The library will be linked from the local path. The `version` attribute is not
+required but will be used if present to validate the dependency.
 
 #### git
 
 A Git repository URL (String).
 
+The URL may be of [any protocol supported by the git command line client](https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a),
+which may include:
+
+- `ssh://`
+- `git://`
+- `https://`
+- `http://`
+- `ftps://`
+- `ftp://`
+- implied ssh protocol (e.g., `user@example.com:subdir/repo.git`)
+
+Just the same as the local git command line client, `ssh_config` and associated
+`netrc` settings will be honored for authentication-protected repositories.
+
 The Git repository will be cloned, the list of versions (and associated
-`shard.yml`) will be extracted from Git tags (eg: `v1.2.3`).
+`shard.yml`) will be extracted from Git tags (e.g., `v1.2.3`).
 
 One of the other attributes (`version`, `tag`, `branch` or `commit`) is
 required. When missing, Shards will install the HEAD refs.
@@ -147,9 +164,9 @@ Example: `git: git://git.example.org/crystal-library.git`
 
 A [GitHub](https://github.com) repository (String).
 
-The value is the `user/repository` sheme. Extends the `git` resolver, and acts
-exactly like it. One of the other attributes (`version`, `tag`, `branch` o
-r `commit`) is required. When missing Shards will install the HEAD refs.
+The value is the `user/repository` scheme. Extends the `git` resolver, and acts
+exactly like it. One of the other attributes (`version`, `tag`, `branch` or
+`commit`) is required. When missing, Shards will install the HEAD refs.
 
 Example: `github: ysbaddaden/minitest.cr`
 
@@ -157,9 +174,9 @@ Example: `github: ysbaddaden/minitest.cr`
 
 A [Bitbucket](https://bitbucket.org) repository (String).
 
-The value is the `user/repository` sheme. Extends the `git` resolver, and acts
-exactly like it. One of the other attributes (`version`, `tag`, `branch` o
-r `commit`) is required. When missing Shards will install the HEAD refs.
+The value is the `user/repository` scheme. Extends the `git` resolver, and acts
+exactly like it. One of the other attributes (`version`, `tag`, `branch` or
+`commit`) is required. When missing, Shards will install the HEAD refs.
 
 Example: `bitbucket: tom/library`
 
@@ -188,13 +205,13 @@ Install a Git dependency at the specified branch (String).
 ### development_dependencies
 
 Dependencies may be grouped together as a set of optional development
-dependencies. Those will be installed for the main project or library
-itself. When the library is installed as a dependency for another
-project the development dependencies will never be installed.
+dependencies. Those will be installed for the main project or library itself.
+When the library is installed as a dependency for another project the
+development dependencies will never be installed.
 
 Development dependencies follow the same scheme than dependencies.
-Example:
 
+Example:
 ```yaml
 development_dependencies:
   minitest:

--- a/src/resolvers/gitlab.cr
+++ b/src/resolvers/gitlab.cr
@@ -1,0 +1,15 @@
+require "./git"
+
+module Shards
+  class GitlabResolver < GitResolver
+    def self.key
+      "gitlab"
+    end
+
+    def git_url
+      "https://gitlab.com/#{dependency["gitlab"]}.git"
+    end
+  end
+
+  register_resolver GitlabResolver
+end


### PR DESCRIPTION
Adds `gitlab: user/project` similar to the one for both github and bitbucket.

This also modifies spelling mistakes and overall formatting of the SPEC.md file, but that can be pulled out into a separate PR if need be.
