### PR TITLE
Fix path resolver recognize incorrect install path

### DIFF
--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -1,6 +1,6 @@
 module FileUtils
   def self.rm_rf(path)
-    return unless File.exists?(path)
+    return unless File.exists?(path) || File.symlink?(path)
 
     if Dir.exists?(path)
       command = "rm -rf #{escape path}"

--- a/src/resolvers/path.cr
+++ b/src/resolvers/path.cr
@@ -31,7 +31,20 @@ module Shards
     end
 
     def installed?
-      File.symlink?(install_path)
+      File.symlink?(install_path) && check_install_path_target
+    end
+
+    private def check_install_path_target
+      begin
+        real_install_path = File.real_path(install_path)
+      rescue errno : Errno
+        if errno.errno == Errno::ENOENT
+          return false
+        else
+          raise errno
+        end
+      end
+      real_install_path == expanded_local_path
     end
 
     def available_versions
@@ -42,9 +55,14 @@ module Shards
       dependency["path"].to_s
     end
 
+    private def expanded_local_path
+      File.expand_path(local_path).tap do |path|
+        raise Error.new("Failed no such path: #{path}") unless Dir.exists?(path)
+      end
+    end
+
     def install(version = nil)
-      path = File.expand_path(local_path)
-      raise Error.new("Failed no such path: #{path}") unless Dir.exists?(path)
+      path = expanded_local_path
 
       cleanup_install_directory
       Dir.mkdir_p(File.dirname(install_path))


### PR DESCRIPTION
Fixes #208

@ysbaddaden I was almost going crazy because `cleanup_install_directory` didn't remove symlinks to non-existing targets. It took my while to finally figure that `FileUtils.rm_rf` doesn't actually call the stdlib method but is a custom implementation which completely ignores broken symlinks.
I'd strongly suggest to rename that method (or the entire module) to a different name in order to avoid such mistakes.