### PR TITLE
Fix: always resolve dependency spec at locked commit

### DIFF
--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -5,11 +5,12 @@ module Shards
     # OPTIMIZE: avoid updating GIT caches until required
     class Install < Command
       def run(*args)
-        manager.resolve
-
         if lockfile?
+          manager.locks = locks
+          manager.resolve
           install(manager.packages, locks)
         else
+          manager.resolve
           install(manager.packages)
         end
 


### PR DESCRIPTION
If the dependency is a branch refs and we previously locked the dependency, we must declare that locked commit (for the install command only) otherwise we end up resolving the spec from the latest branch commit that may have changed dependencies, while still eventually installing the locked commit.

This situation is fixed with a hack in Manager to add the locked commit before the branch dependency is added, so the locked commit will have precedence over the branch.

fixes #219 