### PR TITLE
Fix: GitResolver must report all available versions

### DIFF
--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -64,11 +64,7 @@ module Shards
     def available_versions
       update_local_cache
 
-      versions = if refs = dependency.refs
-                   [version_at(refs)].compact
-                 else
-                   versions_from_tags
-                 end
+      versions = versions_from_tags
 
       if versions.any?
         Shards.logger.debug { "versions: #{versions.reverse.join(", ")}" }
@@ -103,7 +99,7 @@ module Shards
 
     def install(version = nil)
       update_local_cache
-      refs = version && git_refs(version) || dependency.refs || "HEAD"
+      refs = version && git_refs(version) || "HEAD"
 
       cleanup_install_directory
       Dir.mkdir_p(install_path)

--- a/test/git_resolver_test.cr
+++ b/test/git_resolver_test.cr
@@ -16,12 +16,6 @@ module Shards
     def test_available_versions
       assert_equal ["HEAD"], resolver("empty").available_versions
       assert_equal ["0.0.1", "0.1.0", "0.1.1", "0.1.2", "0.2.0"], resolver("library").available_versions
-
-      refs = git_commits("library")
-      assert_equal ["0.0.1"], resolver("library", {"commit" => refs.last}).available_versions
-      assert_equal ["0.2.0"], resolver("library", {"commit" => refs.first}).available_versions
-      assert_equal ["0.1.2"], resolver("library", {"tag" => "v0.1.2"}).available_versions
-      assert_equal ["0.2.0"], resolver("library", {"branch" => "master"}).available_versions
     end
 
     def test_read_spec


### PR DESCRIPTION
GitResolver#available_versions must no longer filter versions based on the Git refs of the initial dependency that created it. It must always report all versions, which are filtered later by the solver.