### PR TITLE
Fix: Git refs must enable pre-release selection

### DIFF
--- a/src/solver.cr
+++ b/src/solver.cr
@@ -54,10 +54,11 @@ module Shards
 
       # pre-releases are opt-in, so we must check that the solution didn't
       # select one unless at least one requirement in the selected graph asked
-      # for it:
+      # for it, or we install the dependency at a Git refs:
       unless @prereleases
         packages.each do |package|
           next unless Versions.prerelease?(package.version)
+          next if package.commit
 
           if dependency = @spec.dependencies.find { |d| d.name == package.name }
             break if Versions.prerelease?(dependency.version)

--- a/test/integration/install_test.cr
+++ b/test/integration/install_test.cr
@@ -71,6 +71,18 @@ class InstallCommandTest < Minitest::Test
     end
   end
 
+  def test_installs_prerelease_version_at_refs
+    metadata = {
+      dependencies: {
+        unstable: {git: git_url(:unstable), branch: "master"}
+      }
+    }
+    with_shard(metadata) do
+      run "shards install"
+      assert_installed "unstable", "0.3.0.beta"
+    end
+  end
+
   def test_installs_dependencies_at_locked_version
     metadata = {
       dependencies:             {web: "1.0.0"},


### PR DESCRIPTION
GitResolver#available_versions must no longer filter versions based on the Git refs of the initial dependency that created it. It must always report all versions, which are filtered later by the solver.

fixes #273