### PR TITLE
Fix: Git resolver doesnt pull tags anymore

### DIFF
--- a/test/integration/update_test.cr
+++ b/test/integration/update_test.cr
@@ -101,6 +101,23 @@ class UpdateCommandTest < Minitest::Test
     end
   end
 
+  def test_finds_then_updates_new_compatible_version
+    metadata = { dependencies: { web: "~> 1.1.0" } }
+    lock = { web: "1.1.2" }
+
+    with_shard(metadata, lock) do
+      run "shards install"
+      assert_installed "web", "1.1.2"
+    end
+
+    create_git_release "web", "1.1.3"
+
+    with_shard(metadata, lock) do
+      run "shards update"
+      assert_installed "web", "1.1.3"
+    end
+  end
+
   def test_wont_generate_lockfile_for_empty_dependencies
     metadata = { dependencies: {} of Symbol => String }
     with_shard(metadata) do

--- a/test/integration/update_test.cr
+++ b/test/integration/update_test.cr
@@ -102,19 +102,21 @@ class UpdateCommandTest < Minitest::Test
   end
 
   def test_finds_then_updates_new_compatible_version
-    metadata = { dependencies: { web: "~> 1.1.0" } }
-    lock = { web: "1.1.2" }
+    create_git_repository "oopsie", "1.1.0", "1.2.0"
+
+    metadata = { dependencies: { oopsie: "~> 1.1.0" } }
+    lock = { oopsie: "1.1.0" }
 
     with_shard(metadata, lock) do
       run "shards install"
-      assert_installed "web", "1.1.2"
+      assert_installed "oopsie", "1.1.0"
     end
 
-    create_git_release "web", "1.1.3"
+    create_git_release "oopsie", "1.1.1"
 
     with_shard(metadata, lock) do
       run "shards update"
-      assert_installed "web", "1.1.3"
+      assert_installed "oopsie", "1.1.1"
     end
   end
 


### PR DESCRIPTION
Creating bare Git repositories doesn't configure the local repository to fetch remote refs, such as branches and tags, which totally broke the update command.

This patch reverts back to mirroring Git repositories, and verifies whether a cloned repository is valid, or not before fetching new refs.

fixes #211