### PR TITLE
Fix: some versions issues

### DIFF
--- a/src/dependency.cr
+++ b/src/dependency.cr
@@ -12,18 +12,23 @@ module Shards
       end
     end
 
-    def initialize(@name)
+    protected def initialize(@name)
       super()
     end
 
-    # DEPRECATED: with no replacement
-    def initialize(@name, config)
+    protected def initialize(@name, config)
       super()
       config.each { |k, v| self[k.to_s] = v.to_s }
     end
 
     def version
-      fetch("version", "*")
+      if version = self["version"]?
+        version
+      elsif self["tag"]? =~ VERSION_TAG
+        $1
+      else
+        "*"
+      end
     end
 
     def refs

--- a/src/versions.cr
+++ b/src/versions.cr
@@ -150,7 +150,11 @@ module Shards
     end
 
     def self.prerelease?(str)
-      str.each_char.any?(&.ascii_letter?)
+      str.each_char do |char|
+        return true if char.ascii_letter?
+        break if char == '+'
+      end
+      false
     end
 
     protected def self.without_prereleases(versions)

--- a/test/dependency_test.cr
+++ b/test/dependency_test.cr
@@ -1,0 +1,29 @@
+require "./test_helper"
+
+class Shards::DependencyTest < Minitest::Test
+  def test_version
+    dependency = Dependency.new("app")
+    assert_equal "*", dependency.version
+
+    dependency = Dependency.new("app", {version: "*"})
+    assert_equal "*", dependency.version
+
+    dependency = Dependency.new("app", {version: "1.0.0"})
+    assert_equal "1.0.0", dependency.version
+
+    dependency = Dependency.new("app", {version: "<= 2.0.0"})
+    assert_equal "<= 2.0.0", dependency.version
+  end
+
+  def test_version_with_tags
+    dependency = Dependency.new("app", { tag: "fix/something" })
+    assert_equal "*", dependency.version
+
+    dependency = Dependency.new("app", { tag: "1.2.3" })
+    assert_equal "*", dependency.version
+
+    # version tag is considered a version:
+    dependency = Dependency.new("app", { tag: "v1.2.3-pre1" })
+    assert_equal "1.2.3-pre1", dependency.version
+  end
+end

--- a/test/versions_test.cr
+++ b/test/versions_test.cr
@@ -10,6 +10,10 @@ module Shards
       assert Versions.prerelease?("1.0.alpha")
       assert Versions.prerelease?("1.0.0-rc1")
       assert Versions.prerelease?("1.0.0-pre.1.2.x.y")
+
+      assert Versions.prerelease?("1.0.0-pre+20190129")
+      refute Versions.prerelease?("1.0+20190129")
+      refute Versions.prerelease?("1.0+build1")
     end
 
     def test_compare


### PR DESCRIPTION
The first patch is a simple bug fix:  don't consider a version number such as `1.0+meta` as a prerelease (i.e. skip metadata);

The other one is a convenience, it maps a version tag definition to be the actual version requirement in dependencies. In the following example, the `tag: v0.12.0-rc1` is identical to `version: 0.12.0-rc1`:
```yaml
dependencies:
  lucky:
    github: luckyframework/lucky
    tag: v0.12.0-rc1
```

This is a nice to have because with Shards < 0.9 this was the only way to declare a pre-release dependency.