### PR TITLE
Crystal/0.25.0

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,5 +2,5 @@ version: 1.0
 shards:
   minitest:
     github: ysbaddaden/minitest.cr
-    commit: 7fcb2dbba54d14ed693d76dfd6da2a4b220d1259
+    commit: ab16ff4989881d9e03b494837a70d0024258c5d0
 

--- a/src/package.cr
+++ b/src/package.cr
@@ -83,7 +83,14 @@ module Shards
         destination = File.join(Shards.bin_path, name)
 
         if File.exists?(destination)
-          next if File.info(destination) == File.info(source)
+          {% if File.class.has_method?(:same?) %}
+            # Since Crystal 0.25.0
+            next if File.same?(destination, source)
+          {% else %}
+            # Up to Crystal 0.24.2
+            next if File.stat(destination).ino == File.stat(source).ino
+          {% end %}
+
           File.delete(destination)
         end
 

--- a/src/package.cr
+++ b/src/package.cr
@@ -83,7 +83,7 @@ module Shards
         destination = File.join(Shards.bin_path, name)
 
         if File.exists?(destination)
-          next if File.stat(destination).ino == File.stat(source).ino
+          next if File.info(destination) == File.info(source)
           File.delete(destination)
         end
 


### PR DESCRIPTION
Fix compatibility for 0.25 without loosing 0.24.
Updating minitest was needed for 0.25 compatibility also.

Unless anything else is needed 0.8.0 can be tagged so the build scripts can move to that version.