### PR TITLE
Use Crystal 0.34 Log module (if possible)

### DIFF
--- a/spec/unit/spec_helper.cr
+++ b/spec/unit/spec_helper.cr
@@ -9,7 +9,7 @@ require "../../src/resolvers/*"
 require "../support/factories"
 
 module Shards
-  logger.level = Logger::Severity::WARN
+  set_warning_log_level
 
   class Dependency
     def self.from_name_config(name, config) : self

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -32,8 +32,8 @@ module Shards
       opts.on("--version", "Print the `shards` version.") { puts self.version_string; exit }
       opts.on("--production", "Run in release mode. No development dependencies and strict sync between shard.yml and shard.lock.") { self.production = true }
       opts.on("--local", "Don't update remote repositories, use the local cache only.") { self.local = true }
-      opts.on("-v", "--verbose", "Increase the log verbosity, printing all debug statements.") { self.logger.level = Logger::Severity::DEBUG }
-      opts.on("-q", "--quiet", "Decrease the log verbosity, printing only warnings and errors.") { self.logger.level = Logger::Severity::WARN }
+      opts.on("-v", "--verbose", "Increase the log verbosity, printing all debug statements.") { self.set_debug_log_level }
+      opts.on("-q", "--quiet", "Decrease the log verbosity, printing only warnings and errors.") { self.set_warning_log_level }
       opts.on("-h", "--help", "Print usage synopsis.") { self.display_help_and_exit(opts) }
 
       opts.unknown_args do |args, options|
@@ -100,12 +100,12 @@ end
 begin
   Shards.run
 rescue ex : OptionParser::InvalidOption
-  Shards.logger.fatal ex.message
+  Shards::Log.fatal { ex.message }
   exit 1
 rescue ex : Shards::ParseError
   ex.to_s(STDERR)
   exit 1
 rescue ex : Shards::Error
-  Shards.logger.error ex.message
+  Shards::Log.error { ex.message }
   exit 1
 end

--- a/src/commands/build.cr
+++ b/src/commands/build.cr
@@ -5,7 +5,7 @@ module Shards
     class Build < Command
       def run(targets, options)
         unless Dir.exists?(Shards.bin_path)
-          Shards.logger.debug "mkdir #{Shards.bin_path}"
+          Log.debug { "mkdir #{Shards.bin_path}" }
           Dir.mkdir(Shards.bin_path)
         end
 
@@ -23,7 +23,7 @@ module Shards
       end
 
       private def build(target, options)
-        Shards.logger.info { "Building: #{target.name}" }
+        Log.info { "Building: #{target.name}" }
 
         args = [
           "build",
@@ -31,7 +31,7 @@ module Shards
           target.main,
         ]
         options.each { |option| args << option }
-        Shards.logger.debug { "crystal #{args.join(' ')}" }
+        Log.debug { "crystal #{args.join(' ')}" }
 
         error = IO::Memory.new
         status = Process.run("crystal", args: args, output: Process::Redirect::Inherit, error: error)

--- a/src/commands/check.cr
+++ b/src/commands/check.cr
@@ -11,7 +11,7 @@ module Shards
           verify(spec.development_dependencies) unless Shards.production?
         end
 
-        Shards.logger.info "Dependencies are satisfied"
+        Log.info { "Dependencies are satisfied" }
       end
 
       private def has_dependencies?
@@ -20,11 +20,11 @@ module Shards
 
       private def verify(dependencies)
         dependencies.each do |dependency|
-          Shards.logger.debug { "#{dependency.name}: checking..." }
+          Log.debug { "#{dependency.name}: checking..." }
           resolver = Shards.find_resolver(dependency)
 
           unless _spec = resolver.installed_spec
-            Shards.logger.debug { "#{dependency.name}: not installed" }
+            Log.debug { "#{dependency.name}: not installed" }
             raise Error.new("Dependencies aren't satisfied. Install them with 'shards install'")
           end
 
@@ -38,13 +38,13 @@ module Shards
 
       private def installed?(dependency, spec)
         unless lock = locks.find { |d| d.name == spec.name }
-          Shards.logger.debug { "#{dependency.name}: not locked" }
+          Log.debug { "#{dependency.name}: not locked" }
           return false
         end
 
         if version = lock["version"]?
           if Versions.resolve([version], dependency.version).empty?
-            Shards.logger.debug { "#{dependency.name}: lock conflict" }
+            Log.debug { "#{dependency.name}: lock conflict" }
             return false
           else
             return spec.version == version
@@ -60,7 +60,7 @@ module Shards
         # end
 
         if Versions.resolve([spec.version], dependency.version).empty?
-          Shards.logger.debug { "#{dependency.name}: version mismatch" }
+          Log.debug { "#{dependency.name}: version mismatch" }
           return false
         end
 

