### PR TITLE
Force git commits created by the spec suite not to be signed

### DIFF
--- a/test/support/factories.cr
+++ b/test/support/factories.cr
@@ -44,7 +44,7 @@ module Shards
     def create_git_commit(project, message = "new commit")
       Dir.cd(git_path(project)) do
         run "git add ."
-        run "git commit --allow-empty -m '#{message}'"
+        run "git commit --allow-empty --no-gpg-sign -m '#{message}'"
       end
     end
 


### PR DESCRIPTION
In the case of the user running the tests setting the git configuration commit.gpgSign=true, running the specs can prompt for a smartcard to be inserted or for the keychain to be unlocked. This is undesirable.