### PR TITLE
Automatic unlock on install and update

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -188,26 +188,19 @@ describe "install" do
     end
   end
 
-  it "fails to install when dependency requirement changed" do
+  it "updates when dependency requirement changed" do
     metadata = {dependencies: {web: "2.0.0"}}
     lock = {web: "1.0.0"}
 
     with_shard(metadata, lock) do
-      ex = expect_raises(FailedCommand) { run "shards install --no-color" }
-      ex.stdout.should contain("Outdated shard.lock")
-      ex.stderr.should be_empty
-      refute_installed "web"
+      run "shards install"
+
+      assert_installed "web", "2.0.0"
+      assert_locked "web", "2.0.0"
     end
   end
 
   it "install subdependency of new dependency respecting lock" do
-    create_git_repository "c"
-    create_git_release "c", "0.1.0", "name: c\nversion: 0.1.0\ndependencies:\n  d:\n    git: #{git_path("d")}\n    version: 0.1.0\n"
-    create_git_release "c", "0.2.0", "name: c\nversion: 0.2.0\ndependencies:\n  d:\n    git: #{git_path("d")}\n    version: 0.2.0\n"
-    create_git_repository "d"
-    create_git_release "d", "0.1.0", "name: d\nversion: 0.1.0\n"
-    create_git_release "d", "0.2.0", "name: d\nversion: 0.2.0\n"
-
     metadata = {dependencies: {c: "*", d: "*"}}
     lock = {d: "0.1.0"}
 

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -188,6 +188,18 @@ describe "install" do
     end
   end
 
+  it "fails to install when dependency requirement changed in production" do
+    metadata = {dependencies: {web: "2.0.0"}}
+    lock = {web: "1.0.0"}
+
+    with_shard(metadata, lock) do
+      ex = expect_raises(FailedCommand) { run "shards install --no-color --production" }
+      ex.stdout.should contain("Outdated shard.lock")
+      ex.stderr.should be_empty
+      refute_installed "web"
+    end
+  end
+
   it "updates when dependency requirement changed" do
     metadata = {dependencies: {web: "2.0.0"}}
     lock = {web: "1.0.0"}

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -85,6 +85,13 @@ private def setup_repositories
   create_git_release "binary", "0.1.0", "name: binary\nversion: 0.1.0\nexecutables:\n  - foobar\n  - baz\n"
   create_file "binary", "bin/foo", "echo 'FOO'", perm: 0o755
   create_git_release "binary", "0.2.0", "name: binary\nversion: 0.2.0\nexecutables:\n  - foobar\n  - baz\n  - foo"
+
+  create_git_repository "c"
+  create_git_release "c", "0.1.0", "name: c\nversion: 0.1.0\ndependencies:\n  d:\n    git: #{git_path("d")}\n    version: 0.1.0\n"
+  create_git_release "c", "0.2.0", "name: c\nversion: 0.2.0\ndependencies:\n  d:\n    git: #{git_path("d")}\n    version: 0.2.0\n"
+  create_git_repository "d"
+  create_git_release "d", "0.1.0", "name: d\nversion: 0.1.0\n"
+  create_git_release "d", "0.2.0", "name: d\nversion: 0.2.0\n"
 end
 
 private def assert(value, message, file, line)

--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -54,6 +54,18 @@ describe "update" do
     end
   end
 
+  it "unlocks subdependency" do
+    metadata = {dependencies: {c: "*"}}
+    lock = {c: "0.1.0", d: "0.1.0"}
+
+    with_shard(metadata, lock) do
+      run "shards update c"
+
+      assert_installed "c", "0.2.0"
+      assert_installed "d", "0.2.0"
+    end
+  end
+
   it "updates specified dependencies" do
     metadata = {dependencies: {web: "*", orm: "*", optional: "*"}}
     lock = {web: "1.0.0", orm: "0.4.0", optional: "0.2.0"}

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -40,14 +40,14 @@ module Shards
             else
               raise InvalidLock.new # unknown lock resolver
             end