--- a/src/commands/command.cr
+++ b/src/commands/command.cr
@@ -52,14 +52,14 @@ module Shards
     end
 
     def write_lockfile(packages)
-      Shards.logger.info { "Writing #{LOCK_FILENAME}" }
+      Log.info { "Writing #{LOCK_FILENAME}" }
       Shards::Lock.write(packages, LOCK_FILENAME)
     end
 
     def handle_resolver_errors
       yield
     rescue e : Molinillo::ResolverError
-      Shards.logger.error e.message
+      Log.error { e.message }
       raise Shards::Error.new("Failed to resolve dependencies")
     end
   end

--- a/src/commands/init.cr
+++ b/src/commands/init.cr
@@ -13,7 +13,7 @@ module Shards
           ECR.embed "#{__DIR__}/../templates/shard.yml.ecr", "__str__"
         end)
 
-        Shards.logger.info "Created #{SPEC_FILENAME}"
+        Log.info { "Created #{SPEC_FILENAME}" }
       end
 
       private def name

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -5,7 +5,7 @@ module Shards
   module Commands
     class Install < Command
       def run
-        Shards.logger.info { "Resolving dependencies" }
+        Log.info { "Resolving dependencies" }
 
         solver = MolinilloSolver.new(spec)
 
@@ -72,11 +72,11 @@ module Shards
 
       private def install(package : Package)
         if package.installed?
-          Shards.logger.info { "Using #{package.name} (#{package.report_version})" }
+          Log.info { "Using #{package.name} (#{package.report_version})" }
           return
         end
 
-        Shards.logger.info { "Installing #{package.name} (#{package.report_version})" }
+        Log.info { "Installing #{package.name} (#{package.report_version})" }
         package.install
         package
       end

--- a/src/commands/list.cr
+++ b/src/commands/list.cr
@@ -18,7 +18,7 @@ module Shards
 
           # FIXME: duplicated from Check#verify
           unless _spec = resolver.installed_spec
-            Shards.logger.debug { "#{dependency.name}: not installed" }
+            Log.debug { "#{dependency.name}: not installed" }
             raise Error.new("Dependencies aren't satisfied. Install them with 'shards install'")
           end
 

--- a/src/commands/lock.cr
+++ b/src/commands/lock.cr
@@ -5,7 +5,7 @@ module Shards
   module Commands
     class Lock < Command
       def run(shards : Array(String), print = false, update = false)
-        Shards.logger.info { "Resolving dependencies" }
+        Log.info { "Resolving dependencies" }
 
         solver = MolinilloSolver.new(spec)
 

--- a/src/commands/outdated.cr
+++ b/src/commands/outdated.cr
@@ -11,7 +11,7 @@ module Shards
       def run(@prereleases = false)
         return unless has_dependencies?
 
-        Shards.logger.info { "Resolving dependencies" }
+        Log.info { "Resolving dependencies" }
 
         solver = MolinilloSolver.new(spec, @prereleases)
         solver.prepare(development: !Shards.production?)
@@ -20,10 +20,10 @@ module Shards
         packages.each { |package| analyze(package) }
 
         if @up_to_date
-          Shards.logger.info "Dependencies are up to date!"
+          Log.info { "Dependencies are up to date!" }
         else
           @output.rewind
-          Shards.logger.warn "Outdated dependencies:"
+          Log.warn { "Outdated dependencies:" }
           puts @output.to_s
         end
       end
@@ -33,7 +33,7 @@ module Shards
         installed = resolver.installed_spec.try(&.version)
 
         unless installed
-          Shards.logger.warn { "#{package.name}: not installed" }
+          Log.warn { "#{package.name}: not installed" }
           return
         end
 

--- a/src/commands/prune.cr
+++ b/src/commands/prune.cr
@@ -13,16 +13,16 @@ module Shards
           name = File.basename(path)
 
           if locks.none? { |d| d.name == name }
-            Shards.logger.debug "rm -rf '#{Helpers::Path.escape(path)}'"
+            Log.debug { "rm -rf '#{Helpers::Path.escape(path)}'" }
             FileUtils.rm_rf(path)
 
             sha1 = "#{path}.sha1"
             if File.exists?(sha1)
-              Shards.logger.debug "rm '#{Helpers::Path.escape(sha1)}'"
+              Log.debug { "rm '#{Helpers::Path.escape(sha1)}'" }
               File.delete(sha1)
             end
 
-            Shards.logger.info "Pruned #{File.join(File.basename(Shards.install_path), name)}"
+            Log.info { "Pruned #{File.join(File.basename(Shards.install_path), name)}" }
           end
         end
       end

--- a/src/commands/update.cr
+++ b/src/commands/update.cr
@@ -5,7 +5,7 @@ module Shards
   module Commands
     class Update < Command
       def run(shards : Array(String))
