### PR TITLE
Fix: Git default HEAD refs

### DIFF
--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -32,7 +32,7 @@ module Shards
           solver.each_conflict do |message|
             Shards.logger.warn { "Conflict #{message}" }
           end
-          Shards.logger.error { "Failed to resolve dependencies" }
+          raise Shards::Error.new("Failed to resolve dependencies")
         end
       end
 

--- a/src/commands/lock.cr
+++ b/src/commands/lock.cr
@@ -36,7 +36,7 @@ module Shards
           solver.each_conflict do |message|
             Shards.logger.warn { "Conflict #{message}" }
           end
-          Shards.logger.error { "Failed to resolve dependencies" }
+          raise Shards::Error.new("Failed to resolve dependencies")
         end
       end
 

--- a/src/commands/outdated.cr
+++ b/src/commands/outdated.cr
@@ -30,7 +30,7 @@ module Shards
           solver.each_conflict do |message|
             Shards.logger.warn { "Conflict #{message}" }
           end
-          Shards.logger.error { "Failed to resolve dependencies" }
+          raise Shards::Error.new("Failed to resolve dependencies")
         end
       end
 

--- a/src/commands/update.cr
+++ b/src/commands/update.cr
@@ -27,7 +27,7 @@ module Shards
           solver.each_conflict do |message|
             Shards.logger.warn { "Conflict #{message}" }
           end
-          Shards.logger.error { "Failed to resolve dependencies" }
+          raise Shards::Error.new("Failed to resolve dependencies")
         end
       end
 

--- a/src/package.cr
+++ b/src/package.cr
@@ -25,7 +25,7 @@ module Shards
     end
 
     def spec
-      @spec ||= resolver.spec(version)
+      @spec ||= resolver.spec(commit || version)
     end
 
     def installed?

--- a/test/integration/build_test.cr
+++ b/test/integration/build_test.cr
@@ -60,7 +60,7 @@ class BuildCommandTest < Minitest::Test
   end
 
   def test_reports_error_when_target_failed_to_compile
-    File.write File.join(application_path, "src", "cli.cr"), "a = ..."
+    File.write File.join(application_path, "src", "cli.cr"), "a = ......"
 
     Dir.cd(application_path) do
       ex = assert_raises(FailedCommand) do

--- a/test/integration/install_test.cr
+++ b/test/integration/install_test.cr
@@ -109,6 +109,12 @@ class InstallCommandTest < Minitest::Test
     end
   end
 
