### PR TITLE
New Crystal search path algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 /.crystal
 /.shards
-/libs
+/lib
 /bin/shards
 /test/.repositories
 /test/.shards
-/test/.libs
+/test/.lib
 /tmp

--- a/SPEC.md
+++ b/SPEC.md
@@ -235,7 +235,7 @@ installed or upgraded in a project that requires it. This may be used to compile
 a C library, to build tools to help working on the project, or anything else.
 
 The script will be run from the dependency's installation directory, for example
-`libs/foo` for a Shard named `foo`.
+`lib/foo` for a Shard named `foo`.
 
 ```yaml
 scripts:

--- a/src/config.cr
+++ b/src/config.cr
@@ -13,7 +13,7 @@ module Shards
   end
 
   def self.install_path
-    @@install_path ||= ENV.fetch("SHARDS_INSTALL_PATH") { File.join(Dir.current, "libs") }
+    @@install_path ||= ENV.fetch("SHARDS_INSTALL_PATH") { File.join(Dir.current, "lib") }
   end
 
   def self.install_path=(@@install_path : String)

--- a/src/config.cr
+++ b/src/config.cr
@@ -13,10 +13,27 @@ module Shards
   end
 
   def self.install_path
-    @@install_path ||= ENV.fetch("SHARDS_INSTALL_PATH") { File.join(Dir.current, "lib") }
+    @@install_path ||= begin
+      warn_about_legacy_libs_path
+      ENV.fetch("SHARDS_INSTALL_PATH") { File.join(Dir.current, "lib") }
+    end
   end
 
   def self.install_path=(@@install_path : String)
+  end
+
+  private def self.warn_about_legacy_libs_path
+    # TODO: drop me in a future release
+
+    legacy_install_path = if path = ENV["SHARDS_INSTALL_PATH"]?
+                            File.join(File.dirname(path), "libs")
+                          else
+                            File.join(Dir.current, "libs")
+                          end
+
+    if File.exists?(legacy_install_path)
+      Shards.logger.warn "Shards now installs dependencies into the 'lib' folder. You may delete the legacy 'libs' folder."
+    end
   end
 
   @@production = false

--- a/src/logger.cr
+++ b/src/logger.cr
@@ -68,7 +68,7 @@ end
 module Shards
   LOGGER_COLORS = {
     "ERROR" => :red,
-    "WARN"  => :orange,
+    "WARN"  => :light_yellow,
     "INFO"  => :light_green,
     "DEBUG" => :light_gray,
   }

--- a/src/man/shards.1
+++ b/src/man/shards.1
@@ -48,7 +48,7 @@ Prints the Shards version.
 .PP
 \fBinstall\fR
 .RS 4
-Resolves and installs dependencies into the \fIlibs\fR folder. If not already
+Resolves and installs dependencies into the \fIlib\fR folder. If not already
 present, generates a \fIshard.lock\fR file from resolved dependencies, locking
 version numbers or Git commits.
 .PP
@@ -60,7 +60,7 @@ doesn't generate a conflict, thus generating a new \fIshard.lock\fR file.
 .PP
 \fBupdate\fR
 .RS 4
-Resolves and updates all dependencies into the \fIlibs\fR folder again,
+Resolves and updates all dependencies into the \fIlib\fR folder again,
 whatever the locked versions and commits in the \fIshard.lock\fR file.
 Eventually generates a new \fIshard.lock\fR file.
 .RE

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -81,18 +81,11 @@ module Shards
       cleanup_install_directory
       Dir.mkdir_p(install_path)
 
-      if file_exists?(refs, SPEC_FILENAME)
-        run "git archive --format=tar #{refs} #{SPEC_FILENAME} | tar -x -f - -C #{FileUtils.escape install_path}"
-      else
+      unless file_exists?(refs, SPEC_FILENAME)
         File.write(File.join(install_path, "shard.yml"), read_spec(version))
       end
 
-      # TODO: search for LICENSE* files
-      if file_exists?(refs, "LICENSE")
-        run "git archive --format=tar #{refs} 'LICENSE' | tar -x -f - -C #{FileUtils.escape install_path}"
-      end
-
-      run "git archive --format=tar --prefix= #{refs}:src/ | tar -x -f - -C #{FileUtils.escape install_path}"
+      run "git archive --format=tar --prefix= #{refs} | tar -x -f - -C #{FileUtils.escape install_path}"
 
       if version =~ RELEASE_VERSION
         File.delete(sha1_path) if File.exists?(sha1_path)

--- a/src/resolvers/path.cr
+++ b/src/resolvers/path.cr
@@ -43,13 +43,12 @@ module Shards
     end
 
     def install(version = nil)
+      path = File.expand_path(local_path)
+      raise Error.new("Failed no such path: #{path}") unless Dir.exists?(path)
+
       cleanup_install_directory
       Dir.mkdir_p(File.dirname(install_path))
-
-      src_path = File.expand_path(File.join(local_path, "src"))
-      raise Error.new("Failed no such path: #{local_path}") unless Dir.exists?(src_path)
-
-      File.symlink(src_path, install_path)
+      File.symlink(path, install_path)
     end
   end
 

--- a/test/git_resolver_test.cr
+++ b/test/git_resolver_test.cr
@@ -33,12 +33,11 @@ module Shards
       assert_equal "name: library\nversion: 0.1.1\n", resolver("library").read_spec("0.1.1")
     end
 
-    # TODO: test that LICENSE was installed
     def test_install
       library, legacy = resolver("library"), resolver("legacy")
 
       library.install("0.1.2")
-      assert File.exists?(install_path("library", "library.cr"))
+      assert File.exists?(install_path("library", "src/library.cr"))
       assert File.exists?(install_path("library", "shard.yml"))
       assert_equal "0.1.2", library.installed_spec.not_nil!.version
       #assert File.exists?(install_path("library", "LICENSE"))
@@ -47,11 +46,11 @@ module Shards
       assert_equal "0.2.0", library.installed_spec.not_nil!.version
 
       legacy.install
-      assert File.exists?(install_path("legacy", "legacy.cr"))
+      assert File.exists?(install_path("legacy", "src/legacy.cr"))
       assert File.exists?(install_path("legacy", "shard.yml"))
 
       legacy.install("1.0.0")
-      assert File.exists?(install_path("legacy", "legacy.cr"))
+      assert File.exists?(install_path("legacy", "src/legacy.cr"))
       assert File.exists?(install_path("legacy", "shard.yml"))
       assert_equal "1.0.0", legacy.installed_spec.not_nil!.version
     end
@@ -64,7 +63,7 @@ module Shards
       empty = resolver("empty")
 
       empty.install # HEAD
-      assert File.exists?(install_path("empty", "empty.cr"))
+      assert File.exists?(install_path("empty", "src/empty.cr"))
       assert File.exists?(install_path("empty", "shard.yml"))
 
       spec = empty.installed_spec.not_nil!

--- a/test/integration/install_test.cr
+++ b/test/integration/install_test.cr
@@ -225,7 +225,7 @@ class InstallCommandTest < Minitest::Test
   def test_runs_postinstall_script
     with_shard({ dependencies: { post: "*" } }) do
       run "shards install"
-      assert File.exists?(File.join(application_path, "libs", "post", "made.txt"))
+      assert File.exists?(File.join(application_path, "lib", "post", "made.txt"))
     end
   end
 
@@ -234,7 +234,7 @@ class InstallCommandTest < Minitest::Test
       ex = assert_raises(FailedCommand) { run "shards install --no-color" }
       assert_match "E: Failed make:\n", ex.stdout
       assert_match "test -n ''\n", ex.stdout
-      refute Dir.exists?(File.join(application_path, "libs", "fails"))
+      refute Dir.exists?(File.join(application_path, "lib", "fails"))
     end
   end
 

--- a/test/integration/prune_test.cr
+++ b/test/integration/prune_test.cr
@@ -20,18 +20,18 @@ class PruneCommandTest < Minitest::Test
   end
 
   def test_removes_directories
-    Dir.mkdir(File.join(application_path, "libs", "test"))
+    Dir.mkdir(File.join(application_path, "lib", "test"))
     Dir.cd(application_path) { run "shards prune" }
     assert_equal ["web"], installed_dependencies
   end
 
   def test_wont_remove_files
-    File.write(File.join(application_path, "libs", ".keep"), "")
+    File.write(File.join(application_path, "lib", ".keep"), "")
     Dir.cd(application_path) { run "shards prune" }
     assert_equal [".keep", "web"], installed_dependencies.sort
   end
 
   private def installed_dependencies
-    Dir[File.join(application_path, "libs", "*")].map { |path| File.basename(path) }
+    Dir[File.join(application_path, "lib", "*")].map { |path| File.basename(path) }
   end
 end

--- a/test/integration_helper.cr
+++ b/test/integration_helper.cr
@@ -47,11 +47,11 @@ class Minitest::Test
     create_git_commit "empty", "initial release"
 
     create_git_repository "post"
-    create_file "post", "src/Makefile", "all:\n\ttouch made.txt\n"
+    create_file "post", "Makefile", "all:\n\ttouch made.txt\n"
     create_git_release "post", "0.1.0", "name: post\nversion: 0.1.0\nscripts:\n  postinstall: make\n"
 
     create_git_repository "fails"
-    create_file "fails", "src/Makefile", "all:\n\ttest -n ''\n"
+    create_file "fails", "Makefile", "all:\n\ttest -n ''\n"
     create_git_release "fails", "0.1.0", "name: fails\nversion: 0.1.0\nscripts:\n  postinstall: make\n"
 
     create_path_repository "foo"

--- a/test/integration_helper.cr
+++ b/test/integration_helper.cr
@@ -113,7 +113,7 @@ class Minitest::Test
   end
 
   def install_path(project, *path_names)
-    File.join(application_path, "libs", project, *path_names)
+    File.join(application_path, "lib", project, *path_names)
   end
 
   def debug(command)

--- a/test/path_resolver_test.cr
+++ b/test/path_resolver_test.cr
@@ -36,14 +36,14 @@ module Shards
     def test_install
       resolver("library").tap do |library|
         library.install
-        assert File.exists?(install_path("library", "library.cr"))
-        refute File.exists?(install_path("library", "shard.yml"))
+        assert File.exists?(install_path("library", "src/library.cr"))
+        assert File.exists?(install_path("library", "shard.yml"))
         assert_equal "1.2.3", library.installed_spec.not_nil!.version
       end
 
       resolver("legacy").tap do |legacy|
         legacy.install
-        assert File.exists?(install_path("legacy", "legacy.cr"))
+        assert File.exists?(install_path("legacy", "src/legacy.cr"))
         refute File.exists?(install_path("legacy", "shard.yml"))
         assert_equal DEFAULT_VERSION, legacy.installed_spec.not_nil!.version
       end

--- a/test/test_helper.cr
+++ b/test/test_helper.cr
@@ -4,7 +4,7 @@ require "../src/logger"
 require "../src/manager"
 
 Shards.cache_path = File.join(__DIR__, ".shards")
-Shards.install_path = File.join(__DIR__, ".libs")
+Shards.install_path = File.join(__DIR__, ".lib")
 
 require "./support/factories"
 require "./support/mock_resolver"


### PR DESCRIPTION
- Shards counterpart to support https://github.com/crystal-lang/crystal/pull/2788
- closes #123 
- unblocks #126 

Breaking changes:
- dependencies are installed into the `lib` folder;
- dependencies are fully installed (not merely the `src`);
- `postinstall` scripts are now run from the root of a dependency, not the `src` folder.
