### PR TITLE
Fix: installing Git refs

### DIFF
--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -50,9 +50,9 @@ module Shards
         version ||= package.version
 
         if package.installed?(version)
-          Shards.logger.info "Using #{package.name} (#{version})"
+          Shards.logger.info "Using #{package.name} (#{package.report_version})"
         else
-          Shards.logger.info "Installing #{package.name} (#{version})"
+          Shards.logger.info "Installing #{package.name} (#{package.report_version})"
           package.install(version)
         end
       end

--- a/src/commands/update.cr
+++ b/src/commands/update.cr
@@ -9,9 +9,9 @@ module Shards
 
         manager.packages.each do |package|
           if package.installed?
-            Shards.logger.info "Using #{package.name} (#{package.version})"
+            Shards.logger.info "Using #{package.name} (#{package.report_version})"
           else
-            Shards.logger.info "Installing #{package.name} (#{package.version})"
+            Shards.logger.info "Installing #{package.name} (#{package.report_version})"
             package.install
           end
         end

--- a/src/package.cr
+++ b/src/package.cr
@@ -18,10 +18,21 @@ module Shards
     end
 
     def version
-      if matching_versions.any?
+      if refs = @dependency.refs
+        refs
+      elsif matching_versions.any?
         matching_versions.first
       else
         raise Conflict.new(self)
+      end
+    end
+
+    def report_version
+      version = self.version
+      if version == spec.version
+        version
+      else
+        "#{spec.version} at #{version}"
       end
     end
 
@@ -93,7 +104,7 @@ module Shards
         self << package
       end
 
-      if dependency.name != package.spec.name
+      unless dependency.name == package.spec.name
         raise Error.new("Error shard name (#{package.spec.name}) doesn't match dependency name (#{dependency.name})")
       end
 

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -51,7 +51,7 @@ module Shards
       update_local_cache
 
       versions = if refs = dependency.refs
-                   [version_at(refs), refs]
+                   [version_at(refs)]
                  else
                    capture("git tag --list #{ GitResolver.git_column_never }")
                      .split("\n")

--- a/test/git_resolver_test.cr
+++ b/test/git_resolver_test.cr
@@ -19,10 +19,10 @@ module Shards
       assert_equal ["0.0.1", "0.1.0", "0.1.1", "0.1.2", "0.2.0"], resolver("library").available_versions
 
       refs = git_commits("library")
-      assert_equal ["0.0.1", refs.last], resolver("library", { "commit" => refs.last }).available_versions
-      assert_equal ["0.2.0", refs.first], resolver("library", { "commit" => refs.first }).available_versions
-      assert_equal ["0.1.2", "v0.1.2"], resolver("library", { "tag" => "v0.1.2" }).available_versions
-      assert_equal ["0.2.0", "master"], resolver("library", { "branch" => "master" }).available_versions
+      assert_equal ["0.0.1"], resolver("library", { "commit" => refs.last }).available_versions
+      assert_equal ["0.2.0"], resolver("library", { "commit" => refs.first }).available_versions
+      assert_equal ["0.1.2"], resolver("library", { "tag" => "v0.1.2" }).available_versions
+      assert_equal ["0.2.0"], resolver("library", { "branch" => "master" }).available_versions
     end
 
     def test_read_spec


### PR DESCRIPTION
Specifying a Git refs (tag, branch or commit) used to inject that ref into the available versions array for the shard. This behavior caused an issue in NaturalSort when trying to resolve a version number to install.

The behavior was changed so the Git refs is no longer injected, but will be reported as the actual "version" to be installed.

Also introduces a `Package#report_version` method which returns a string describing which version (number) of a shard is installed, along with the Git refs which is installed. For example:

    Installing dotenv (0.1.0 at master)

fixes #162