### PR TITLE
Added a feature `shards build`

### DIFF
--- a/src/cli.cr
+++ b/src/cli.cr
@@ -10,7 +10,7 @@ module Shards
     #puts "    info <package>"
     puts "    init"
     puts "    install"
-    puts "    build"
+    puts "    build [targets] [options]"
     puts "    list"
     puts "    prune"
     #puts "    search <query>"
@@ -55,7 +55,8 @@ module Shards
           Commands::Update.run(path)
         #Commands.update(*args[1 .. -1])
         when  "build"
-          Commands::Build.run(path, args.size > 1 ? args[1] : nil)
+          Commands::Build.set_args(args[1..(args.size-1)]) if args.size > 1
+          Commands::Build.run(path)
         else
           display_help_and_exit(opts)
         end

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -10,6 +10,7 @@ module Shards
     #puts "    info <package>"
     puts "    init"
     puts "    install"
+    puts "    build"
     puts "    list"
     puts "    prune"
     #puts "    search <query>"
@@ -52,7 +53,9 @@ module Shards
         #  Commands::Search.run(args[1])
         when "update"
           Commands::Update.run(path)
-          #Commands.update(*args[1 .. -1])
+        #Commands.update(*args[1 .. -1])
+        when  "build"
+          Commands::Build.run(path, args.size > 1 ? args[1] : nil)
         else
           display_help_and_exit(opts)
         end

--- a/src/commands/build.cr
+++ b/src/commands/build.cr
@@ -3,34 +3,69 @@ require "./command"
 module Shards
   module Commands
     class Build < Command
+
+      @@args = [] of String
+
+      # command line arguments
+      @targets = [] of String
+      @options = [] of String
+
       def run
-        # Return if 'crystal' command is not installed
-        return unless has_crystal_command?
-
-        @sub ||= "default"
-
-        if @sub == "all"
+        # Install dependencies before the build
+        Install.run(@path)
+        # Parse to find targets and options
+        parse_args
+        # mkdir bin
+        mkdir_bin
+        if @targets.size == 0
+          raise Error.new("Error: No target found in shard.yml") if manager.spec.targets.nil?
           manager.spec.targets.each do |target|
             build target
           end
         else
-          target = manager.spec.targets.find{ |t| t.name == @sub }
-          raise Error.new("Target \'#{@sub}\' is not found") if target.nil?
-          build target
+          @targets.each do |name|
+            target = manager.spec.targets.find{ |t| t.name == name }
+            raise Error.new("Error: target \'#{name}\' is not found") if target.nil?
+            build target
+          end
         end
+      end
+
+      def parse_args
+        is_option? = false
+        @@args.each do |arg|
+          is_option? = true if arg.starts_with?("-")
+          if is_option?
+            @options.push(arg)
+          else
+            @targets.push(arg)
+          end
+        end
+      end
+
+      def mkdir_bin
+        bin_path = File.join(@path, "bin")
+        Dir.mkdir bin_path unless Dir.exists?(bin_path)
       end
 
       def build(target)
         Shards.logger.info "Building: #{target.name}"
 
+        args = ["build", target.main] + @options
+        unless @options.includes?("-o")
+          args.push("-o")
+          args.push(File.join("bin", target.name))
+        end
+
         error = MemoryIO.new
-        status = Process.run("/bin/sh", input: MemoryIO.new(target.cmd), output: nil, error: error)
+        status = Process.run("crystal",
+                             args: args,
+                             output: nil, error: error)
         raise Error.new("#{error.to_s}") unless status.success?
       end
 
-      def has_crystal_command?
-        raise Error.new("\'crystal\' is not installed") unless system("which crystal > /dev/null 2>&1")
-        true
+      def self.set_args(args : Array(String))
+        @@args = args
       end
     end
   end

--- a/src/commands/build.cr
+++ b/src/commands/build.cr
@@ -1,0 +1,36 @@
+require "./command"
+
+module Shards
+  module Commands
+    class Build < Command
+      def run
+        # Return if 'crystal' command is not installed
+        return unless crystal_is_installed?
+
+        name = @sub.nil? ? "default" : @sub
+
+        if name == "all"
+          Shards.logger.info "Build all targets"
+          manager.spec.targets.each do |target|
+            build target
+          end
+        else
+          target = manager.spec.targets.find{ |t| t.name == name }
+          raise Error.new("Target \'#{name}\' is not found") if target.nil?
+          build target
+        end
+      end
+
+      def build(target)
+        Shards.logger.info "Target: #{target.name}"
+        Shards.logger.info "   cmd: #{target.cmd}"
+        # git.cr L232
+      end
+
+      def crystal_is_installed?
+        raise Error.new("\'crystal\' is not installed") unless system("which crystal > /dev/null 2>&1")
+        true
+      end
+    end
+  end
+end