+  def test_resolves_dependency_at_head_when_no_version_tags
+    metadata = {dependencies: {"missing": "*"}}
+    with_shard(metadata) { run "shards install" }
+    assert_installed "missing", "0.1.0"
+  end
+
   def test_installs_dependency_at_locked_commit_when_refs_is_a_branch
     metadata = {
       dependencies: {

--- a/test/integration/install_test.cr
+++ b/test/integration/install_test.cr
@@ -318,21 +318,38 @@ class InstallCommandTest < Minitest::Test
     end
   end
 
-  def test_installs_executables
+  def test_installs_executables_at_version
+    metadata = {
+      dependencies: {binary: "0.1.0"}
+    }
+    with_shard(metadata) { run("shards install --no-color") }
+
+    foobar = File.join(application_path, "bin", "foobar")
+    baz = File.join(application_path, "bin", "baz")
+    foo = File.join(application_path, "bin", "foo")
+
+    assert File.exists?(foobar), "Expected to have installed bin/foobar executable"
+    assert File.exists?(baz), "Expected to have installed bin/baz executable"
+    refute File.exists?(foo), "Expected not to have installed bin/foo executable"
+
+    assert_equal "OK\n", `#{foobar}`
+    assert_equal "KO\n", `#{baz}`
+  end
+
+  def test_installs_executables_at_refs
     metadata = {
       dependencies: {
-        binary: {type: "path", path: rel_path(:binary)},
+        binary: {git: git_url(:binary), commit: git_commits(:binary)[-1]}
       },
     }
     with_shard(metadata) { run("shards install --no-color") }
 
     foobar = File.join(application_path, "bin", "foobar")
     baz = File.join(application_path, "bin", "baz")
+    foo = File.join(application_path, "bin", "foo")
 
     assert File.exists?(foobar), "Expected to have installed bin/foobar executable"
     assert File.exists?(baz), "Expected to have installed bin/baz executable"
-
-    assert_equal "OK\n", `#{foobar}`
-    assert_equal "KO\n", `#{baz}`
+    refute File.exists?(foo), "Expected not to have installed bin/foo executable"
   end
 end

--- a/test/integration/update_test.cr
+++ b/test/integration/update_test.cr
@@ -216,21 +216,21 @@ class UpdateCommandTest < Minitest::Test
     end
   end
 
-  def test_installs_executables
-    metadata = {
-      dependencies: {
-        binary: {type: "path", path: rel_path(:binary)},
-      },
-    }
-    with_shard(metadata) { run("shards install --no-color") }
+  def test_installs_new_executables
+    metadata = {dependencies: {binary: "0.2.0"}}
+    lock = {binary: "0.1.0"}
+    with_shard(metadata, lock) { run("shards update --no-color") }
 
-    create_file "binary", "bin/foo", "echo 'FOO'", perm: 0o755
-    create_shard "binary", "name: binary\nversion: 0.2.0\nexecutables:\n  - foobar\n  - baz\n  - foo"
-
-    with_shard(metadata) { run("shards update --no-color") }
-
+    foobar = File.join(application_path, "bin", "foobar")
+    baz = File.join(application_path, "bin", "baz")
     foo = File.join(application_path, "bin", "foo")
+
+    assert File.exists?(foobar), "Expected to have installed bin/foobar executable"
+    assert File.exists?(baz), "Expected to have installed bin/baz executable"
     assert File.exists?(foo), "Expected to have installed bin/foo executable"
+
+    assert_equal "OK\n", `#{foobar}`
+    assert_equal "KO\n", `#{baz}`
     assert_equal "FOO\n", `#{foo}`
   end
 

--- a/test/integration_helper.cr
+++ b/test/integration_helper.cr
@@ -52,9 +52,13 @@ class Minitest::Test
     # path dependency:
     create_path_repository "foo", "0.1.0"
 
-    # dependency with neither a shard.yml nor version tags:
-    create_git_repository "empty"
-    create_git_commit "empty", "initial release"
+    # dependency with neither a shard.yml and/or version tags:
+    #create_git_repository "empty"
+    #create_git_commit "empty", "initial release"
+
+    create_git_repository "missing"
+    create_shard "missing", "name: missing\nversion: 0.1.0\n"
+    create_git_commit "missing", "initial release"
 
     # dependencies with postinstall scripts:
     create_git_repository "post"

--- a/test/integration_helper.cr
+++ b/test/integration_helper.cr
@@ -27,6 +27,7 @@ class Minitest::Test
   end
 
   def setup_repositories
+    # git dependencies for testing version resolution:
     create_git_repository "web", "1.0.0", "1.1.0", "1.1.1", "1.1.2", "1.2.0", "2.0.0", "2.1.0"
     create_git_repository "pg", "0.1.0", "0.2.0", "0.2.1", "0.3.0"
     create_git_repository "optional", "0.2.0", "0.2.1", "0.2.2"
@@ -44,9 +45,18 @@ class Minitest::Test
     create_git_repository "release", "0.2.0", "0.2.1", "0.2.2"
     create_git_release "release", "0.3.0", "name: release\nversion: 0.3.0\ncustom_dependencies:\n  pg:\n    git: #{git_path("optional")}\n"
 
+    # git dependencies with prereleases:
+    create_git_repository "unstable", "0.1.0", "0.2.0", "0.3.0.alpha", "0.3.0.beta"
+    create_git_repository "preview", "0.1.0", "0.2.0", "0.3.0.a", "0.3.0.b", "0.3.0", "0.4.0.a"
+
+    # path dependency:
+    create_path_repository "foo", "0.1.0"
+
+    # dependency with neither a shard.yml nor version tags:
     create_git_repository "empty"
     create_git_commit "empty", "initial release"
 
+    # dependencies with postinstall scripts:
     create_git_repository "post"
     create_file "post", "Makefile", "all:\n\ttouch made.txt\n"
     create_git_release "post", "0.1.0", "name: post\nversion: 0.1.0\nscripts:\n  postinstall: make\n"
@@ -55,17 +65,7 @@ class Minitest::Test
     create_file "fails", "Makefile", "all:\n\ttest -n ''\n"
     create_git_release "fails", "0.1.0", "name: fails\nversion: 0.1.0\nscripts:\n  postinstall: make\n"
 
-    create_path_repository "foo", "0.1.0"
-
-    create_path_repository "binary"
-    create_shard "binary", "name: binary\nversion: 0.1.0\nexecutables:\n  - foobar\n  - baz\n"
-    create_file "binary", "bin/foobar", "#! /usr/bin/env sh\necho 'OK'", perm: 0o755
-    create_file "binary", "bin/baz", "#! /usr/bin/env sh\necho 'KO'", perm: 0o755
-
-    create_git_repository "unstable", "0.1.0", "0.2.0", "0.3.0.alpha", "0.3.0.beta"
-    create_git_repository "preview", "0.1.0", "0.2.0", "0.3.0.a", "0.3.0.b", "0.3.0", "0.4.0.a"
-
-    # postinstall script with transitive dependency:
+    # transitive dependencies in postinstall scripts:
     create_git_repository "version"
     create_file "version", "src/version.cr", %(module Version; STRING = "version @ 0.1.0"; end)
     create_git_release "version", "0.1.0"
@@ -81,6 +81,14 @@ dependencies:
 scripts:
   postinstall: crystal build src/version.cr
 YAML
+
+    # dependencies with executables:
+    create_git_repository "binary"
+    create_file "binary", "bin/foobar", "#! /usr/bin/env sh\necho 'OK'", perm: 0o755
+    create_file "binary", "bin/baz", "#! /usr/bin/env sh\necho 'KO'", perm: 0o755
+    create_git_release "binary", "0.1.0", "name: binary\nversion: 0.1.0\nexecutables:\n  - foobar\n  - baz\n"
+    create_file "binary", "bin/foo", "echo 'FOO'", perm: 0o755
+    create_git_release "binary", "0.2.0", "name: binary\nversion: 0.2.0\nexecutables:\n  - foobar\n  - baz\n  - foo"
 
     Minitest::Test.created_repositories!
   end

--- a/test/support/factories.cr
+++ b/test/support/factories.cr
@@ -36,6 +36,9 @@ module Shards
           contents = shard.is_a?(String) ? shard : "name: #{project}\nversion: #{version}\n"
           create_shard project, contents
         end
+        Dir.cd(git_path(project)) do
+          run "git add src/#{project}.cr"
+        end
         create_git_commit project, "release: v#{version}"
       end
       create_git_tag(project, "v#{version}")


### PR DESCRIPTION
- 2fb303e now resolves HEAD to `x.x.x+git.commit.<sha1>` when a shard doesn't have any version tags;
- 42a7bf9 `Package` now resolves a SPEC at commit if present instead of the version tag; this caused bug #269 when a shard doesn't have version tags (`shard.yml` not found at version, despite `shard.yml` existing at commit).

~~I don't have time to write proper tests. If someone wants to take a stab at 'em!~~

closes #269