### PR TITLE
Introduces `version` command to retrieve shards current version

### DIFF
--- a/src/cli.cr
+++ b/src/cli.cr
@@ -15,7 +15,8 @@ module Shards
     puts "    prune"
     #puts "    search <query>"
     puts "    update"
-    #puts "    update [package package ...]"
+    # puts "    update [package package ...]"
+    puts "    version [path]"
     puts
     puts "Options:"
     puts opts
@@ -50,12 +51,14 @@ module Shards
           Commands::List.run(path)
         when "prune"
           Commands::Prune.run(path)
-        #when "search"
-        #  display_help_and_exit(opts) unless args[1]?
-        #  Commands::Search.run(path, args[1])
+          # when "search"
+          #  display_help_and_exit(opts) unless args[1]?
+          #  Commands::Search.run(path, args[1])
         when "update"
           Commands::Update.run(path)
-          #Commands.update(path, *args[1..-1])
+          # Commands.update(path, *args[1..-1])
+        when "version"
+          Commands::Version.run(args[1]? || path)
         else
           display_help_and_exit(opts)
         end

--- a/src/commands/version.cr
+++ b/src/commands/version.cr
@@ -1,0 +1,33 @@
+require "../helpers/versions"
+require "./command"
+
+module Shards
+  module Commands
+    class Version < Command
+      def self.run(path, *args)
+        path = lookup_path(path)
+        new(path).run(*args)
+      end
+
+      def run(*args)
+        puts spec.version
+      end
+
+      # look up for `SPEC_FILENAME` in *path* or up
+      private def self.lookup_path(path)
+        previous = nil
+        current = File.expand_path(path)
+
+        until !File.directory?(current) || current == previous
+          shard_file = File.join(current, SPEC_FILENAME)
+          break if File.exists?(shard_file)
+
+          previous = current
+          current = File.dirname(current)
+        end
+
+        current
+      end
+    end
+  end
+end

--- a/test/integration/version_test.cr
+++ b/test/integration/version_test.cr
@@ -1,0 +1,36 @@
+require "../integration_helper"
+
+class VersionCommandTest < Minitest::Test
+  def test_version_default_directory
+    metadata = {
+      version: "1.33.7",
+    }
+    with_shard(metadata) do
+      stdout = run "shards version", capture: true
+      assert_match "1.33.7", stdout
+    end
+  end
+
+  def test_version_within_directory
+    metadata = {
+      version: "0.0.42",
+    }
+    with_shard(metadata) do
+      inner_path = File.join(application_path, "lib/test")
+      Dir.mkdir_p inner_path
+
+      outer_path = File.expand_path("..", application_path)
+      Dir.cd(outer_path) do
+        stdout = run "shards version #{inner_path}", capture: true
+        assert_match "0.0.42", stdout
+      end
+    end
+  end
+
+  def test_fails_version
+    ex = assert_raises(FailedCommand) do
+      root = File.expand_path("/", Dir.current)
+      run "shards version #{root}"
+    end
+  end
+end


### PR DESCRIPTION
Sometimes is useful to obtain the current version string of the library/project you're working on, either to help you determine if was bumped (when preparing for a new release) or when integrating it within the library's `VERSION` constant (through macros).

This change introduces `version` command for such purpose, allowing you retrieve from current directory (by default) or be able to provide a different path.

Usage example

```crystal
module Foo
  VERSION = {{ `shards version #{__DIR__}`.chomp.stringify }}
end
```

Resulting in a `Foo::VERSION` matching the `version` defined in `shard.yml`.

Fixes #147