--- a/src/commands/build.cr
+++ b/src/commands/build.cr
@@ -17,7 +17,7 @@ module Shards
         parse_args
         # mkdir bin
         mkdir_bin
-        if @targets.size == 0
+        if @targets.empty?
           raise Error.new("Error: No target found in shard.yml") if manager.spec.targets.nil?
           manager.spec.targets.each do |target|
             build target
@@ -34,7 +34,7 @@ module Shards
       def parse_args
         is_option? = false
         @@args.each do |arg|
-          is_option? = true if arg.starts_with?("-")
+          is_option? = true if arg.starts_with?('-')
           if is_option?
             @options.push(arg)
           else

--- a/src/commands/command.cr
+++ b/src/commands/command.cr
@@ -12,7 +12,7 @@ module Shards
     @spec : Spec?
     @locks : Array(Dependency)?
 
-    def initialize(path, @sub = nil)
+    def initialize(path)
       if File.directory?(path)
         @path = path
         @spec_path = File.join(path, SPEC_FILENAME)

--- a/src/commands/command.cr
+++ b/src/commands/command.cr
@@ -5,13 +5,14 @@ require "../spec"
 module Shards
   abstract class Command
     getter path : String
+    getter sub : String | Nil
     getter spec_path : String
     getter lockfile_path : String
 
     @spec : Spec?
     @locks : Array(Dependency)?
 
-    def initialize(path)
+    def initialize(path, @sub = nil)
       if File.directory?(path)
         @path = path
         @spec_path = File.join(path, SPEC_FILENAME)
@@ -24,8 +25,8 @@ module Shards
 
     abstract def run
 
-    def self.run(path)
-      new(path).run
+    def self.run(path, sub = nil)
+      new(path, sub).run
     end
 
     def spec

--- a/src/commands/command.cr
+++ b/src/commands/command.cr
@@ -5,7 +5,6 @@ require "../spec"
 module Shards
   abstract class Command
     getter path : String
-    getter sub : String | Nil
     getter spec_path : String
     getter lockfile_path : String
 
@@ -25,8 +24,8 @@ module Shards
 
     abstract def run
 
-    def self.run(path, sub = nil)
-      new(path, sub).run
+    def self.run(path)
+      new(path).run
     end
 
     def spec

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -97,18 +97,12 @@ module Shards
           end
         when "targets"
           read_mapping(pull) do
-            target = Target.new(pull.read_scalar)
+            target_name = pull.read_scalar
             read_mapping(pull) do
-              case pull.read_scalar
-              when "main"
-                target.main = pull.read_scalar
-              when "options"
-                read_sequence(pull) do
-                  target.options.push(pull.read_scalar)
-                end
-              end
+              pull.read_next # main:
+              target = Target.new(target_name, pull.read_scalar)
+              targets << target
             end
-            targets << target
           end
         when "libraries"
           read_mapping(pull) do

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -3,6 +3,7 @@ require "yaml"
 require "./config"
 require "./dependency"
 require "./errors"
+require "./target"
 
 module Shards
   class Spec
@@ -94,6 +95,21 @@ module Shards
             read_mapping(pull) { dependency[pull.read_scalar] = pull.read_scalar }
             development_dependencies << dependency
           end
+        when "targets"
+          read_mapping(pull) do
+            target = Target.new(pull.read_scalar)
+            read_mapping(pull) do
+              case pull.read_scalar
+              when "main"
+                target.main = pull.read_scalar
+              when "options"
+                read_sequence(pull) do
+                  target.options.push(pull.read_scalar)
+                end
+              end
+            end
+            targets << target
+          end
         when "libraries"
           read_mapping(pull) do
             libraries << Library.new(pull)
@@ -138,6 +154,10 @@ module Shards
 
     def development_dependencies
       @development_dependencies ||= [] of Dependency
+    end
+
+    def targets
+      @targets ||= [] of Target
     end
 
     def libraries

--- a/src/target.cr
+++ b/src/target.cr
@@ -1,0 +1,17 @@
+module Shards
+  class Target
+    getter name : String
+    property main : String
+    property options : Array(String)
+
+    def initialize(@name)
+      super()
+      @main = ""
+      @options = [] of String
+    end
+
+    def cmd
+      "crystal build #{@main} #{@options.join(" ")}"
+    end
+  end
+end

--- a/src/target.cr
+++ b/src/target.cr
@@ -1,17 +1,9 @@
 module Shards
   class Target
     getter name : String
-    property main : String
-    property options : Array(String)
+    getter main : String
 
-    def initialize(@name)
-      super()
-      @main = ""
-      @options = [] of String
-    end
-
-    def cmd
-      "crystal build #{@main} #{@options.join(" ")}"
+    def initialize(@name, @main)
     end
   end
 end

