### PR TITLE
Add outdated command to know which dependencies are outdated

### DIFF
--- a/src/cli.cr
+++ b/src/cli.cr
@@ -12,6 +12,7 @@ module Shards
           init                           - Initializes a shard folder.
           install                        - Installs dependencies from `shard.lock` file.
           list [--tree]                  - Lists installed dependencies.
+          outdated [--pre]               - Lists dependencies that are outdated.
           prune                          - Removes unused dependencies from `lib` folder.
           update                         - Updates dependencies and `shards.lock`.
           version [<path>]               - Prints the current version of the shard.
@@ -46,6 +47,8 @@ module Shards
           Commands::Install.run(path)
         when "list"
           Commands::List.run(path, tree: args.includes?("--tree"))
+        when "outdated"
+          Commands::Outdated.run(path, prereleases: args.includes?("--pre"))
         when "prune"
           Commands::Prune.run(path)
         when "update"

--- a/src/commands/outdated.cr
+++ b/src/commands/outdated.cr
@@ -1,0 +1,75 @@
+require "./command"
+
+module Shards
+  module Commands
+    class Outdated < Command
+      @up_to_date = true
+      @output = IO::Memory.new
+
+      def self.run(path, @@prereleases = false)
+        super
+      end
+
+      def run(*args)
+        return unless has_dependencies?
+
+        if lockfile?
+          manager.locks = locks
+          manager.resolve
+        else
+          manager.resolve
+        end
+
+        manager.packages.each do |package|
+          analyze(package)
+        end
+
+        if @up_to_date
+          Shards.logger.info "Dependencies are up to date!"
+        else
+          @output.rewind
+          Shards.logger.warn "Outdated dependencies:"
+          puts @output.to_s
+        end
+      end
+
+      private def analyze(package)
+        _spec = package.resolver.installed_spec
+
+        unless _spec
+          Shards.logger.warn { "#{package.name}: not installed" }
+          return
+        end
+
+        installed = _spec.version
+
+        # already the latest version?
+        latest = Versions.sort(package.available_versions(@@prereleases)).first
+        return if latest == installed
+
+        @up_to_date = false
+
+        @output << "  * " << package.name
+        @output << " (installed: " << installed
+
+        # is new version matching constraints available?
+        available = package.matching_versions(@@prereleases).first
+        unless available == installed
+          @output << ", available: " << available
+        end
+
+        # also report latest version:
+        if Versions.compare(latest, available) < 0
+          @output << ", latest: " << latest
+        end
+
+        @output.puts ')'
+      end
+
+      # FIXME: duplicates Check#has_dependencies?
+      private def has_dependencies?
+        spec.dependencies.any? || (!Shards.production? && spec.development_dependencies.any?)
+      end
+    end
+  end
+end

--- a/src/package.cr
+++ b/src/package.cr
@@ -40,8 +40,8 @@ module Shards
       end
     end
 
-    def matching_versions
-      Versions.resolve(available_versions, requirements)
+    def matching_versions(prereleases = false)
+      Versions.resolve(available_versions, requirements, prereleases)
     end
 
     def spec
@@ -123,8 +123,13 @@ module Shards
       @resolver ||= Shards.find_resolver(@dependency)
     end
 
-    private def available_versions
-      @available_versions ||= resolver.available_versions
+    def available_versions(prereleases = true)
+      versions = @available_versions ||= resolver.available_versions
+      if prereleases
+        versions
+      else
+        Versions.without_prereleases(versions)
+      end
     end
   end
 

--- a/src/versions.cr
+++ b/src/versions.cr
@@ -153,9 +153,13 @@ module Shards
       str.each_char.any?(&.ascii_letter?)
     end
 
-    def self.resolve(versions, requirements : Enumerable(String))
-      unless requirements.any? { |r| prerelease?(r) }
-        versions = versions.reject { |v| prerelease?(v) }
+    protected def self.without_prereleases(versions)
+      versions.reject { |v| prerelease?(v) }
+    end
+
+    def self.resolve(versions, requirements : Enumerable(String), prereleases = false)
+      unless prereleases || requirements.any? { |r| prerelease?(r) }
+        versions = without_prereleases(versions)
       end
 
       matching_versions = requirements

--- a/test/integration/outdated_test.cr
+++ b/test/integration/outdated_test.cr
@@ -1,0 +1,63 @@
+require "../integration_helper"
+
+class OutdatedCommandTest < Minitest::Test
+  def test_up_to_date
+    with_shard({dependencies: {web: "*"}}) do
+      run "shards install"
+
+      stdout = run "shards outdated --no-color", capture: true
+      assert_match "I: Dependencies are up to date!", stdout
+    end
+  end
+
+  def test_not_latest_version
+    with_shard({dependencies: {orm: "*"}}, {orm: "0.3.1"}) do
+      run "shards install"
+
+      stdout = run "shards outdated --no-color", capture: true
+      assert_match "W: Outdated dependencies:", stdout
+      assert_match "  * orm (installed: 0.3.1, available: 0.5.0)", stdout
+    end
+  end
+
+  def test_available_version_matching_pessimistic_operator
+    with_shard({dependencies: {orm: "~> 0.3.0"}}, {orm: "0.3.1"}) do
+      run "shards install"
+
+      stdout = run "shards outdated --no-color", capture: true
+      assert_match "W: Outdated dependencies:", stdout
+      assert_match "  * orm (installed: 0.3.1, available: 0.3.2, latest: 0.5.0)", stdout
+    end
+  end
+
+  def test_reports_new_prerelease
+    with_shard({dependencies: {unstable: "0.3.0.alpha"}}) do
+      run "shards install"
+    end
+    with_shard({dependencies: {unstable: "~> 0.3.0.alpha"}}) do
+      stdout = run "shards outdated --no-color", capture: true
+      assert_match "W: Outdated dependencies:", stdout
+      assert_match "  * unstable (installed: 0.3.0.alpha, available: 0.3.0.beta)", stdout
+    end
+  end
+
+  def test_wont_report_prereleases_by_default
+    with_shard({dependencies: {preview: "*"}}, {preview: "0.2.0"}) do
+      run "shards install"
+
+      stdout = run "shards outdated --no-color", capture: true
+      assert_match "W: Outdated dependencies:", stdout
+      assert_match "  * preview (installed: 0.2.0, available: 0.3.0)", stdout
+    end
+  end
+
+  def test_reports_prereleases_when_asked
+    with_shard({dependencies: {preview: "*"}}, {preview: "0.2.0"}) do
+      run "shards install"
+
+      stdout = run "shards outdated --pre --no-color", capture: true
+      assert_match "W: Outdated dependencies:", stdout
+      assert_match "  * preview (installed: 0.2.0, available: 0.4.0.a)", stdout
+    end
+  end
+end


### PR DESCRIPTION
Basically: it resolves dependencies just like the `install` command does, then reports any dependency that has a new release matching all constraints (`available: x.y.z`), and the latest release if it's different.

Optionally supports checking for pre-releases with `--pre`.

The command assumes that dependencies are installed. It doesn't fail if `shard.yml` is missing; maybe it should?

The command is meant for developers to know about new releases of dependencies, and thus always succeeds (i.e. `exit 0`) unless there was an error.

closes #56 