### PR TITLE
Add CircleCI 2.0 with nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ dry:
     - run: *prepare
     - checkout
     - run: make
-    - run: bin/shards install
+    - run: shards install
     - run: make test
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 2 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,31 +3,28 @@ version: 2
 dry:
   prepare: &prepare
     command: |
-      make
+      crystal --version
       git config --global user.email "you@example.com"
       git config --global user.name "Your Name"
       git config --global column.ui always
+  
+  steps: &steps
+    - run: *prepare
+    - checkout
+    - run: make
+    - run: bin/shards install
+    - run: make test
 
 jobs:
   test:
     docker:
       - image: crystallang/crystal:latest
-    steps:
-      - run: crystal --version
-      - checkout
-      - run: *prepare
-      - run: shards
-      - run: make test
+    steps: &steps
 
   test-on-nightly:
     docker:
       - image: crystallang/crystal:nightly
-    steps:
-      - run: crystal --version
-      - checkout
-      - run: *prepare
-      - run: shards
-      - run: make test
+    steps: &steps
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,64 @@
+version: 2
+
+dry:
+  restore_shards_cache: &restore_shards_cache
+    keys:
+      - shards-cache-v1-{{ .Branch }}-{{ checksum "shard.lock" }}
+      - shards-cache-v1-{{ .Branch }}
+      - shards-cache-v1
+
+  save_shards_cache: &save_shards_cache
+    key: shards-cache-v1-{{ .Branch }}-{{ checksum "shard.lock" }}
+    paths:
+      - ./shards-cache
+
+  prepare: &prepare
+    command: |
+      make
+      git config --global user.email "you@example.com"
+      git config --global user.name "Your Name"
+      git config --global column.ui always
+
+jobs:
+  test:
+    docker:
+      - image: crystallang/crystal:latest
+        environment:
+          SHARDS_CACHE_PATH: ./shards-cache
+    steps:
+      - run: crystal --version
+      - checkout
+      - run: *prepare
+      - restore_cache: *restore_shards_cache
+      - run: shards
+      - save_cache: *save_shards_cache
+      - run: make test
+
+  test-on-nightly:
+    docker:
+      - image: crystallang/crystal:nightly
+        environment:
+          SHARDS_CACHE_PATH: ./shards-cache
+    steps:
+      - run: crystal --version
+      - checkout
+      - run: *prepare
+      - restore_cache: *restore_shards_cache
+      - run: shards
+      - run: make test
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - test
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - test-on-nightly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,6 @@
 version: 2
 
 dry:
-  restore_shards_cache: &restore_shards_cache
-    keys:
-      - shards-cache-v1-{{ .Branch }}-{{ checksum "shard.lock" }}
-      - shards-cache-v1-{{ .Branch }}
-      - shards-cache-v1
-
-  save_shards_cache: &save_shards_cache
-    key: shards-cache-v1-{{ .Branch }}-{{ checksum "shard.lock" }}
-    paths:
-      - ./shards-cache
-
   prepare: &prepare
     command: |
       make
@@ -23,27 +12,20 @@ jobs:
   test:
     docker:
       - image: crystallang/crystal:latest
-        environment:
-          SHARDS_CACHE_PATH: ./shards-cache
     steps:
       - run: crystal --version
       - checkout
       - run: *prepare
-      - restore_cache: *restore_shards_cache
       - run: shards
-      - save_cache: *save_shards_cache
       - run: make test
 
   test-on-nightly:
     docker:
       - image: crystallang/crystal:nightly
-        environment:
-          SHARDS_CACHE_PATH: ./shards-cache
     steps:
       - run: crystal --version
       - checkout
       - run: *prepare
-      - restore_cache: *restore_shards_cache
       - run: shards
       - run: make test
 


### PR DESCRIPTION
Fixes #177.
Adds CircleCI as an alternative CI using docker images. 

* It will use crystal:latest image on every push, and
* It will build master using crystal:nightly image every midnight
* There is not much dependencies in shards, but I've already ~~shamelessly copy~~ setup the appropriate commands for caching the global shards cache between builds.