### PR TITLE
Show the shard's name when running scripts

### DIFF
--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -42,8 +42,8 @@ module Shards
 
     def run_script(name)
       if installed? && (command = installed_spec.try(&.scripts[name]?))
-        Shards.logger.info "#{name.capitalize} #{command} (#{dependency.name})"
-        Script.run(install_path, command)
+        Shards.logger.info "#{name.capitalize} of #{dependency.name}: #{command}"
+        Script.run(install_path, command, name, dependency.name)
       end
     end
 

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -42,7 +42,7 @@ module Shards
 
     def run_script(name)
       if installed? && (command = installed_spec.try(&.scripts[name]?))
-        Shards.logger.info "#{name.capitalize} #{command}"
+        Shards.logger.info "#{name.capitalize} #{command} (#{dependency.name})"
         Script.run(install_path, command)
       end
     end

--- a/src/script.cr
+++ b/src/script.cr
@@ -3,11 +3,11 @@ module Shards
     class Error < Error
     end
 
-    def self.run(path, command)
+    def self.run(path, command, script_name, dependency_name)
       Dir.cd(path) do
         output = IO::Memory.new
         status = Process.run("/bin/sh", input: IO::Memory.new(command), output: output, error: output)
-        raise Error.new("Failed #{command}:\n#{output.to_s.rstrip}") unless status.success?
+        raise Error.new("Failed #{script_name} of #{dependency_name} on #{command}:\n#{output.to_s.rstrip}") unless status.success?
       end
     end
   end

--- a/test/integration/install_test.cr
+++ b/test/integration/install_test.cr
@@ -295,15 +295,16 @@ class InstallCommandTest < Minitest::Test
 
   def test_runs_postinstall_script
     with_shard({dependencies: {post: "*"}}) do
-      run "shards install"
+      output = run "shards install --no-color", capture: true
       assert File.exists?(File.join(application_path, "lib", "post", "made.txt"))
+      assert_match "Postinstall of post: make", output
     end
   end
 
   def test_prints_details_and_removes_dependency_when_postinstall_script_fails
     with_shard({dependencies: {fails: "*"}}) do
       ex = assert_raises(FailedCommand) { run "shards install --no-color" }
-      assert_match "E: Failed make:\n", ex.stdout
+      assert_match "E: Failed postinstall of fails on make:\n", ex.stdout
       assert_match "test -n ''\n", ex.stdout
       refute Dir.exists?(File.join(application_path, "lib", "fails"))
     end


### PR DESCRIPTION
When running `$ shards install` it will now append the shard name where the script is defined

For example when running it in lucky it will show the precompiled_tasks for avram and make bin from ameba are run.

```
... stripped ...
Installing teeplate (0.8.0)
Installing blank (0.1.0)
Installing db (0.8.0)
Installing pg (0.20.0)
Postinstall script/precompile_tasks (avram)
Postinstall make bin (ameba)
Writing shard.lock
```

When the command fails, [only the command is displayed](https://github.com/crystal-lang/shards/blob/0cda1578a12f6d59254b81c2b7a2386f34a3ea44/src/script.cr#L10) with no path/dependency name. 