-          elsif Shards.production?
+          else
             raise LockConflict.new("can't install new dependency #{package.name} in production")
           end
         end
       end
 
       private def validate_locked_version(package, version)
-        return if Shards.production? && package.version == version
+        return if package.version == version
         return if Versions.matches?(version, package.spec.version)
         raise LockConflict.new("#{package.name} requirements changed")
       end

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -19,7 +19,7 @@ module Shards
         packages = handle_resolver_errors { solver.solve }
         return if packages.empty?
 
-        if lockfile?
+        if lockfile? && Shards.production?
           validate(packages)
         end
 

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -49,7 +49,7 @@ module Shards
         deps.each do |dep|
           if lock = lock_index[dep.name]?
             if version = lock["version"]?
-              next if !Versions.matches?(version, dep.version)
+              next unless Versions.matches?(version, dep.version)
             end
 
             add_lock(base, lock_index, dep.name)

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -14,6 +14,27 @@ module Shards
     def prepare(@development = true)
     end
 
+    private def add_lock(base, lock_index, name)
+      if lock = lock_index.delete(name)
+        resolver = Shards.find_resolver(lock)
+
+        if version = lock["version"]?
+          spec = resolver.spec(version)
+        elsif commit = lock["commit"]?
+          spec = resolver.spec(commit)
+          lock["version"] = "#{spec.version}+git.commit.#{commit}"
+        else
+          return
+        end
+
+        base.add_vertex(lock.name, lock, true)
+
+        spec.dependencies.each do |dep|
+          add_lock(base, lock_index, dep.name)
+        end
+      end
+    end
+
     def solve : Array(Package)
       deps = if @development
                @spec.dependencies + @spec.development_dependencies
@@ -23,18 +44,16 @@ module Shards
 
       base = Molinillo::DependencyGraph(Dependency, Dependency).new
       if locks = @locks
-        locks.each do |lock|
-          if version = lock["version"]?
-            dep = deps.find { |d| d.name == lock.name }
-            next if dep && !Versions.matches?(version, dep.version)
-          end
+        lock_index = locks.to_h { |d| {d.name, d} }
 
-          if commit = lock["commit"]?
-            resolver = Shards.find_resolver(lock)
-            spec = resolver.spec(commit)
-            lock["version"] = "#{spec.version}+git.commit.#{commit}"
+        deps.each do |dep|
+          if lock = lock_index[dep.name]?
+            if version = lock["version"]?
+              next if !Versions.matches?(version, dep.version)
+            end
+
+            add_lock(base, lock_index, dep.name)
           end
-          base.add_vertex(lock.name, lock, true)
         end
       end
 
@@ -45,6 +64,7 @@ module Shards
 
       packages = [] of Package
       result.each do |v|
+        next unless v.payload
         spec = v.payload.as?(Spec) || raise "BUG: returned graph payload was not a Spec"
         v.requirements.each do |dependency|
           unless dependency.name == spec.name
@@ -140,7 +160,7 @@ module Shards
         #       to [HEAD], we must resolve the refs to an actual version:
         versions_for_refs("HEAD", dependency, resolver)
       else
-        matching
+        matching.uniq
       end
     end
 


### PR DESCRIPTION
This PR changes the way the content of `shards.lock` is used during dependency resolution. Instead of passing all o them blindly to the solver, they are traversed as a tree, starting from the dependencies specified explicitly in `shards.yml`, only if the version still matches, and following each sub-dependency recursively.

This fixes some issues:
  * If the version in `shards.yml` is changed, running `shards` just does the update of that shard. 
  * Running `shards update foo`, if `foo` has dependency `bar`, now it's not needed to run `shards update foo bar` to unlock `bar` (unless `bar` is also in `shards.yml`)

The behavior of `shards` is now more similar to `bundler`, and I think it's a good thing. Much more intuitive and simple to use.