### PR TITLE
Added possibility to install submodules of a git repository or local repository

### DIFF
--- a/src/dependency.cr
+++ b/src/dependency.cr
@@ -30,6 +30,10 @@ module Shards
       self["branch"]? || self["tag"]? || self["commit"]?
     end
 
+    def dep
+      fetch("dep", nil)
+    end
+
     def inspect(io)
       io << "#<" << self.class.name << " {" << name << " => "
       super

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -8,8 +8,7 @@ module Shards
   abstract class Resolver
     getter dependency : Dependency
 
-    def initialize(@dependency, @update_cache = true)
-    end
+    def initialize(@dependency, @update_cache = true); end
 
     def spec(version = nil)
       Spec.from_yaml(read_spec(version))
@@ -21,7 +20,7 @@ module Shards
       path = File.join(install_path, SPEC_FILENAME)
       return Spec.from_file(path) if File.exists?(path)
 
-      raise Error.new("Missing #{SPEC_FILENAME.inspect} for #{dependency.name.inspect}")
+      raise Error.new("Missing #{shards_location.inspect} for #{dependency.name.inspect}")
     end
 
     def installed?
@@ -47,6 +46,14 @@ module Shards
     protected def cleanup_install_directory
       Shards.logger.debug "rm -rf '#{Helpers::Path.escape(install_path)}'"
       FileUtils.rm_rf(install_path)
+    end
+
+    protected def shards_location
+      if dependency.dep
+        "#{dependency.dep}/#{SPEC_FILENAME}"
+      else
+        SPEC_FILENAME
+      end
     end
   end
 

--- a/test/integration/install_test.cr
+++ b/test/integration/install_test.cr
@@ -12,12 +12,10 @@ class InstallCommandTest < Minitest::Test
         monofirstsubmodule: {
           git: git_path(:mono),
           dep: "libs/monofirstsubmodule",
-          version: "1.0.0"
         },
         monosecondsubmodule: {
           git: git_path(:mono),
           dep: "libs/monosecondsubmodule",
-          version: "2.0.0"
         },
         monopathsubmodule: {
           path: File.join(rel_path(:mono), "libs", "monopathsubmodule"),

--- a/test/integration/install_test.cr
+++ b/test/integration/install_test.cr
@@ -3,7 +3,26 @@ require "../integration_helper"
 class InstallCommandTest < Minitest::Test
   def test_installs_dependencies
     metadata = {
-      dependencies:             {web: "*", orm: "*", foo: {path: rel_path(:foo)}},
+      dependencies: {
+        web: "*",
+        orm: "*",
+        foo: {
+          path: rel_path(:foo)
+        },
+        monofirstsubmodule: {
+          git: git_path(:mono),
+          dep: "libs/monofirstsubmodule",
+          version: "1.0.0"
+        },
+        monosecondsubmodule: {
+          git: git_path(:mono),
+          dep: "libs/monosecondsubmodule",
+          version: "2.0.0"
+        },
+        monopathsubmodule: {
+          path: File.join(rel_path(:mono), "libs", "monopathsubmodule"),
+        }
+      },
       development_dependencies: {mock: "*"},
     }
 
@@ -14,6 +33,10 @@ class InstallCommandTest < Minitest::Test
       assert_installed "web", "2.1.0"
       assert_installed "orm", "0.5.0"
       assert_installed "pg", "0.2.1"
+
+      # It installed mono repo dependencies
+      assert_installed "monofirstsubmodule", "2.0.0"
+      assert_installed "monosecondsubmodule", "2.0.0"
 
       # it installed the path dependency
       assert_installed "foo", "0.1.0"

--- a/test/integration_helper.cr
+++ b/test/integration_helper.cr
@@ -55,6 +55,8 @@ class Minitest::Test
     create_file "fails", "Makefile", "all:\n\ttest -n ''\n"
     create_git_release "fails", "0.1.0", "name: fails\nversion: 0.1.0\nscripts:\n  postinstall: make\n"
 
+    create_mono_git_repository "mono", ["1.0.0", "2.0.0"], ["monofirstsubmodule", "monosecondsubmodule", "monopathsubmodule"]
+
     create_path_repository "foo", "0.1.0"
 
     create_path_repository "binary"


### PR DESCRIPTION
<h1>Intentions</h1>
Some organisations are using a mono repository structure. They want to install shards based on a submodule of a git repository. Rails / Angular are examples of frameworks that are using the mono repo style. Because this was not supported in shards yet i adjusted the code to be able to install submodules.

<h1>What is done</h1>

- Changed the git resolver to check for the "dep" keyword in the dependencies. If there is a a dep defined it will add it to the refs of the git commands so the correct submodule is installed. If there is no dep defined it will use the normal flow that was already there.
- Changed the factory support test file to have seperate functions so we can reuse them in the new mono repo factory methods.
- Add the mono repo factory method. The factory method will initialise a mono repo with submodules. 
- Added integrations tests to verify that the submodules are installed with git and path.

<h1>Instructions</h1>

In the shards.yml you can now specify a extra attribute called "dep". The dep will describe the path to the submodule inside the git repository.

```yml
dependencies:
  logger:
    git: git@github.com:ultimategogetter/test.git
    dep: libs/logger
```

<h1>TODO</h1>

- When the change is accepted write documentation how to use this new feature