### PR TITLE
Respect locks when adding new dependencies

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -200,6 +200,25 @@ describe "install" do
     end
   end
 
+  it "install subdependency of new dependency respecting lock" do
+    create_git_repository "c"
+    create_git_release "c", "0.1.0", "name: c\nversion: 0.1.0\ndependencies:\n  d:\n    git: #{git_path("d")}\n    version: 0.1.0\n"
+    create_git_release "c", "0.2.0", "name: c\nversion: 0.2.0\ndependencies:\n  d:\n    git: #{git_path("d")}\n    version: 0.2.0\n"
+    create_git_repository "d"
+    create_git_release "d", "0.1.0", "name: d\nversion: 0.1.0\n"
+    create_git_release "d", "0.2.0", "name: d\nversion: 0.2.0\n"
+
+    metadata = {dependencies: {c: "*", d: "*"}}
+    lock = {d: "0.1.0"}
+
+    with_shard(metadata, lock) do
+      run "shards install"
+
+      assert_installed "c", "0.1.0"
+      assert_installed "d", "0.1.0"
+    end
+  end
+
   it "installs and updates lockfile for added dependencies" do
     metadata = {
       dependencies: {

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -130,7 +130,9 @@ module Shards
         end
 
       if (locks = @locks) && (locked = locks.find { |dep| dep.name == dependency.name })
-        matching << locked.version
+        if Versions.matches?(locked.version, dependency.version)
+          matching << locked.version
+        end
       end
 
       if matching.size == 1 && matching.first == "HEAD"


### PR DESCRIPTION
I found this bug that confuses the Molinillo solver and it ends ignoring the lock in some situations like when adding a new dependency that have sub-dependencies already locked.