### PR TITLE
Version bump (0.10.0) and update reference to molinillo shard

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,5 +2,5 @@ version: 1.0
 shards:
   molinillo:
     github: crystal-lang/crystal-molinillo
-    commit: 4b78e8c577ac322c8c0363788f3e1109f19668d9
+    version: 0.1.0
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: shards
-version: 0.9.0
+version: 0.10.0
 
 authors:
   - Julien Portalier <julien@portalier.com>


### PR DESCRIPTION
I just released the first version (0.1.0) of the molinillo shard. Getting ready for the next release of Shards.