### PR TITLE
Corrects off by 1 error when applying natural sort between version descriptors.

### DIFF
--- a/src/helpers/natural_sort.cr
+++ b/src/helpers/natural_sort.cr
@@ -16,12 +16,12 @@ module Shards
           return 0 if ia > la
           return 0 unless a[ia .. -1] =~ EXTRACT_ALPHA_OR_NUMBER_GROUP
           aaa = $1
-          ia += $1.size + 1
+          ia += $1.size
 
           return 0 if ib > lb
           return 0 unless b[ib .. -1] =~ EXTRACT_ALPHA_OR_NUMBER_GROUP
           bbb = $1
-          ib += $1.size + 1
+          ib += $1.size
 
           if aaa =~ IS_NUMBER_STRING && bbb =~ IS_NUMBER_STRING
             aaa, bbb = aaa.to_i, bbb.to_i


### PR DESCRIPTION
I'm not sure about this, but I think this was an error. Take for example the commit hash in issue #162:

"341678090110cdb5436f75cc796c785ed392c4be"

Before this change, this natural sort implementation would first consider "341678090110" then skip the subsequent "c" then continue with "db5436f75cc796c785ed392c4be". This is because the `ia` and `ib` indexes get moved `size + 1` instead of just `size`. I made the correction and tests still pass. 

Apologies if I'm missing something about how the algo is supposed to work :).