-        Shards.logger.info { "Resolving dependencies" }
+        Log.info { "Resolving dependencies" }
 
         solver = MolinilloSolver.new(spec)
 
@@ -40,11 +40,11 @@ module Shards
 
       private def install(package : Package)
         if package.installed?
-          Shards.logger.info { "Using #{package.name} (#{package.report_version})" }
+          Log.info { "Using #{package.name} (#{package.report_version})" }
           return
         end
 
-        Shards.logger.info { "Installing #{package.name} (#{package.report_version})" }
+        Log.info { "Installing #{package.name} (#{package.report_version})" }
         package.install
         package
       end

--- a/src/config.cr
+++ b/src/config.cr
@@ -69,7 +69,7 @@ module Shards
                           end
 
     if File.exists?(legacy_install_path)
-      Shards.logger.warn "Shards now installs dependencies into the 'lib' folder. You may delete the legacy 'libs' folder."
+      Log.warn { "Shards now installs dependencies into the 'lib' folder. You may delete the legacy 'libs' folder." }
     end
   end
 

--- a/src/logger.cr
+++ b/src/logger.cr
@@ -1,5 +1,16 @@
-require "logger"
 require "colorize"
+
+module Shards
+  @@colors = true
+
+  def self.colors=(value)
+    @@colors = value
+  end
+end
+
+# Using Crystal < 0.34 logger module
+
+require "logger"
 
 module Shards
   LOGGER_COLORS = {
@@ -8,12 +19,6 @@ module Shards
     "INFO"  => :light_green,
     "DEBUG" => :light_gray,
   }
-
-  @@colors = true
-
-  def self.colors=(value)
-    @@colors = value
-  end
 
   @@logger : Logger?
 
@@ -38,5 +43,23 @@ module Shards
         end
       end
     end
+  end
+
+  def self.set_warning_log_level
+    logger.level = Logger::Severity::WARN
+  end
+
+  def self.set_debug_log_level
+    logger.level = Logger::Severity::DEBUG
+  end
+
+  module Log
+    {% for severity in %w(debug info warn error fatal) %}
+      def self.{{severity.id}}
+        Shards.logger.{{severity.id}} do
+          yield
+        end
+      end
+    {% end %}
   end
 end

--- a/src/logger.cr
+++ b/src/logger.cr
@@ -8,58 +8,105 @@ module Shards
   end
 end
 
-# Using Crystal < 0.34 logger module
+{% if compare_versions(Crystal::VERSION, "0.34.0-0") > 0 %}
+  require "log"
 
-require "logger"
+  Log.setup_from_env(
+    level: ENV.fetch("CRYSTAL_LOG_LEVEL", "INFO"),
+    sources: ENV.fetch("CRYSTAL_LOG_SOURCES", "shards.*"),
+    backend: Log::IOBackend.new.tap do |backend|
+      backend.formatter = Shards::FORMATTER
+    end
+  )
 
-module Shards
-  LOGGER_COLORS = {
-    "ERROR" => :red,
-    "WARN"  => :light_yellow,
-    "INFO"  => :light_green,
-    "DEBUG" => :light_gray,
-  }
+  module Shards
+    Log = ::Log.for(self)
 
-  @@logger : Logger?
+    def self.set_warning_log_level
+      Log.level = ::Log::Severity::Warning
+    end
 
-  def self.logger
-    @@logger ||= Logger.new(STDOUT).tap do |logger|
-      logger.progname = "shards"
-      logger.level = Logger::Severity::INFO
+    def self.set_debug_log_level
+      Log.level = ::Log::Severity::Debug
+    end
 
-      logger.formatter = Logger::Formatter.new do |severity, _datetime, _progname, message, io|
-        if @@colors
-          io << if color = LOGGER_COLORS[severity.to_s]?
-            if idx = message.index(' ')
-              message[0...idx].colorize(color).to_s + message[idx..-1]
-            else
-              message.colorize(color)
-            end
+    LOGGER_COLORS = {
+      ::Log::Severity::Error   => :red,
+      ::Log::Severity::Warning => :light_yellow,
+      ::Log::Severity::Info    => :light_green,
+      ::Log::Severity::Debug   => :light_gray,
+    }
+
+    FORMATTER = ::Log::Formatter.new do |entry, io|
+      message = entry.message
+
+      if @@colors
+        io << if color = LOGGER_COLORS[entry.severity]?
+          if idx = message.index(' ')
+            message[0...idx].colorize(color).to_s + message[idx..-1]
           else
-            message
+            message.colorize(color)
           end
         else
-          io << severity.to_s[0] << ": " << message
+          message
         end
+      else
+        io << entry.severity.label[0] << ": " << message
       end
     end
   end
+{% else %}
+  require "logger"
 
