### PR TITLE
Move osx ci from Travis to Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,37 +1,52 @@
-version: 2
+version: 2.1
 
-dry:
-  prepare: &prepare
-    command: |
-      crystal --version
-      git config --global user.email "you@example.com"
-      git config --global user.name "Your Name"
-      git config --global column.ui always
+orbs:
+  crystal: manastech/crystal@1.0.0
 
-  steps: &steps
-    - run: *prepare
-    - checkout
-    - run: shards install
-    - run: make
-    - run: make test
-    - run: crystal tool format --check
+commands:
+  shards-make-test:
+    steps:
+      - run:
+          name: git config
+          command: |
+            git config --global user.email "you@example.com"
+            git config --global user.name "Your Name"
+            git config --global column.ui always
+      - crystal/version
+      - checkout
+      - crystal/shards-install
+      - run: make
+      - run: make test
+      - crystal/format-check
 
 jobs:
   test:
     docker:
       - image: crystallang/crystal:latest
-    steps: *steps
+    steps:
+      - shards-make-test
+
+  test-on-osx:
+    macos:
+      xcode: 11.1.0 # latest mojave
+    steps:
+      - run:
+          name: Install Crystal
+          command: brew install crystal
+      - shards-make-test
 
   test-on-nightly:
     docker:
       - image: crystallang/crystal:nightly
-    steps: *steps
+    steps:
+      - shards-make-test
 
 workflows:
   version: 2
   ci:
     jobs:
       - test
+      - test-on-osx
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,22 @@ commands:
       - run: make test
       - crystal/format-check
 
+  with-brew-cache:
+    parameters:
+      steps:
+        type: steps
+    steps:
+      - restore_cache:
+          keys:
+            - brew-cache-v1-{{ .Branch }}
+            - brew-cache-v1-
+      - steps: <<parameters.steps>>
+      - save_cache:
+          key: brew-cache-v1-{{ .Branch }}-{{ epoch }}
+          paths:
+            - /usr/local/Homebrew
+            - ~/Library/Caches/Homebrew
+
 jobs:
   test:
     docker:
@@ -30,9 +46,11 @@ jobs:
     macos:
       xcode: 11.1.0 # latest mojave
     steps:
-      - run:
-          name: Install Crystal
-          command: brew install crystal
+      - with-brew-cache:
+          steps:
+            - run:
+                name: Install Crystal
+                command: brew install crystal
       - shards-make-test
 
   test-on-nightly:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: crystal
 
 os:
   - linux
-  - osx
 
 before_script: |
   make


### PR DESCRIPTION
Plus some cleanup in circle ci config

Travis ran in 11min + queue
Circle ran in 7min + queue

Installing from homebrew even with caching takes a lot of time. But the main reason is to avoid hangs due while waiting for travis to give an osx instance.