--- a/test/integration/build_test.cr
+++ b/test/integration/build_test.cr
@@ -1,0 +1,75 @@
+require "../integration_helper"
+
+class BuildCommandTest < Minitest::Test
+
+  def test_succeeds_for_default
+    metadata = {
+      targets: { default: { main: "mock.cr" } }
+    }
+    
+    with_shard(metadata) do
+      Dir.cd(application_path) do
+        File.open "mock.cr", "w"
+        run "shards build"
+        assert File.exists?(File.join(application_path, "mock"))
+      end
+    end
+  end
+
+  def test_succeeds_for_default_with_options
+    metadata = {
+      targets: { default: { main: "mock.cr", options: ["--release"] } }
+    }
+    
+    with_shard(metadata) do
+      Dir.cd(application_path) do
+        File.open "mock.cr", "w"
+        run "shards build"
+        assert File.exists?(File.join(application_path, "mock"))
+      end
+    end
+  end
+
+  def test_succeeds_for_specified_target
+    metadata = {
+      targets: { mock: { main: "mock.cr" } }
+    }
+
+    with_shard(metadata) do
+      Dir.cd(application_path) do
+        File.open "mock.cr", "w"
+        run "shards build mock"
+        assert File.exists?(File.join(application_path, "mock"))
+      end
+    end
+  end
+
+  def test_succeeds_for_all_targets
+    metadata = { targets: {
+                   mock1: { main: "mock1.cr" },
+                   mock2: { main: "mock2.cr" }
+                 } }
+
+    with_shard(metadata) do
+      Dir.cd(application_path) do
+        File.open "mock1.cr", "w"
+        File.open "mock2.cr", "w"
+        run "shards build all"
+        assert File.exists?(File.join(application_path, "mock1"))
+        assert File.exists?(File.join(application_path, "mock2"))
+      end
+    end
+  end
+
+  def test_fails_when_target_is_missing
+    metadata = { targets: { mock: { main: "mock.cr" } } }
+
+    with_shard(metadata) do
+      Dir.cd(application_path) do
+        File.open "mock.cr", "w"
+        ex = assert_raises(FailedCommand) { run "shards build mock_fake" }
+        assert_match "\e[31mTarget\e[0m 'mock_fake' is not found\n", ex.stdout
+      end
+    end
+  end
+end

--- a/test/integration/build_test.cr
+++ b/test/integration/build_test.cr
@@ -2,35 +2,58 @@ require "../integration_helper"
 
 class BuildCommandTest < Minitest::Test
 
-  def test_succeeds_for_default
-    metadata = {
-      targets: { default: { main: "mock.cr" } }
-    }
-    
-    with_shard(metadata) do
-      Dir.cd(application_path) do
-        File.open "mock.cr", "w"
-        run "shards build"
-        assert File.exists?(File.join(application_path, "mock"))
-      end
-    end
-  end
-
-  def test_succeeds_for_default_with_options
-    metadata = {
-      targets: { default: { main: "mock.cr", options: ["--release"] } }
-    }
-    
-    with_shard(metadata) do
-      Dir.cd(application_path) do
-        File.open "mock.cr", "w"
-        run "shards build"
-        assert File.exists?(File.join(application_path, "mock"))
-      end
-    end
-  end
-
   def test_succeeds_for_specified_target
+    metadata = {
+      targets: { mock: { main: "mock.cr" } }
+    }
+    
+    with_shard(metadata) do
+      Dir.cd(application_path) do
+        File.open "mock.cr", "w"
+        run "shards build mock"
+        assert File.exists?(File.join(application_path, "bin", "mock"))
+      end
+    end
+  end
+
+  def test_succeeds_for_all_targets
+    metadata = {
+      targets: { mock1: { main: "mock1.cr" },
+                 mock2: { main: "mock2.cr" } }
+    }
+    
+    with_shard(metadata) do
+      Dir.cd(application_path) do
+        File.open "mock1.cr", "w"
+        File.open "mock2.cr", "w"
+        run "shards build"
+        assert File.exists?(File.join(application_path, "bin", "mock1"))
+        assert File.exists?(File.join(application_path, "bin", "mock2"))
+      end
+    end
+  end
+
+  def test_succeeds_for_multiple_targets
+    metadata = {
+      targets: { mock1: { main: "mock1.cr" },
+                 mock2: { main: "mock2.cr" },
+                 mock3: { main: "mock3.cr" } }
+    }
+
+    with_shard(metadata) do
+      Dir.cd(application_path) do
+        File.open "mock1.cr", "w"
+        File.open "mock2.cr", "w"
+        File.open "mock3.cr", "w"
+        run "shards build mock1 mock2"
+        assert File.exists?(File.join(application_path, "bin", "mock1"))
+        assert File.exists?(File.join(application_path, "bin", "mock2"))
+        assert !File.exists?(File.join(application_path, "bin", "mock3"))
+      end
+    end
+  end
+
+  def test_fails_when_specified_target_is_not_found
     metadata = {
       targets: { mock: { main: "mock.cr" } }
     }
