### PR TITLE
Versioning rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@
 /bin/shards.dwarf
 /spec/.repositories
 /spec/.shards
-/spec/.lib
+/spec/unit/.lib
 /tmp

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -343,7 +343,17 @@ describe "install" do
     lock = {web: web_version}
 
     with_shard(metadata, lock) do
-      debug "shards install --production"
+      run "shards install --production"
+      assert_installed "web", "2.1.0", git: git_commits(:web).first
+    end
+  end
+
+  it "install in production mode with locked commit by a previous shards version" do
+    metadata = {dependencies: {web: "*"}}
+
+    with_shard(metadata) do
+      File.write "shard.lock", {version: "1.0", shards: {web: {git: git_url(:web), commit: git_commits(:web).first}}}
+      run "shards install --production"
       assert_installed "web", "2.1.0", git: git_commits(:web).first
     end
   end

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -88,7 +88,7 @@ describe "install" do
     }
     with_shard(metadata) do
       run "shards install"
-      assert_installed "unstable", "0.3.0.beta"
+      assert_installed "unstable", "0.3.0.beta", git: git_commits(:unstable).first
     end
   end
 
@@ -133,7 +133,7 @@ describe "install" do
   it "resolves dependency at head when no version tags" do
     metadata = {dependencies: {"missing": "*"}}
     with_shard(metadata) { run "shards install" }
-    assert_installed "missing", "0.1.0"
+    assert_installed "missing", "0.1.0", git: git_commits(:missing).first
   end
 
   it "installs dependency at locked commit when refs is a branch" do
@@ -146,7 +146,7 @@ describe "install" do
 
     with_shard(metadata, lock) do
       run "shards install"
-      assert_installed "web", "1.2.0"
+      assert_installed "web", "1.2.0", git: git_commits(:web)[-5]
     end
   end
 
@@ -158,7 +158,7 @@ describe "install" do
 
     with_shard(metadata, lock) do
       run "shards install"
-      assert_installed "web", "1.1.1"
+      assert_installed "web", "1.1.1", git: git_commits(:web)[-3]
     end
   end
 
@@ -177,7 +177,7 @@ describe "install" do
     }
     with_shard(metadata, lock) { run "shards install" }
 
-    assert_installed "locked", "0.1.0"
+    assert_installed "locked", "0.1.0", git: git_commits(:locked).last
     refute_installed "pg"
   end
 
@@ -188,12 +188,12 @@ describe "install" do
 
     with_shard(metadata, {web: git_commits(:web)[-5]}) do
       run "shards install"
-      assert_installed "web", "1.2.0"
+      assert_installed "web", "1.2.0", git: git_commits(:web)[-5]
     end
 
     with_shard(metadata, {web: git_commits(:web)[0]}) do
       run "shards install"
-      assert_installed "web", "2.1.0"
+      assert_installed "web", "2.1.0", git: git_commits(:web)[0]
     end
   end
 
@@ -467,7 +467,7 @@ describe "install" do
     }
     with_shard(metadata) do
       run "shards install"
-      assert_installed "another_name", "0.3.0"
+      assert_installed "another_name", "0.3.0", git: git_commits(:renamed).first
     end
   end
 

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -275,7 +275,7 @@ describe "install" do
 
     with_shard(metadata) do
       run "shards install"
-      assert_locked "web", git_commits(:web).first
+      assert_locked "web", "2.1.0", git: git_commits(:web).first
     end
   end
 

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -49,6 +49,15 @@ describe "install" do
     end
   end
 
