### PR TITLE
Support shard renames

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -365,6 +365,42 @@ describe "install" do
     end
   end
 
+  it "fail install old version when shard was renamed" do
+    metadata = {
+      dependencies: {
+        new_name: {git: git_url(:renamed), version: "0.1.0"},
+      },
+    }
+    with_shard(metadata) do
+      ex = expect_raises(FailedCommand) { run "shards install --no-color" }
+      ex.stdout.should contain("Error shard name (old_name) doesn't match dependency name (new_name)")
+    end
+  end
+
+  it "fail install new version when shard was renamed" do
+    metadata = {
+      dependencies: {
+        old_name: {git: git_url(:renamed), version: "0.2.0"},
+      },
+    }
+    with_shard(metadata) do
+      ex = expect_raises(FailedCommand) { run "shards install --no-color" }
+      ex.stdout.should contain("Error shard name (new_name) doesn't match dependency name (old_name)")
+    end
+  end
+
+  it "install untagged version when shard was renamed" do
+    metadata = {
+      dependencies: {
+        another_name: {git: git_url(:renamed), branch: "master"},
+      },
+    }
+    with_shard(metadata) do
+      run "shards install"
+      assert_installed "another_name", "0.3.0"
+    end
+  end
+
   it "installs executables at version" do
     metadata = {
       dependencies: {binary: "0.1.0"},

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -341,6 +341,30 @@ describe "install" do
     end
   end
 
+  it "test install old with version when shard was renamed" do
+    metadata = {
+      dependencies: {
+        old_name: {git: git_url(:renamed), version: "0.1.0"},
+      },
+    }
+    with_shard(metadata) do
+      run "shards install"
+      assert_installed "old_name", "0.1.0"
+    end
+  end
+
+  it "test install new when shard was renamed" do
+    metadata = {
+      dependencies: {
+        new_name: {git: git_url(:renamed)},
+      },
+    }
+    with_shard(metadata) do
+      run "shards install"
+      assert_installed "new_name", "0.2.0"
+    end
+  end
+
   it "installs executables at version" do
     metadata = {
       dependencies: {binary: "0.1.0"},

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -64,6 +64,7 @@ private def setup_repositories
   create_git_repository "renamed"
   create_git_release "renamed", "0.1.0", "name: old_name\nversion: 0.1.0"
   create_git_release "renamed", "0.2.0", "name: new_name\nversion: 0.2.0"
+  create_git_version_commit "renamed", "0.3.0", "name: another_name\nversion: 0.3.0"
 
   create_git_repository "transitive"
   create_file "transitive", "src/version.cr", %(require "version"; puts Version::STRING)

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -61,6 +61,10 @@ private def setup_repositories
   create_file "version", "src/version.cr", %(module Version; STRING = "version @ 0.1.0"; end)
   create_git_release "version", "0.1.0"
 
+  create_git_repository "renamed"
+  create_git_release "renamed", "0.1.0", "name: old_name\nversion: 0.1.0"
+  create_git_release "renamed", "0.2.0", "name: new_name\nversion: 0.2.0"
+
   create_git_repository "transitive"
   create_file "transitive", "src/version.cr", %(require "version"; puts Version::STRING)
   create_git_release "transitive", "0.2.0", <<-YAML

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -28,7 +28,7 @@ def create_git_repository(project, *versions)
   versions.each { |version| create_git_release project, version }
 end
 
-def create_git_release(project, version, shard = true)
+def create_git_version_commit(project, version, shard = true)
   Dir.cd(git_path(project)) do
     if shard
       contents = shard.is_a?(String) ? shard : "name: #{project}\nversion: #{version}\n"
@@ -39,6 +39,10 @@ def create_git_release(project, version, shard = true)
     end
     create_git_commit project, "release: v#{version}"
   end
+end
+
+def create_git_release(project, version, shard = true)
+  create_git_version_commit(project, version, shard)
   create_git_tag(project, "v#{version}")
 end
 

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -45,7 +45,7 @@ module Shards
 
       packages = [] of Package
       result.each do |v|
-        spec = v.payload.as(Spec) || raise "BUG: returned graph payload was not a Spec"
+        spec = v.payload.as?(Spec) || raise "BUG: returned graph payload was not a Spec"
         v.requirements.each do |dependency|
           unless dependency.name == spec.name
             raise Error.new("Error shard name (#{spec.name}) doesn't match dependency name (#{dependency.name})")


### PR DESCRIPTION
Currently a shard that was renamed in some point in history cannot be installed unless a version is specified. This is annoying, because for example this `shard.yml` fails with a misleading error:

```yml
name: test
version: 0.1.0

dependencies:
  lucky:
    github: luckyframework/lucky
```

```
$ shards install
Resolving dependencies
Fetching https://github.com/luckyframework/lucky.git
Error shard name (lucky_web) doesn't match dependency name (lucky)
```

This PR allows installing latest version of a shard (when no version is specified) or a previous version only if the name matches.