### PR TITLE
Make shards reproducible

### DIFF
--- a/src/version.cr
+++ b/src/version.cr
@@ -1,7 +1,7 @@
 module Shards
   VERSION    = {{ read_file("#{__DIR__}/../VERSION").chomp }}
   BUILD_SHA1 = {{ `git log --format=%h -n 1 2>/dev/null || echo ""`.stringify.chomp }}
-  BUILD_DATE = {{ `date -u +'%Y-%m-%d'`.stringify.chomp }}
+  BUILD_DATE = Time.unix({{ (env("SOURCE_DATE_EPOCH") || `date +%s`).to_i }}).to_s("%Y-%m-%d")
 
   def self.version_string
     if BUILD_SHA1.empty?


### PR DESCRIPTION
By default the shards binary embeds a build date which makes it
impossible to rebuild due to time differences. Use SOURCE_DATE_EPOCH to
use a predictable timestamp as input for the date function which in turn
makes shards reproducible.

Motiviation: https://reproducible-builds.org