### PR TITLE
Enforce prefix 'v' in git version tags

### DIFF
--- a/src/package.cr
+++ b/src/package.cr
@@ -109,7 +109,7 @@ module Shards
       key = resolver.class.key
       io << "    " << key << ": " << @dependency[key] << '\n'
 
-      if @dependency.refs || !(version =~ RELEASE_VERSION)
+      if @dependency.refs || !(version =~ VERSION_REFERENCE)
         io << "    commit: " << resolver.installed_commit_hash.to_s << '\n'
       else
         io << "    version: " << version << '\n'

--- a/test/git_resolver_test.cr
+++ b/test/git_resolver_test.cr
@@ -8,6 +8,9 @@ module Shards
 
       create_git_repository "library", "0.0.1", "0.1.0", "0.1.1", "0.1.2"
       create_git_release "library", "0.2.0", shard: "name: library\nversion: 0.2.0\nauthors:\n  - julien <julien@portalier.com>"
+
+      # Create a version tag not prefixed by 'v' which should be ignored
+      create_git_tag "library", "99.9.9"
     end
 
     def test_available_versions

--- a/test/support/factories.cr
+++ b/test/support/factories.cr
@@ -37,7 +37,13 @@ module Shards
           create_shard project, contents
         end
         create_git_commit project, "release: v#{version}"
-        run "git tag v#{version}"
+      end
+      create_git_tag(project, "v#{version}")
+    end
+
+    def create_git_tag(project, version)
+      Dir.cd(git_path(project)) do
+        run "git tag #{version}"
       end
     end
 


### PR DESCRIPTION
Shards recognizes tags without 'v' prefix as valid version identifiers but then can't use them as valid ref for accessing it in the git repo. That leads to errors.

Maintainers of shards need to prefix release version tags with a `v`. This can be fixed retroactively.
A useful shell command for adding v-prefixed tags:
```bash
for tag in $(git tag --list | grep -P '^[\d.]+$'); do git tag v$tag $tag; done
```

This issue has been discussed in #108