+  it "won't fail if version file is missing (backward compatibility)" do
+    metadata = {dependencies: {web: "*"}}
+    with_shard(metadata) do
+      run "shards install"
+      File.delete("lib/web.version")
+      run "shards install"
+    end
+  end
+
   it "won't install prerelease version" do
     metadata = {
       dependencies: {unstable: "*"},

--- a/spec/integration/prune_spec.cr
+++ b/spec/integration/prune_spec.cr
@@ -1,7 +1,9 @@
 require "./spec_helper"
 
 private def installed_dependencies
-  Dir.glob(File.join(application_path, "lib", "*"), match_hidden: true).map { |path| File.basename(path) }
+  Dir.glob(File.join(application_path, "lib", "*"), match_hidden: true)
+    .map { |path| File.basename(path) }
+    .reject { |file| file =~ /\.version$/ }
 end
 
 describe "prune" do

--- a/spec/integration/prune_spec.cr
+++ b/spec/integration/prune_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 private def installed_dependencies
   Dir.glob(File.join(application_path, "lib", "*"), match_hidden: true)
     .map { |path| File.basename(path) }
-    .reject { |file| file =~ /\.version$/ }
+    .reject(&.ends_with?(".version"))
 end
 
 describe "prune" do

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -142,18 +142,15 @@ def assert_installed_file(path, file = __FILE__, line = __LINE__)
   assert File.exists?(File.join(install_path(name), path)), "Expected #{path} to have been installed", file, line
 end
 
-def assert_locked(name, version = nil, file = __FILE__, line = __LINE__)
+def assert_locked(name, version = nil, file = __FILE__, line = __LINE__, *, git = nil)
   path = File.join(application_path, "shard.lock")
   assert File.exists?(path), "expected shard.lock to have been generated", file, line
   locks = Shards::Lock.from_file(path)
   assert lock = locks.find { |d| d.name == name }, "expected #{name} dependency to have been locked", file, line
 
   if lock && version
-    if version =~ Shards::VERSION_REFERENCE
-      assert version == lock.version, "expected #{name} dependency to have been locked at version #{version}", file, line
-    else
-      assert version == lock.refs, "expected #{name} dependency to have been locked at commit #{version}", file, line
-    end
+    expected_version = git ? "#{version}+git.commit.#{git}" : version
+    assert expected_version == lock.version, "expected #{name} dependency to have been locked at version #{version}", file, line
   end
 end
 

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -111,18 +111,12 @@ private def refute(value, message, file, line)
   fail(message, file, line) if value
 end
 
-def assert_installed(name, version = nil, file = __FILE__, line = __LINE__)
+def assert_installed(name, version = nil, file = __FILE__, line = __LINE__, *, git = nil)
   assert Dir.exists?(install_path(name)), "expected #{name} dependency to have been installed", file, line
 
   if version
-    assert File.exists?(install_path(name, "shard.yml")), "expected shard.yml for installed #{name} dependency was not found", file, line
-    spec = Shards::Spec.from_file(install_path(name, "shard.yml"))
-
-    if spec.version == "0" && File.exists?(install_path("#{name}.sha1"))
-      File.read(install_path("#{name}.sha1")).should eq(version), file, line
-    else
-      spec.version.should eq(version), file, line
-    end
+    expected_version = git ? "#{version}+git.commit.#{git}" : version
+    File.read(install_path("#{name}.version")).should eq(expected_version), file, line
   end
 end
 

--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -153,7 +153,8 @@ describe "update" do
 
     with_shard(metadata, lock) do
       run "shards update"
-      assert_installed "web", "2.1.0"
+      assert_installed "web", "2.1.0", git: git_commits(:web).first
+      assert_locked "web", "2.1.0", git: git_commits(:web).first
     end
   end
 

--- a/spec/support/cli.cr
+++ b/spec/support/cli.cr
@@ -70,21 +70,12 @@ end
 def to_lock_yaml(lock)
   return unless lock
 
-  String.build do |yml|
-    yml << "version: 1.0\n"
-    yml << "shards:\n"
-
-    lock.each do |name, version|
-      yml << "  " << name << ":\n"
-      yml << "    git: " << git_url(name).inspect << '\n'
-
-      if version =~ /^[\d\.]+$/
-        yml << "    version: " << version.inspect << '\n'
-      else
-        yml << "    commit: " << version.inspect << '\n'
-      end
-    end
-  end
+  YAML.dump({
+    version: "1.0",
+    shards:  lock.to_a.to_h do |name, version|
+      {name, {git: git_url(name), version: version}}
+    end,
+  })
 end
 
 module Shards::Specs

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -59,6 +59,18 @@ def create_git_commit(project, message = "new commit")
   end
 end
 
+def checkout_new_git_branch(project, branch)
+  Dir.cd(git_path(project)) do
+    run "git checkout -b #{branch}"
+  end
+end
+
+def checkout_git_branch(project, branch)
+  Dir.cd(git_path(project)) do
+    run "git checkout #{branch}"
+  end
+end
+
 def create_shard(project, contents)
   create_file project, "shard.yml", contents
 end
@@ -71,9 +83,9 @@ def create_file(project, filename, contents, perm = nil)
   File.chmod(path, perm) if perm
 end
 
-def git_commits(project)
+def git_commits(project, rev = "HEAD")
   Dir.cd(git_path(project)) do
-    run("git log --format='%H'").strip.split('\n')
+    run("git log --format='%H' #{rev}").strip.split('\n')
   end
 end
 

--- a/spec/unit/git_resolver_spec.cr
+++ b/spec/unit/git_resolver_spec.cr
@@ -13,6 +13,9 @@ module Shards
 
       create_git_repository "unreleased"
       create_git_version_commit "unreleased", "0.1.0"
+      checkout_new_git_branch "unreleased", "branch"
+      create_git_commit "unreleased", "testing"
+      checkout_git_branch "unreleased", "master"
 
       create_git_repository "library", "0.0.1", "0.1.0", "0.1.1", "0.1.2"
       create_git_release "library", "0.2.0", shard: "name: library\nversion: 0.2.0\nauthors:\n  - julien <julien@portalier.com>"
@@ -30,6 +33,7 @@ module Shards
       resolver("empty").latest_version_for_ref("master").should be_nil
       resolver("empty").latest_version_for_ref(nil).should be_nil
       resolver("unreleased").latest_version_for_ref("master").should eq("0.1.0+git.commit.#{git_commits(:unreleased)[0]}")
+      resolver("unreleased").latest_version_for_ref("branch").should eq("0.1.0+git.commit.#{git_commits(:unreleased, "branch")[0]}")
       resolver("unreleased").latest_version_for_ref(nil).should eq("0.1.0+git.commit.#{git_commits(:unreleased)[0]}")
       resolver("library").latest_version_for_ref("master").should eq("0.2.0+git.commit.#{git_commits(:library)[0]}")
       resolver("library").latest_version_for_ref(nil).should eq("0.2.0+git.commit.#{git_commits(:library)[0]}")

--- a/spec/unit/git_resolver_spec.cr
+++ b/spec/unit/git_resolver_spec.cr
@@ -21,11 +21,6 @@ module Shards
       create_git_tag "library", "99.9.9"
     end
 
-    it "available versions" do
-      resolver("empty").available_versions.should eq(["HEAD"])
-      resolver("library").available_versions.should eq(["0.0.1", "0.1.0", "0.1.1", "0.1.2", "0.2.0"])
-    end
-
     it "available releases" do
       resolver("empty").available_releases.should be_empty
       resolver("library").available_releases.should eq(["0.0.1", "0.1.0", "0.1.1", "0.1.2", "0.2.0"])

--- a/spec/unit/path_resolver_spec.cr
+++ b/spec/unit/path_resolver_spec.cr
@@ -12,7 +12,7 @@ module Shards
     end
 
     it "available versions" do
-      resolver("library").available_versions.should eq(["1.2.3"])
+      resolver("library").available_releases.should eq(["1.2.3"])
     end
 
     it "read spec" do

--- a/spec/unit/path_resolver_spec.cr
+++ b/spec/unit/path_resolver_spec.cr
@@ -16,12 +16,12 @@ module Shards
     end
 
     it "read spec" do
-      resolver("library").read_spec.should eq("name: library\nversion: 1.2.3\n")
+      resolver("library").spec("1.2.3").version.should eq("1.2.3")
     end
 
     it "install" do
       resolver("library").tap do |library|
-        library.install
+        library.install("1.2.3")
         File.exists?(install_path("library", "src/library.cr")).should be_true
         File.exists?(install_path("library", "shard.yml")).should be_true
         library.installed_spec.not_nil!.version.should eq("1.2.3")
@@ -29,21 +29,21 @@ module Shards
     end
 
     it "install fails when path doesnt exist" do
-      expect_raises(Error) { resolver("unknown").install }
+      expect_raises(Error) { resolver("unknown").install("1.0.0") }
     end
 
     it "installed reports library is installed" do
       resolver("library").tap do |resolver|
         resolver.installed?.should be_false
 
-        resolver.install
+        resolver.install("1.2.3")
         resolver.installed?.should be_true
       end
     end
 
     it "installed when target is incorrect link" do
       resolver("library").tap do |resolver|
-        resolver.install
+        resolver.install("1.2.3")
         resolver.installed?.should be_true
       end
     end
@@ -53,7 +53,7 @@ module Shards
         File.symlink("/does-not-exist", resolver.install_path)
         resolver.installed?.should be_false
 
-        resolver.install
+        resolver.install("1.2.3")
         resolver.installed?.should be_true
       end
     end
@@ -64,7 +64,7 @@ module Shards
         File.touch(File.join(resolver.install_path, "foo"))
         resolver.installed?.should be_false
 
-        resolver.install
+        resolver.install("1.2.3")
         resolver.installed?.should be_true
       end
     end
@@ -74,7 +74,7 @@ module Shards
         File.touch(resolver.install_path)
         resolver.installed?.should be_false
 
-        resolver.install
+        resolver.install("1.2.3")
         resolver.installed?.should be_true
       end
     end

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -78,8 +78,8 @@ module Shards
       end
 
       private def outdated_lockfile?(packages)
-        a = packages.map { |x| {x.name, x.version, x.commit} }
-        b = locks.map { |x| {x.name, x.version?, x.commit} }
+        a = packages.map { |x| {x.name, x.version} }
+        b = locks.map { |x| {x.name, x.version?} }
         a != b
       end
     end

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -33,9 +33,7 @@ module Shards
       private def validate(packages)
         packages.each do |package|
           if lock = locks.find { |d| d.name == package.name }
-            if commit = lock.commit
-              validate_locked_commit(package, commit)
-            elsif version = lock.version?
+            if version = lock.version?
               validate_locked_version(package, version)
             else
               raise InvalidLock.new # unknown lock resolver
@@ -48,11 +46,6 @@ module Shards
 
       private def validate_locked_version(package, version)
         return if package.version == version
-        raise LockConflict.new("#{package.name} requirements changed")
-      end
-
-      private def validate_locked_commit(package, commit)
-        return if package.commit == commit
         raise LockConflict.new("#{package.name} requirements changed")
       end
 

--- a/src/commands/outdated.cr
+++ b/src/commands/outdated.cr
@@ -40,9 +40,9 @@ module Shards
         # already the latest version?
         available_versions =
           if @prereleases
-            resolver.available_versions
+            resolver.available_releases
           else
-            Versions.without_prereleases(resolver.available_versions)
+            Versions.without_prereleases(resolver.available_releases)
           end
         latest = Versions.sort(available_versions).first
         return if latest == installed

--- a/src/commands/prune.cr
+++ b/src/commands/prune.cr
@@ -16,10 +16,10 @@ module Shards
             Log.debug { "rm -rf '#{Helpers::Path.escape(path)}'" }
             FileUtils.rm_rf(path)
 
-            sha1 = "#{path}.sha1"
-            if File.exists?(sha1)
-              Log.debug { "rm '#{Helpers::Path.escape(sha1)}'" }
-              File.delete(sha1)
+            version_file = "#{path}.version"
+            if File.exists?(version_file)
+              Log.debug { "rm '#{Helpers::Path.escape(version_file)}'" }
+              File.delete(version_file)
             end
 
             Log.info { "Pruned #{File.join(File.basename(Shards.install_path), name)}" }

--- a/src/dependency.cr
+++ b/src/dependency.cr
@@ -107,7 +107,7 @@ module Shards
     end
 
     def to_s(io)
-      io << name << " " << version
+      io << name << " (" << to_human_requirement << ")"
     end
 
     def inspect(io)

--- a/src/dependency.cr
+++ b/src/dependency.cr
@@ -61,7 +61,7 @@ module Shards
       end
     end
 
-    def initialize(@name)
+    def initialize(@name, *, @version = nil, @branch = nil)
     end
 
     def_equals_and_hash @name, @version, @git, @path, @tag, @branch, @commit

--- a/src/lock.cr
+++ b/src/lock.cr
@@ -61,13 +61,7 @@ module Shards
         else
           io << "    git: " << dependency.git << '\n'
         end
-
-        if package.commit
-          io << "    commit: " << package.commit << '\n'
-        else
-          io << "    version: " << package.version << '\n'
-        end
-
+        io << "    version: " << package.version << '\n'
         io << '\n'
       end
     end

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -87,7 +87,7 @@ module Shards
         resolver = spec.resolver || raise "BUG: returned Spec has no resolver"
         version = spec.version
 
-        packages << Package.new(spec.name, resolver, version, nil)
+        packages << Package.new(spec.name, resolver, version)
       end
 
       packages

--- a/src/package.cr
+++ b/src/package.cr
@@ -30,7 +30,7 @@ module Shards
 
     def installed?
       if spec = resolver.installed_spec
-        (commit && resolver.installed_commit_hash == commit) || spec.version == version
+        spec.version == version
       else
         false
       end

--- a/src/package.cr
+++ b/src/package.cr
@@ -6,26 +6,21 @@ module Shards
     getter name : String
     getter resolver : Resolver
     getter version : String
-    getter commit : String?
     @spec : Spec?
 
-    def initialize(@name, @resolver, @version, @commit)
+    def initialize(@name, @resolver, @version)
     end
 
     def report_version
       if (resolver = self.resolver).is_a?(PathResolver)
         "#{version} at #{resolver.dependency_path}"
       else
-        if commit
-          "#{version} at #{commit}"
-        else
-          version
-        end
+        version
       end
     end
 
     def spec
-      @spec ||= resolver.spec(commit || version)
+      @spec ||= resolver.spec(version)
     end
 
     def installed?
@@ -38,7 +33,7 @@ module Shards
 
     def install
       # install the shard:
-      resolver.install(commit || version)
+      resolver.install(version)
 
       # link the project's lib path as the shard's lib path, so the dependency
       # can access transitive dependencies:

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -81,19 +81,6 @@ module Shards
       end
     end
 
-    def available_versions
-      update_local_cache
-
-      versions = versions_from_tags
-
-      if versions.any?
-        Log.debug { "versions: #{versions.reverse.join(", ")}" }
-        versions
-      else
-        ["HEAD"]
-      end
-    end
-
     protected def versions_from_tags
       capture("git tag --list #{GitResolver.git_column_never}")
         .split('\n')

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -41,7 +41,7 @@ module Shards
       @@git_column_never ||= Versions.compare(git_version, "1.7.11") < 0 ? "--column=never" : ""
     end
 
-    private def read_spec(version : String)
+    def read_spec(version : String)
       update_local_cache
       refs = git_refs(version)
 

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -81,6 +81,15 @@ module Shards
       end
     end
 
+    def matches_ref?(ref : Dependency, version : String)
+      if commit = ref.commit
+        git_refs(version) == commit
+      else
+        # TODO: check branch and tags
+        true
+      end
+    end
+
     protected def versions_from_tags
       capture("git tag --list #{GitResolver.git_column_never}")
         .split('\n')

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -41,7 +41,7 @@ module Shards
       @@git_column_never ||= Versions.compare(git_version, "1.7.11") < 0 ? "--column=never" : ""
     end
 
-    def read_spec(version = "*")
+    private def read_spec(version : String)
       update_local_cache
       refs = git_refs(version)
 
@@ -52,25 +52,33 @@ module Shards
       end
     end
 
-    def spec(version = nil)
-      spec = Spec.from_yaml(read_spec(version))
-      spec.resolver = self
-
-      if version && version =~ VERSION_REFERENCE
-        # In this case, we know that the version was looked up by git tag, so we
-        # validate the spec version against the tag version.
-        version = version.lstrip('v')
-        if spec.version != version
-          spec.mismatched_version = true
+    private def spec_at_ref(ref : String) : Spec?
+      update_local_cache
+      begin
+        if file_exists?(ref, SPEC_FILENAME)
+          spec_yaml = capture("git show #{ref}:#{SPEC_FILENAME}")
+          Spec.from_yaml(spec_yaml)
         end
+      rescue Error
+        nil
       end
-
-      spec
     end
 
     private def spec?(version)
       spec(version)
     rescue Error
+    end
+
+    def available_releases : Array(String)
+      update_local_cache
+      versions_from_tags
+    end
+
+    def latest_version_for_ref(ref : String?) : String?
+      if spec = spec_at_ref(ref || "HEAD")
+        commit = commit_sha1_at(ref)
+        "#{spec.version}+git.commit.#{commit}"
+      end
     end
 
     def available_versions
@@ -86,10 +94,8 @@ module Shards
       end
     end
 
-    protected def versions_from_tags(refs = nil)
-      options = "--contains #{refs}" if refs
-
-      capture("git tag --list #{options} #{GitResolver.git_column_never}")
+    protected def versions_from_tags
+      capture("git tag --list #{GitResolver.git_column_never}")
         .split('\n')
         .compact_map { |tag| $1 if tag =~ VERSION_TAG }
     end
@@ -109,36 +115,20 @@ module Shards
       end
     end
 
-    def install(version = nil)
+    def install_sources(version)
       update_local_cache
-      refs = version && git_refs(version) || "HEAD"
+      refs = git_refs(version)
 
-      cleanup_install_directory
       Dir.mkdir_p(install_path)
-
       unless file_exists?(refs, SPEC_FILENAME)
         File.write(File.join(install_path, "shard.yml"), read_spec(version))
       end
 
       run "git archive --format=tar --prefix= #{refs} | tar -x -f - -C #{Helpers::Path.escape(install_path)}"
-
-      if version =~ VERSION_REFERENCE
-        File.delete(sha1_path) if File.exists?(sha1_path)
-      else
-        File.write(sha1_path, commit_sha1_at(version))
-      end
     end
 
     def commit_sha1_at(refs)
       capture("git log -n 1 --pretty=%H #{refs}").strip
-    end
-
-    def installed_commit_hash
-      File.read(sha1_path).strip if installed? && File.exists?(sha1_path)
-    end
-
-    def sha1_path
-      @sha1_path ||= File.join(Shards.install_path, "#{dependency.name}.sha1")
     end
 
     def local_path
@@ -164,40 +154,12 @@ module Shards
     private def git_refs(version)
       case version
       when VERSION_REFERENCE
-        if version && version.starts_with?('v')
-          version
-        else
-          "v#{version}"
-        end
+        "v#{version}"
       when VERSION_AT_GIT_COMMIT
         $1
-      when "*"
-        "HEAD"
       else
-        version || "HEAD"
+        raise Error.new("Invalid version for git resolver: #{version}")
       end
-    end
-
-    protected def version_at(refs)
-      update_local_cache
-
-      if spec = spec?(refs)
-        spec.version
-      else
-        # FIXME: return the latest release tag BEFORE or AT the refs exactly, but
-        #        never release tags AFTER the refs
-        versions_from_tags(refs).first?
-      end
-    end
-
-    private def refs_at(commit)
-      update_local_cache
-
-      refs = [] of String?
-      refs << commit
-      refs += capture("git tag --list --contains #{commit} #{GitResolver.git_column_never}").split('\n')
-      refs += capture("git branch --list --contains #{commit} #{GitResolver.git_column_never}").split(' ')
-      refs.compact.uniq
     end
 
     private def update_local_cache

--- a/src/resolvers/path.cr
+++ b/src/resolvers/path.cr
@@ -6,7 +6,7 @@ module Shards
       "path"
     end
 
-    def read_spec(version = nil)
+    private def read_spec(version = nil)
       spec_path = File.join(local_path, SPEC_FILENAME)
 
       if File.exists?(spec_path)
@@ -28,9 +28,6 @@ module Shards
 
     def installed_spec
       Spec.from_yaml(read_spec) if installed?
-    end
-
-    def installed_commit_hash
     end
 
     def installed?
@@ -59,6 +56,13 @@ module Shards
       {% end %}
     end
 
+    def available_releases : Array(String)
+      [spec.version] of String
+    end
+
+    def latest_version_for_ref(ref : String?) : String?
+    end
+
     def available_versions
       [spec.version]
     end
@@ -73,10 +77,9 @@ module Shards
       end
     end
 
-    def install(version = nil)
+    def install_sources(version)
       path = expanded_local_path
 
-      cleanup_install_directory
       Dir.mkdir_p(File.dirname(install_path))
       File.symlink(path, install_path)
     end

--- a/src/resolvers/path.cr
+++ b/src/resolvers/path.cr
@@ -6,7 +6,7 @@ module Shards
       "path"
     end
 
-    private def read_spec(version = nil)
+    def read_spec(version = nil)
       spec_path = File.join(local_path, SPEC_FILENAME)
 
       if File.exists?(spec_path)

--- a/src/resolvers/path.cr
+++ b/src/resolvers/path.cr
@@ -63,10 +63,6 @@ module Shards
     def latest_version_for_ref(ref : String?) : String?
     end
 
-    def available_versions
-      [spec.version]
-    end
-
     def local_path
       dependency.path.not_nil!
     end

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -20,7 +20,7 @@ module Shards
       end
 
       spec = Spec.from_file(path)
-      spec.version = File.read(version_path)
+      spec.version = File.read(version_path) if File.exists?(version_path)
       spec
     end
 

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -65,7 +65,7 @@ module Shards
       spec
     end
 
-    private abstract def read_spec(version : String)
+    abstract def read_spec(version : String)
     abstract def install_sources(version : String)
 
     def install(version : String)

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -62,7 +62,6 @@ module Shards
     end
 
     private abstract def read_spec(version : String)
-    abstract def available_versions
     abstract def install_sources(version : String)
 
     def install(version : String)

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -54,6 +54,10 @@ module Shards
     abstract def available_releases : Array(String)
     abstract def latest_version_for_ref(ref : String?) : String?
 
+    def matches_ref?(ref : Dependency, version : String)
+      false
+    end
+
     def spec(version : String) : Spec
       spec = Spec.from_yaml(read_spec(version))
       spec.resolver = self

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -11,33 +11,70 @@ module Shards
     def initialize(@dependency)
     end
 
-    def specs(versions)
-      specs = {} of String => Spec
-      versions.each do |version|
-        specs[version] = spec(version)
-      rescue Error
-      end
-      specs
-    end
-
     def installed_spec
       return unless installed?
 
       path = File.join(install_path, SPEC_FILENAME)
-      return Spec.from_file(path) if File.exists?(path)
+      unless File.exists?(path)
+        raise Error.new("Missing #{SPEC_FILENAME.inspect} for #{dependency.name.inspect}")
+      end
 
-      raise Error.new("Missing #{SPEC_FILENAME.inspect} for #{dependency.name.inspect}")
+      spec = Spec.from_file(path)
+      spec.version = File.read(version_path)
+      spec
     end
 
     def installed?
       File.exists?(install_path)
     end
 
-    abstract def read_spec(version = nil)
-    abstract def spec(version)
+    def versions_for(dependency : Dependency) : Array(String)
+      if ref = dependency.refs
+        versions_for_ref(ref)
+      else
+        releases = available_releases
+        if releases.empty?
+          versions_for_ref(nil)
+        elsif version_req = dependency.version?
+          Versions.resolve(releases, version_req)
+        else
+          releases
+        end
+      end
+    end
+
+    private def versions_for_ref(ref : String?) : Array(String)
+      if version = latest_version_for_ref(ref)
+        [version]
+      else
+        [] of String
+      end
+    end
+
+    abstract def available_releases : Array(String)
+    abstract def latest_version_for_ref(ref : String?) : String?
+
+    def spec(version : String) : Spec
+      spec = Spec.from_yaml(read_spec(version))
+      spec.resolver = self
+      spec.version = version
+      spec
+    end
+
+    private abstract def read_spec(version : String)
     abstract def available_versions
-    abstract def install(version = nil)
-    abstract def installed_commit_hash
+    abstract def install_sources(version : String)
+
+    def install(version : String)
+      cleanup_install_directory
+
+      install_sources(version)
+      File.write(version_path, version)
+    end
+
+    def version_path
+      @version_path ||= File.join(Shards.install_path, "#{dependency.name}.version")
+    end
 
     def run_script(name)
       if installed? && (command = installed_spec.try(&.scripts[name]?))

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -75,7 +75,10 @@ module Shards
     getter license : String?
     getter crystal : String?
     property resolver : Resolver?
-    property? mismatched_version = false
+
+    def mismatched_version?
+      Versions.compare(version, original_version) != 0
+    end
 
     # :nodoc:
     def initialize(pull : YAML::PullParser, validate = false)


### PR DESCRIPTION
This ended up being a not so small PR and I have more changes coming, but I prefer to split here now that at least the tests are passing 😅 

This is mostly a refactor, although I fixed some cases of locks with commits that were either not working or working not totally on purpose.

For the user, there are two (non breaking) visible changes:
  * There is a `shard_name.version` file for each shard within the `lib` directory. This replaces the `.sha1` file that was generated for shards not coming from a release version.
  * The `shard.lock` file now contains `version` for both releases and git refs. For versions it's the same a before, but for git refs the version is stores something like: `0.9.0+git.commit.ed686ad3015f48f8b22cf4fbec80e8c8088ef44b`

Internally there are some refactors:
  * Versions contains metadata to represent references to a commit. No more need to check either `commit` or `version`.
  * The interface of the `Resolver` class changed slightly:
    * `versions_for(Dependency)` now returns the list of versions (releases or refs) matching the dependency requirement.
    * `spec(version)` works only with version strings, no more refs. (refs are transformed into versions first by calling the previous method)
    *   `install` is performed by version also, no more refs.
  * Lock files with old format can still be read and they will be transformed when needed.
  * `MolinilloSolver` is now pretty much agnostic to git refs. There is still a minor reference to git metadata that I plan to remove soon. Understanding of whether a version matches a requirement is delegated to the resolver.

All these changes (and the ones coming) will make it easier soon to add or fix features:
  * Know if certain commit still matches a ref
  * Provide information about outdated refs (and fix #325)
  * Install from locks without running the resolver
  * Better support for overrides of shards (i.e: a sub-dependency with a version with an explicit dependency in shard.yml)
