### PR TITLE
Fixes issue #162

### DIFF
--- a/src/helpers/natural_sort.cr
+++ b/src/helpers/natural_sort.cr
@@ -24,7 +24,7 @@ module Shards
           ib += $1.size + 1
 
           if aaa =~ IS_NUMBER_STRING && bbb =~ IS_NUMBER_STRING
-            aaa, bbb = aaa.to_i, bbb.to_i
+            aaa, bbb = aaa.to_i64, bbb.to_i64
             ret = bbb <=> aaa
           else
             ret = bbb <=> aaa

--- a/test/natural_sort_test.cr
+++ b/test/natural_sort_test.cr
@@ -1,0 +1,12 @@
+require "./test_helper"
+require "../src/helpers/natural_sort"
+
+module Shards
+  class NaturalSortTest < Minitest::Test
+    # See https://github.com/crystal-lang/shards/issues/162
+    def test_supports_big_numbers
+      result = Shards::Helpers::NaturalSort.sort("341678090110cdb5436f75cc796c785ed392c4be", "0.1.0")
+      assert_equal -1, result
+    end
+  end
+end


### PR DESCRIPTION
When comparing commit hashes, we attempt to convert portions of them `to_i`. These portions might end up being bigger than what an `Int32` can hold, thus this bug.

This commit fixes the issue by converting those parts `to_i64` instead.