### PR TITLE
Add a fallback to alternate shards commands

### DIFF
--- a/src/cli.cr
+++ b/src/cli.cr
@@ -78,8 +78,8 @@ module Shards
           Commands::Version.run(args[1]? || path)
         else
           program_name = "shards-#{args[0]}"
-          if Process.find_executable(program_name)
-            run_shards_subcommand(program_name, args)
+          if program_path = Process.find_executable(program_name)
+            run_shards_subcommand(program_path, args)
           else
             display_help_and_exit(opts)
           end

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -103,7 +103,7 @@ module Shards
   def self.run_shards_subcommand(process_name, args)
     Process.exec(
       command: process_name,
-      args: args[1..-1],
+      args: args[1..],
     )
   end
 

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -77,7 +77,12 @@ module Shards
         when "version"
           Commands::Version.run(args[1]? || path)
         else
-          display_help_and_exit(opts)
+          process_name = "shards-#{args[0]}"
+          if Process.find_executable(process_name).nil?
+            display_help_and_exit(opts)
+          else
+            run_shards_subcommand(process_name, args)
+          end
         end
 
         exit
@@ -93,6 +98,20 @@ module Shards
       shards_opts = ENV.fetch("SHARDS_OPTS", "").split
     {% end %}
     ARGV.concat(shards_opts)
+  end
+
+  def self.run_shards_subcommand(process_name, args)
+    Process.exec(
+      command: process_name,
+      args: args[1..-1],
+      env: nil,
+      clear_env: false,
+      shell: false,
+      input: STDIN,
+      output: STDOUT,
+      error: STDERR,
+      chdir: nil
+    )
   end
 
   def self.build(path, args)

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -104,13 +104,6 @@ module Shards
     Process.exec(
       command: process_name,
       args: args[1..-1],
-      env: nil,
-      clear_env: false,
-      shell: false,
-      input: STDIN,
-      output: STDOUT,
-      error: STDERR,
-      chdir: nil
     )
   end
 

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -77,11 +77,11 @@ module Shards
         when "version"
           Commands::Version.run(args[1]? || path)
         else
-          process_name = "shards-#{args[0]}"
-          if Process.find_executable(process_name).nil?
-            display_help_and_exit(opts)
+          program_name = "shards-#{args[0]}"
+          if Process.find_executable(program_name)
+            run_shards_subcommand(program_name, args)
           else
-            run_shards_subcommand(process_name, args)
+            display_help_and_exit(opts)
           end
         end
 


### PR DESCRIPTION
This allows additional functionality to be added to the shards command in a similar way extra commands are added to `git`. Basically, if the shards command isn't found in shards itself, it will run `shards-#{command}`, passing STDIO through. If there is no executable that matches the attempted command, the regular shards usage message is shown.