### PR TITLE
Fix detection of circular dependencies

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -6,5 +6,5 @@ shards:
 
   molinillo:
     github: crystal-lang/crystal-molinillo
-    commit: 00fbe6c5ef9492d56cc7ec7b9a8b9cf2fe1a36ea
+    commit: 4b78e8c577ac322c8c0363788f3e1109f19668d9
 


### PR DESCRIPTION
Upgrade the version of `molinillo` that fixes an error when trying to raise errors about circular dependencies.