### PR TITLE
Fix logger formatter for Crystal 0.23

### DIFF
--- a/src/logger.cr
+++ b/src/logger.cr
@@ -34,7 +34,7 @@ module Shards
                   message
                 end
         else
-          io << severity[0] << ": " << message
+          io << severity.to_s[0] << ": " << message
         end
       end
     end


### PR DESCRIPTION
`severity` is now a Logger::Severity, not a string.