### PR TITLE
Fix: prune command must only remove directories

### DIFF
--- a/src/commands/prune.cr
+++ b/src/commands/prune.cr
@@ -15,6 +15,13 @@ module Shards
           if locks.none? { |d| d.name == name }
             Shards.logger.debug "rm -rf '#{Helpers::Path.escape(path)}'"
             FileUtils.rm_rf(path)
+
+            sha1 = "#{path}.sha1"
+            if File.exists?(sha1)
+              Shards.logger.debug "rm '#{Helpers::Path.escape(sha1)}'"
+              File.delete(sha1)
+            end
+
             Shards.logger.info "Pruned #{File.join(File.basename(Shards.install_path), name)}"
           end
         end

--- a/src/commands/prune.cr
+++ b/src/commands/prune.cr
@@ -9,7 +9,7 @@ module Shards
         return unless lockfile?
 
         Dir[File.join(Shards.install_path, "*")].each do |path|
-          next unless Dir.exists?(path)
+          next unless File.directory?(path)
           name = File.basename(path)
 
           if locks.none? { |d| d.name == name }

--- a/test/integration/prune_test.cr
+++ b/test/integration/prune_test.cr
@@ -3,7 +3,7 @@ require "../integration_helper"
 class PruneCommandTest < Minitest::Test
   def setup
     metadata = {
-      dependencies:             {web: "*", orm: "*"},
+      dependencies:             {web: "*", orm: {git: git_url(:orm), branch: "master"}},
       development_dependencies: {mock: "*"},
     }
     with_shard(metadata) { run "shards install" }
@@ -17,6 +17,7 @@ class PruneCommandTest < Minitest::Test
   def test_removes_unused_dependencies
     Dir.cd(application_path) { run "shards prune" }
     assert_equal ["web"], installed_dependencies
+    refute File.exists?(File.join(application_path, "lib", "orm.sha1"))
   end
 
   def test_removes_directories

--- a/test/integration/prune_test.cr
+++ b/test/integration/prune_test.cr
@@ -26,9 +26,9 @@ class PruneCommandTest < Minitest::Test
   end
 
   def test_wont_remove_files
-    File.write(File.join(application_path, "lib", ".keep"), "")
+    File.write(File.join(application_path, "lib", "keep"), "")
     Dir.cd(application_path) { run "shards prune" }
-    assert_equal [".keep", "web"], installed_dependencies.sort
+    assert_equal ["keep", "web"], installed_dependencies.sort
   end
 
   private def installed_dependencies


### PR DESCRIPTION
The issue was found in the nightly builds.