### PR TITLE
Fix macro command reference path relative to source location

### DIFF
--- a/src/version.cr
+++ b/src/version.cr
@@ -1,5 +1,5 @@
 module Shards
-  VERSION    = {{ `cat VERSION`.stringify.chomp }}
+  VERSION    = {{ `cat #{__DIR__}/../VERSION`.stringify.chomp }}
   BUILD_SHA1 = {{ `git log --format=%h -n 1 2>/dev/null || echo ""`.stringify.chomp }}
   BUILD_DATE = {{ `date -u +'%Y-%m-%d'`.stringify.chomp }}
 


### PR DESCRIPTION
When shards is used as a library, the former code would read VERSION file from main project folder (while shards typically sits in `lib/shard`). It would also complain if there is no VERSION file at the specified location.

The shell command can be replaced by `read_file` after the next Crystal release (or the one after that).

The git command in the next line will obviously fail as well, but it's not trivial to fix. It doesn't break building.
An optimal solution for using `shards` as a library would probably be that `shards version` command provides the commit hash of the installed version. This doesn't work when shards is built as an application because it would depend on a compiled version of itself.