### PR TITLE
SPEC: Allow periods in shard name

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -68,8 +68,8 @@ The name of library (String, required).
 - It should be lowercase (a-z).
 - It should not contain `crystal`.
 - It may contain digits (0-9) but not start with one.
-- It may contain underscores or dashes but not start/end with one.
-- It must not have consecutive underscores or dashes.
+- It may contain underscores, dashes or periods but not start/end with one.
+- It must not have consecutive underscores, dashes or periods.
 
 Examples: `minitest`, `mysql2`, `battery-horse`.
 


### PR DESCRIPTION
This is a proposal to allow period (`.`) in the name of a spec.

The main reason to allow this is because its already in use (since there is no strict enforcement anyways). There are a number of shards ending with `.cr`, for example https://github.com/TPei/progress_bar.cr, https://github.com/krthr/haye.cr, https://github.com/imdrasil/hermes.cr
This is somewhat of an attempt to "legalize" those names.

I'm not aware of any specific reason for prohibiting this character. There might be some source of confusion with respect to file extensions. But since shard names are typically used as directories, I don't see any real issues there.
The general idea is to keep the allowed character limited, but basic special characters should be allowed (dashes and underscores are already allowed).

/cc crystal-lang/crystal#8737