### PR TITLE
Print output to STDOUT

### DIFF
--- a/src/commands/build.cr
+++ b/src/commands/build.cr
@@ -34,7 +34,7 @@ module Shards
         Shards.logger.debug "crystal #{args.join(' ')}"
 
         error = IO::Memory.new
-        status = Process.run("crystal", args: args, output: STDOUT, error: error)
+        status = Process.run("crystal", args: args, output: Process::Redirect::Inherit, error: error)
         raise Error.new("Error target #{target.name} failed to compile:\n#{error}") unless status.success?
       end
     end

--- a/src/commands/build.cr
+++ b/src/commands/build.cr
@@ -34,7 +34,7 @@ module Shards
         Shards.logger.debug "crystal #{args.join(' ')}"
 
         error = IO::Memory.new
-        status = Process.run("crystal", args: args, output: error, error: error)
+        status = Process.run("crystal", args: args, output: STDOUT, error: error)
         raise Error.new("Error target #{target.name} failed to compile:\n#{error}") unless status.success?
       end
     end


### PR DESCRIPTION
Hi @ysbaddaden !

Currently if I execute `shards build -v --stats --progress` I can't see the expected output:

```
shards build --stats --progress -v
Dependencies are satisfied
Building: scry
crystal build -o /home/main/Projects/scry/bin/scry src/scry.cr --stats --progress
``` 

With this PR I can get the full output:

```
shards build -v --stats --progress
Dependencies are satisfied
Building: scry
crystal build -o /home/main/Projects/scry/bin/scry src/scry.cr --stats --progress
Parse:                             00:00:00.000286771 (   0.25MB)
Semantic (top level):              00:00:00.410225224 (  52.33MB)
Semantic (new):                    00:00:00.002928317 (  52.33MB)
Semantic (type declarations):      00:00:00.036812337 (  60.33MB)
Semantic (abstract def check):     00:00:00.002699638 (  60.33MB)
Semantic (ivars initializers):     00:00:00.002162979 (  60.33MB)
Semantic (cvars initializers):     00:00:00.256014863 (  68.33MB)
Semantic (main):                   00:00:01.675022400 ( 196.77MB)
Semantic (cleanup):                00:00:00.005818732 ( 196.77MB)
Semantic (recursive struct check): 00:00:00.001716627 ( 196.77MB)
Codegen (crystal):                 00:00:01.556659857 ( 252.77MB)
Codegen (bc+obj):                  00:00:10.571737589 ( 252.77MB)
Codegen (linking):                 00:00:00.959200345 ( 252.77MB)
                                          
Codegen (bc+obj):
 - no previous .o files were reused
``` 