-  def self.set_warning_log_level
-    logger.level = Logger::Severity::WARN
-  end
+  module Shards
+    LOGGER_COLORS = {
+      "ERROR" => :red,
+      "WARN"  => :light_yellow,
+      "INFO"  => :light_green,
+      "DEBUG" => :light_gray,
+    }
 
-  def self.set_debug_log_level
-    logger.level = Logger::Severity::DEBUG
-  end
+    @@logger : Logger?
 
-  module Log
-    {% for severity in %w(debug info warn error fatal) %}
-      def self.{{severity.id}}
-        Shards.logger.{{severity.id}} do
-          yield
+    def self.logger
+      @@logger ||= Logger.new(STDOUT).tap do |logger|
+        logger.progname = "shards"
+        logger.level = Logger::Severity::INFO
+
+        logger.formatter = Logger::Formatter.new do |severity, _datetime, _progname, message, io|
+          if @@colors
+            io << if color = LOGGER_COLORS[severity.to_s]?
+              if idx = message.index(' ')
+                message[0...idx].colorize(color).to_s + message[idx..-1]
+              else
+                message.colorize(color)
+              end
+            else
+              message
+            end
+          else
+            io << severity.to_s[0] << ": " << message
+          end
         end
       end
-    {% end %}
+    end
+
+    def self.set_warning_log_level
+      logger.level = Logger::Severity::WARN
+    end
+
+    def self.set_debug_log_level
+      logger.level = Logger::Severity::DEBUG
+    end
+
+    module Log
+      {% for severity in %w(debug info warn error fatal) %}
+        def self.{{severity.id}}
+          Shards.logger.{{severity.id}} do
+            yield
+          end
+        end
+      {% end %}
+    end
   end
-end
+{% end %}

--- a/src/package.cr
+++ b/src/package.cr
@@ -44,7 +44,7 @@ module Shards
       # can access transitive dependencies:
       unless resolver.is_a?(PathResolver)
         lib_path = File.join(resolver.install_path, "lib")
-        Shards.logger.debug { "Link #{Shards.install_path} to #{lib_path}" }
+        Log.debug { "Link #{Shards.install_path} to #{lib_path}" }
         File.symlink("../../lib", lib_path)
       end
     end
@@ -62,7 +62,7 @@ module Shards
       Dir.mkdir_p(Shards.bin_path)
 
       spec.executables.each do |name|
-        Shards.logger.debug { "Install bin/#{name}" }
+        Log.debug { "Install bin/#{name}" }
         source = File.join(resolver.install_path, "bin", name)
         destination = File.join(Shards.bin_path, name)
 

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -67,7 +67,7 @@ module Shards
       versions = versions_from_tags
 
       if versions.any?
-        Shards.logger.debug { "versions: #{versions.reverse.join(", ")}" }
+        Log.debug { "versions: #{versions.reverse.join(", ")}" }
         versions
       else
         ["HEAD"]
@@ -195,7 +195,7 @@ module Shards
       end
 
       return if Shards.local? || @updated_cache
-      Shards.logger.info "Fetching #{git_url}"
+      Log.info { "Fetching #{git_url}" }
 
       if cloned_repository?
         # repositories cloned with shards v0.8.0 won't fetch any new remote
@@ -226,7 +226,7 @@ module Shards
     end
 
     private def delete_repository
-      Shards.logger.debug "rm -rf '#{local_path}'"
+      Log.debug { "rm -rf '#{local_path}'" }
       FileUtils.rm_rf(local_path)
       @origin_url = nil
     end
@@ -302,7 +302,7 @@ module Shards
         raise Error.new("Error missing git command line tool. Please install Git first!")
       end
 
-      Shards.logger.debug command
+      Log.debug { command }
 
       output = capture ? IO::Memory.new : Process::Redirect::Close
       error = IO::Memory.new

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -42,7 +42,7 @@ module Shards
 
     def run_script(name)
       if installed? && (command = installed_spec.try(&.scripts[name]?))
-        Shards.logger.info "#{name.capitalize} of #{dependency.name}: #{command}"
+        Log.info { "#{name.capitalize} of #{dependency.name}: #{command}" }
         Script.run(install_path, command, name, dependency.name)
       end
     end
@@ -52,7 +52,7 @@ module Shards
     end
 
     protected def cleanup_install_directory
-      Shards.logger.debug "rm -rf '#{Helpers::Path.escape(install_path)}'"
+      Log.debug { "rm -rf '#{Helpers::Path.escape(install_path)}'" }
       FileUtils.rm_rf(install_path)
     end
   end


### PR DESCRIPTION
I migrate shards code to use Log module API.
But allow compilation for logger module behind compare_versions.
Once we drop support for older Crystal that can be removed.

With the log module we could even be able to allow logging from molinillo solver be tweaking `CRYSTAL_LOG_SOURCES`. How cool is that 😍 