@@ -38,37 +61,9 @@ class BuildCommandTest < Minitest::Test
     with_shard(metadata) do
       Dir.cd(application_path) do
         File.open "mock.cr", "w"
-        run "shards build mock"
-        assert File.exists?(File.join(application_path, "mock"))
-      end
-    end
-  end
-
-  def test_succeeds_for_all_targets
-    metadata = { targets: {
-                   mock1: { main: "mock1.cr" },
-                   mock2: { main: "mock2.cr" }
-                 } }
-
-    with_shard(metadata) do
-      Dir.cd(application_path) do
-        File.open "mock1.cr", "w"
-        File.open "mock2.cr", "w"
-        run "shards build all"
-        assert File.exists?(File.join(application_path, "mock1"))
-        assert File.exists?(File.join(application_path, "mock2"))
-      end
-    end
-  end
-
-  def test_fails_when_target_is_missing
-    metadata = { targets: { mock: { main: "mock.cr" } } }
-
-    with_shard(metadata) do
-      Dir.cd(application_path) do
-        File.open "mock.cr", "w"
-        ex = assert_raises(FailedCommand) { run "shards build mock_fake" }
-        assert_match "\e[31mTarget\e[0m 'mock_fake' is not found\n", ex.stdout
+        ex = assert_raises(FailedCommand) { run "shards --no-color build mock_fake" }
+        assert_match "E: Error: target 'mock_fake' is not found\n", ex.stdout
+        assert_empty ex.stderr
       end
     end
   end

--- a/test/support/cli.cr
+++ b/test/support/cli.cr
@@ -54,6 +54,25 @@ module Shards
             else
               yml << value
             end
+          elsif key.to_s == "targets"
+            yml << "targets:\n"
+            value.each do |target, info|
+              yml << "  " << target.to_s << ":\n"
+              info.each_key do |info_key|
+                case info_key
+                when :main
+                  yml << "    main: " << info[info_key].inspect << "\n"
+                when :options
+                  yml << "    options:\n"
+                  options = info[info_key]
+                  if options.is_a?(Array(String))
+                    options.each do |option|
+                      yml << "      - " << option.inspect << "\n"
+                    end
+                  end
+                end
+              end
+            end
           end
         end
       end

--- a/test/support/cli.cr
+++ b/test/support/cli.cr
@@ -56,21 +56,10 @@ module Shards
             end
           elsif key.to_s == "targets"
             yml << "targets:\n"
-            value.each do |target, info|
-              yml << "  " << target.to_s << ":\n"
-              info.each_key do |info_key|
-                case info_key
-                when :main
-                  yml << "    main: " << info[info_key].inspect << "\n"
-                when :options
-                  yml << "    options:\n"
-                  options = info[info_key]
-                  if options.is_a?(Array(String))
-                    options.each do |option|
-                      yml << "      - " << option.inspect << "\n"
-                    end
-                  end
-                end
+            unless value.nil?
+              value.each do |target, info|
+                yml << "  " << target.to_s << ":\n"
+                yml << "    main: " << info[:main].inspect << "\n"
               end
             end
           end

--- a/test/support/cli.cr
+++ b/test/support/cli.cr
@@ -56,10 +56,14 @@ module Shards
             end
           elsif key.to_s == "targets"
             yml << "targets:\n"
-            unless value.nil?
+            if value.responds_to?(:each)
               value.each do |target, info|
                 yml << "  " << target.to_s << ":\n"
-                yml << "    main: " << info[:main].inspect << "\n"
+                if info.responds_to?(:each)
+                  info.each do |main, src|
+                    yml << "    main: " << src.inspect << "\n"
+                  end
+                end
               end
             end
           end


### PR DESCRIPTION
Hi all,

This PR is based on https://github.com/crystal-lang/crystal/pull/3538.
I added a `build` command for `shards`.

In shard.yml, we set
```
targets:
  default:
    main: src/main.cr
    options:
      - -o bin/main
      - --release
  sub:
    main: src/sub.cr
```

Then,
```
$ shards build # Build "default" target without specified target
Building: default

$ shards build sub # Build specified target, here it is "sub"
Building: sub

$ shards build all # Build all targets
Building: default
Building: sub

$ shards build fake # Undefined targets raise an error
Target 'fake' is not found
```

Thanks for your review!