### PR TITLE
Do not generate lockfile when there are no deps.

### DIFF
--- a/src/commands/command.cr
+++ b/src/commands/command.cr
@@ -55,5 +55,13 @@ module Shards
     def lockfile?
       File.exists?(lockfile_path)
     end
+
+    private def generate_lockfile?
+      !Shards.production? && manager.packages.any? && (!lockfile? || outdated_lockfile?)
+    end
+
+    private def outdated_lockfile?
+      locks.size != manager.packages.size
+    end
   end
 end

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -57,14 +57,6 @@ module Shards
           package.install(version)
         end
       end
-
-      private def generate_lockfile?
-        !Shards.production? && manager.packages.any? && (!lockfile? || outdated_lockfile?)
-      end
-
-      private def outdated_lockfile?
-        locks.size != manager.packages.size
-      end
     end
   end
 end

--- a/src/commands/update.cr
+++ b/src/commands/update.cr
@@ -5,6 +5,11 @@ module Shards
     class Update < Command
       # TODO: only update specified dependencies (ie. load locked versions, but don't enforce them)
       def run
+        unless has_dependencies?
+          Shards.logger.info "Dependencies are satisifed"
+          return
+        end
+
         manager.resolve
 
         manager.packages.each do |package|
@@ -17,6 +22,10 @@ module Shards
         end
 
         manager.to_lock(lockfile_path)
+      end
+
+      private def has_dependencies?
+        spec.dependencies.any? || (!shards.production? && spec.development_dependencies.any?)
       end
     end
   end

--- a/src/commands/update.cr
+++ b/src/commands/update.cr
@@ -5,11 +5,6 @@ module Shards
     class Update < Command
       # TODO: only update specified dependencies (ie. load locked versions, but don't enforce them)
       def run
-        unless has_dependencies?
-          Shards.logger.info "Dependencies are satisifed"
-          return
-        end
-
         manager.resolve
 
         manager.packages.each do |package|
@@ -21,7 +16,9 @@ module Shards
           end
         end
 
-        manager.to_lock(lockfile_path)
+        if generate_lockfile?
+          manager.to_lock(lockfile_path)
+        end
       end
 
       private def has_dependencies?

--- a/test/integration/update_test.cr
+++ b/test/integration/update_test.cr
@@ -104,7 +104,8 @@ class UpdateCommandTest < Minitest::Test
   def test_empty_dependencies
     metadata = { dependencies: {} of Symbol => String }
     with_shard(metadata) do
-      refute_lockfile
+      path = File.join(application_path, "shard.lock")
+      refute File.exists?(path)
     end
   end
 end

--- a/test/integration/update_test.cr
+++ b/test/integration/update_test.cr
@@ -100,4 +100,11 @@ class UpdateCommandTest < Minitest::Test
       refute_locked "orm"
     end
   end
+
+  def test_empty_dependencies
+    metadata = { dependencies: {} of Symbol => String }
+    with_shard(metadata) do
+      refute_lockfile
+    end
+  end
 end

--- a/test/integration_helper.cr
+++ b/test/integration_helper.cr
@@ -108,6 +108,11 @@ class Minitest::Test
     refute locks.find { |d| d.name == name }, "expected #{name} dependency to not have been locked"
   end
 
+  def refute_lockfile
+    path = File.join(application_path, "shard.lock")
+    refute File.exists?(path)
+  end
+
   def cache_path(*path_names)
     File.join(application_path, ".shards", *path_names)
   end

--- a/test/integration_helper.cr
+++ b/test/integration_helper.cr
@@ -108,11 +108,6 @@ class Minitest::Test
     refute locks.find { |d| d.name == name }, "expected #{name} dependency to not have been locked"
   end
 
-  def refute_lockfile
-    path = File.join(application_path, "shard.lock")
-    refute File.exists?(path)
-  end
-
   def cache_path(*path_names)
     File.join(application_path, ".shards", *path_names)
   end


### PR DESCRIPTION
I noticed when running the `shards update` command that it generates an invalid lockfile for projects with no dependencies, this then upsets `crystal deps` of course.  It seems a bit odd so this is a proposal to avoid generating a lockfile if there are no dependencies to lock.
I would be happy to modify it if it's unsuitable for any reason.