### PR TITLE
Use Set instead of Array for memorizing conflicts

### DIFF
--- a/src/solver/sat.cr
+++ b/src/solver/sat.cr
@@ -31,7 +31,7 @@ module Shards
         @clauses = Array(Clause).new
         @table = Hash(String, Literal).new
         @variables = Array(String).new
-        @conflicts = Array(Array(Literal)).new
+        @conflicts = Set(Array(Literal)).new
       end
 
       def add_clause(str : String) : Nil


### PR DESCRIPTION
Fixes the SAT solver so it doesn't fill the memory. Doesn't fix the solver from being very long (not necessarily SAT being but the afterwards decision on the best outcome).

Refs #282 