### PR TITLE
Fix validation in production mode for dependencies referenced by commit

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -200,6 +200,17 @@ describe "install" do
     end
   end
 
+  it "fails to install when dependency requirement (commit) changed in production" do
+    metadata = {dependencies: {inprogress: {git: git_url(:inprogress), commit: git_commits(:inprogress)[1]}}}
+    lock = {inprogress: git_commits(:inprogress).first}
+
+    with_shard(metadata, lock) do
+      ex = expect_raises(FailedCommand) { run "shards install --no-color --production" }
+      ex.stdout.should contain("Outdated shard.lock")
+      refute_installed "inprogress"
+    end
+  end
+
   it "updates when dependency requirement changed" do
     metadata = {dependencies: {web: "2.0.0"}}
     lock = {web: "1.0.0"}

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -66,6 +66,10 @@ private def setup_repositories
   create_git_release "renamed", "0.2.0", "name: new_name\nversion: 0.2.0"
   create_git_version_commit "renamed", "0.3.0", "name: another_name\nversion: 0.3.0"
 
+  create_git_repository "inprogress"
+  create_git_version_commit "inprogress", "0.1.0"
+  create_git_version_commit "inprogress", "0.1.0"
+
   create_git_repository "transitive"
   create_file "transitive", "src/version.cr", %(require "version"; puts Version::STRING)
   create_git_release "transitive", "0.2.0", <<-YAML

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -33,10 +33,10 @@ module Shards
       private def validate(packages)
         packages.each do |package|
           if lock = locks.find { |d| d.name == package.name }
-            if version = lock.version?
-              validate_locked_version(package, version)
-            elsif commit = lock["commit"]?
+            if commit = lock["commit"]?
               validate_locked_commit(package, commit)
+            elsif version = lock.version?
+              validate_locked_version(package, version)
             else
               raise InvalidLock.new # unknown lock resolver
             end
@@ -48,12 +48,11 @@ module Shards
 
       private def validate_locked_version(package, version)
         return if package.version == version
-        return if Versions.matches?(version, package.spec.version)
         raise LockConflict.new("#{package.name} requirements changed")
       end
 
       private def validate_locked_commit(package, commit)
-        return if commit == package.commit
+        return if package.commit == commit
         raise LockConflict.new("#{package.name} requirements changed")
       end
 


### PR DESCRIPTION
This is what @RX14 said on a previous PR (https://github.com/crystal-lang/shards/pull/337#issuecomment-605658181)

The logic was indeed wrong and I fixed it and added another test. I changed the order of the tests in the `validate` method because the solver adds a `version` on every lock, even for those with a `commit` [here](https://github.com/crystal-lang/shards/blob/fac08bce2c3482b10437eb8241bfa9565270ec0d/src/molinillo_solver.cr#L25).

Also, because the validation functions are now used only in production mode, the logic is simplified and they check only for exact match, version or commit.