### PR TITLE
Replace glob patterns in Makefile with `find` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@
 
 CRYSTAL = crystal
 CRFLAGS =
-SOURCES = src/*.cr src/**/*.cr lib/molinillo/**/*.cr
+SHARDS_SOURCES = $(shell find src -name '*.cr')
+MOLINILLO_SOURCES = $(shell find lib/molinillo -name '*.cr')
+SOURCES = $(SHARDS_SOURCES) $(MOLINILLO_SOURCES)
 TEMPLATES = src/templates/*.ecr
 
 DESTDIR =


### PR DESCRIPTION
Currently the Makefile makes use of the `**` wildcard. But that actually doesn't have any effect. I replaced that with `find` calls, that I hope are fully portable 🤞 