### PR TITLE
Rework of dependency and requirements

### DIFF
--- a/spec/integration/init_spec.cr
+++ b/spec/integration/init_spec.cr
@@ -11,7 +11,7 @@ describe "init" do
       File.exists?(File.join(application_path, Shards::SPEC_FILENAME)).should be_true
       spec = Shards::Spec.from_file(shard_path)
       spec.name.should eq("integration")
-      spec.version.should eq("0.1.0")
+      spec.version.should eq(version "0.1.0")
     end
   end
 

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -7,6 +7,7 @@ require "../../src/lock"
 require "../../src/spec"
 require "../support/factories"
 require "../support/cli"
+require "../support/requirement"
 
 Spec.before_suite do
   run "rm -rf #{tmp_path}/*"
@@ -144,7 +145,7 @@ def assert_locked(name, version = nil, file = __FILE__, line = __LINE__, *, git 
 
   if lock && version
     expected_version = git ? "#{version}+git.commit.#{git}" : version
-    assert expected_version == lock.version, "expected #{name} dependency to have been locked at version #{version}", file, line
+    assert expected_version == lock.requirement.as(Shards::Version).value, "expected #{name} dependency to have been locked at version #{version}", file, line
   end
 end
 

--- a/spec/support/cli.cr
+++ b/spec/support/cli.cr
@@ -34,7 +34,7 @@ def to_shard_yaml(metadata)
             case version
             when String
               yml << "    git: " << git_url(name).inspect << '\n'
-              yml << "    version: " << version.inspect << '\n'
+              yml << "    version: " << version.inspect << '\n' unless version == "*"
               # when Hash
               #  version.each do |k, v|
               #    yml << "    " << k << ": " << v.inspect << '\n'

--- a/spec/support/requirement.cr
+++ b/spec/support/requirement.cr
@@ -1,0 +1,19 @@
+def branch(name)
+  Shards::GitBranchRef.new(name)
+end
+
+def commit(sha1)
+  Shards::GitCommitRef.new(sha1)
+end
+
+def version(version)
+  Shards::Version.new(version)
+end
+
+def versions(versions)
+  versions.map { |v| version(v) }
+end
+
+def version_req(pattern)
+  Shards::VersionReq.new(pattern)
+end

--- a/spec/unit/dependency_spec.cr
+++ b/spec/unit/dependency_spec.cr
@@ -79,7 +79,7 @@ private def parse_dependency(dep)
   pull.read_stream do
     pull.read_document do
       pull.read_mapping do
-        yield Shards::Dependency.new(pull)
+        yield Shards::Dependency.from_yaml(pull)
       end
     end
   end

--- a/spec/unit/dependency_spec.cr
+++ b/spec/unit/dependency_spec.cr
@@ -64,9 +64,11 @@ module Shards
       end
     end
 
-    it "fail with extra arguments" do
-      expect_raises YAML::ParseException, %(Unknown attribute "branch" for dependency "foo") do
-        parse_dependency({foo: {path: "/foo", branch: "master"}}) { }
+    it "allow extra arguments" do
+      parse_dependency({foo: {path: "/foo", branch: "master"}}) do |dep|
+        dep.name.should eq("foo")
+        dep.resolver.is_a?(PathResolver).should be_true
+        dep.requirement.should eq(Any)
       end
     end
   end

--- a/spec/unit/lock_spec.cr
+++ b/spec/unit/lock_spec.cr
@@ -18,14 +18,12 @@ module Shards
       shards.size.should eq(2)
 
       shards[0].name.should eq("repo")
-      shards[0].path.should be_nil
-      shards[0].git.should eq("https://github.com/user/repo.git")
-      shards[0].version.should eq("1.2.3")
+      shards[0].resolver.should eq(GitResolver.new("repo", "https://github.com/user/repo.git"))
+      shards[0].requirement.should eq(version "1.2.3")
 
       shards[1].name.should eq("example")
-      shards[1].path.should be_nil
-      shards[1].git.should eq("https://example.com/example-crystal.git")
-      shards[1].refs.should eq("0d246ee6c52d4e758651b8669a303f04be9a2a96")
+      shards[1].resolver.should eq(GitResolver.new("example", "https://example.com/example-crystal.git"))
+      shards[1].requirement.should eq(commit "0d246ee6c52d4e758651b8669a303f04be9a2a96")
     end
 
     it "raises on unknown version" do

--- a/spec/unit/path_resolver_spec.cr
+++ b/spec/unit/path_resolver_spec.cr
@@ -1,8 +1,7 @@
 require "./spec_helper"
 
 private def resolver(name)
-  dependency = Shards::Dependency.new(name, path: git_path(name))
-  Shards::PathResolver.new(dependency)
+  Shards::PathResolver.new(name, git_path(name))
 end
 
 module Shards
@@ -12,38 +11,38 @@ module Shards
     end
 
     it "available versions" do
-      resolver("library").available_releases.should eq(["1.2.3"])
+      resolver("library").available_releases.should eq([version "1.2.3"])
     end
 
     it "read spec" do
-      resolver("library").spec("1.2.3").version.should eq("1.2.3")
+      resolver("library").spec("1.2.3").version.should eq(version "1.2.3")
     end
 
     it "install" do
       resolver("library").tap do |library|
-        library.install("1.2.3")
+        library.install(version "1.2.3")
         File.exists?(install_path("library", "src/library.cr")).should be_true
         File.exists?(install_path("library", "shard.yml")).should be_true
-        library.installed_spec.not_nil!.version.should eq("1.2.3")
+        library.installed_spec.not_nil!.version.should eq(version "1.2.3")
       end
     end
 
     it "install fails when path doesnt exist" do
-      expect_raises(Error) { resolver("unknown").install("1.0.0") }
+      expect_raises(Error) { resolver("unknown").install(version "1.0.0") }
     end
 
     it "installed reports library is installed" do
       resolver("library").tap do |resolver|
         resolver.installed?.should be_false
 
-        resolver.install("1.2.3")
+        resolver.install(version "1.2.3")
         resolver.installed?.should be_true
       end
     end
 
     it "installed when target is incorrect link" do
       resolver("library").tap do |resolver|
-        resolver.install("1.2.3")
+        resolver.install(version "1.2.3")
         resolver.installed?.should be_true
       end
     end
@@ -53,7 +52,7 @@ module Shards
         File.symlink("/does-not-exist", resolver.install_path)
         resolver.installed?.should be_false
 
-        resolver.install("1.2.3")
+        resolver.install(version "1.2.3")
         resolver.installed?.should be_true
       end
     end
@@ -64,7 +63,7 @@ module Shards
         File.touch(File.join(resolver.install_path, "foo"))
         resolver.installed?.should be_false
 
-        resolver.install("1.2.3")
+        resolver.install(version "1.2.3")
         resolver.installed?.should be_true
       end
     end
@@ -74,9 +73,13 @@ module Shards
         File.touch(resolver.install_path)
         resolver.installed?.should be_false
 
-        resolver.install("1.2.3")
+        resolver.install(version "1.2.3")
         resolver.installed?.should be_true
       end
+    end
+
+    it "renders report version" do
+      resolver("library").report_version(version "1.2.3").should eq("1.2.3 at #{git_path("library")}")
     end
   end
 end

--- a/spec/unit/resolver_spec.cr
+++ b/spec/unit/resolver_spec.cr
@@ -2,9 +2,19 @@ require "./spec_helper"
 
 module Shards
   describe Resolver do
-    it "find resolver with unordered dependency keys" do
-      dependency = Dependency.new("test", git: "file:///tmp/test")
-      Shards.find_resolver(dependency).class.should eq(GitResolver)
+    it "find resolver" do
+      Resolver.find_resolver("git", "test", "file:///tmp/test")
+        .should eq(GitResolver.new("test", "file:///tmp/test"))
+    end
+
+    it "compares" do
+      resolver = PathResolver.new("name", "/path")
+
+      resolver.should eq(resolver)
+      resolver.should eq(PathResolver.new("name", "/path"))
+      resolver.should_not eq(PathResolver.new("name2", "/path"))
+      resolver.should_not eq(PathResolver.new("name", "/path2"))
+      resolver.should_not eq(GitResolver.new("name", "/path"))
     end
   end
 end

--- a/spec/unit/spec_helper.cr
+++ b/spec/unit/spec_helper.cr
@@ -7,6 +7,7 @@ require "../../src/logger"
 require "../../src/resolvers/*"
 
 require "../support/factories"
+require "../support/requirement"
 
 module Shards
   set_warning_log_level
@@ -14,6 +15,7 @@ end
 
 Spec.before_each do
   clear_repositories
+  Shards::Resolver.clear_resolver_cache
 end
 
 private def clear_repositories

--- a/spec/unit/spec_spec.cr
+++ b/spec/unit/spec_spec.cr
@@ -5,7 +5,7 @@ module Shards
     it "parse minimal shard" do
       spec = Spec.from_yaml("name: shards\nversion: 0.1.0\n")
       spec.name.should eq("shards")
-      spec.version.should eq("0.1.0")
+      spec.version.should eq(version "0.1.0")
       spec.description.should be_nil
       spec.license.should be_nil
       spec.authors.should be_empty
@@ -58,45 +58,25 @@ module Shards
           branch: master
         local:
           path: /var/clones/local
-          tag: unreleased
       YAML
 
       spec.dependencies.size.should eq(3)
 
       spec.dependencies[0].name.should eq("repo")
-      spec.dependencies[0].path.should be_nil
-      spec.dependencies[0].git.should eq("https://github.com/user/repo.git")
-      spec.dependencies[0].version.should eq("1.2.3")
-      spec.dependencies[0].refs.should be_nil
+      spec.dependencies[0].resolver.should eq(GitResolver.new("repo", "https://github.com/user/repo.git"))
+      spec.dependencies[0].requirement.should eq(version_req "1.2.3")
 
       spec.dependencies[1].name.should eq("example")
-      spec.dependencies[1].path.should be_nil
-      spec.dependencies[1].git.should eq("https://example.com/example-crystal.git")
-      spec.dependencies[1].version.should eq("*")
-      spec.dependencies[1].refs.should eq("master")
+      spec.dependencies[1].resolver.should eq(GitResolver.new("example", "https://example.com/example-crystal.git"))
+      spec.dependencies[1].requirement.should eq(branch "master")
 
       spec.dependencies[2].name.should eq("local")
-      spec.dependencies[2].path.should eq("/var/clones/local")
-      spec.dependencies[2].git.should be_nil
-      spec.dependencies[2].version.should eq("*")
-      spec.dependencies[2].refs.should eq("unreleased")
-    end
-
-    it "fails dependency with duplicate resolver" do
-      expect_raises Shards::ParseError, %(Duplicate resolver mapping for dependency "foo" at line 6, column 5) do
-        Spec.from_yaml <<-YAML
-          name: orm
-          version: 1.0.0
-          dependencies:
-            foo:
-              github: user/repo
-              gitlab: user/repo
-          YAML
-      end
+      spec.dependencies[2].resolver.should eq(PathResolver.new("local", "/var/clones/local"))
+      spec.dependencies[2].requirement.should eq(Any)
     end
 
     it "fails dependency with missing resolver" do
-      expect_raises Shards::ParseError, %(Missing resolver for dependency "foo" at line 4, column 3) do
+      expect_raises Shards::ParseError, %(Unknown resolver "branch" for dependency "foo" at line 5, column 5) do
         Spec.from_yaml <<-YAML
           name: orm
           version: 1.0.0
@@ -107,8 +87,9 @@ module Shards
       end
     end
 
-    it "accepts dependency with extra attributes" do
-      spec = Spec.from_yaml <<-YAML
+    it "fails dependency with extra attributes" do
+      expect_raises Shards::ParseError, %(Unknown attribute "extra" for dependency "foo" at line 6, column 5) do
+        Spec.from_yaml <<-YAML
         name: orm
         version: 1.0.0
         dependencies:
@@ -116,8 +97,20 @@ module Shards
             github: user/repo
             extra: foobar
         YAML
-      dep = Dependency.new("foo", git: "https://github.com/user/repo.git")
-      spec.dependencies[0].should eq dep
+      end
+    end
+
+    it "fails dependency with unexpected attributes" do
+      expect_raises Shards::ParseError, %(Unknown attribute "extra" for dependency "foo" at line 6, column 5) do
+        Spec.from_yaml <<-YAML
+        name: orm
+        version: 1.0.0
+        dependencies:
+          foo:
+            path: ../path
+            extra: foobar
+        YAML
+      end
     end
 
     it "parse development dependencies" do
@@ -136,14 +129,12 @@ module Shards
       spec.development_dependencies.size.should eq(2)
 
       spec.development_dependencies[0].name.should eq("minitest")
-      spec.development_dependencies[0].path.should be_nil
-      spec.development_dependencies[0].git.should eq("https://github.com/ysbaddaden/minitest.cr.git")
-      spec.development_dependencies[0].version.should eq("0.1.4")
+      spec.development_dependencies[0].resolver.should eq(GitResolver.new("minitest", "https://github.com/ysbaddaden/minitest.cr.git"))
+      spec.development_dependencies[0].requirement.should eq(version_req "0.1.4")
 
       spec.development_dependencies[1].name.should eq("webmock")
-      spec.development_dependencies[1].path.should be_nil
-      spec.development_dependencies[1].git.should eq("https://github.com/manastech/webcmok-crystal.git")
-      spec.development_dependencies[1].refs.should eq("master")
+      spec.development_dependencies[1].resolver.should eq(GitResolver.new("webmock", "https://github.com/manastech/webcmok-crystal.git"))
+      spec.development_dependencies[1].requirement.should eq(branch "master")
     end
 
     it "parse targets" do
@@ -239,11 +230,11 @@ module Shards
     it "skips unknown attributes" do
       spec = Spec.from_yaml("\nanme: test\ncustom:\n  test: more\nname: test\nversion: 1\n")
       spec.name.should eq("test")
-      spec.version.should eq("1")
+      spec.version.should eq(version "1")
 
       spec = Spec.from_yaml("\nanme:\nname: test\nversion: 1\n")
       spec.name.should eq("test")
-      spec.version.should eq("1")
+      spec.version.should eq(version "1")
     end
 
     it "raises on unknown attributes if validating" do

--- a/spec/unit/versions_spec.cr
+++ b/spec/unit/versions_spec.cr
@@ -1,5 +1,13 @@
 require "./spec_helper"
 
+private def resolve(versions : Array(String), req : String) : Array(String)
+  Shards::Versions.resolve(versions(versions), version_req req).map &.value
+end
+
+private def matches?(version : String, req : String) : Bool
+  Shards::Versions.matches?(version(version), version_req(req))
+end
+
 module Shards
   describe Versions do
     #   class VersionsTest < Minitest::Test
@@ -126,90 +134,90 @@ module Shards
     it "resolve any" do
       versions = %w(0.0.1 0.1.0 0.1.1 0.1.2 0.2.0 0.10.0)
 
-      Versions.resolve(versions, "*").should eq(versions)
+      resolve(versions, "*").should eq(versions)
     end
 
     it "resolve eq" do
       versions = %w(0.0.1 0.1.0 0.1.1 0.1.2 0.2.0 0.10.0)
 
-      Versions.resolve(versions, "0.2.0").should eq(["0.2.0"])
-      Versions.resolve(versions, "0.1.1").should eq(["0.1.1"])
-      Versions.resolve(versions, "0.10.0").should eq(["0.10.0"])
-      Versions.resolve(versions, "1.0.0").should be_empty
-      Versions.resolve(versions, "0.0.1.alpha").should be_empty
+      resolve(versions, "0.2.0").should eq(["0.2.0"])
+      resolve(versions, "0.1.1").should eq(["0.1.1"])
+      resolve(versions, "0.10.0").should eq(["0.10.0"])
+      resolve(versions, "1.0.0").should be_empty
+      resolve(versions, "0.0.1.alpha").should be_empty
     end
 
     it "resolve gt" do
       versions = %w(0.0.1 0.1.0 0.1.1 0.1.2 0.2.0 0.10.0)
 
-      Versions.resolve(versions, "> 0.1.2").should eq(["0.2.0", "0.10.0"])
-      Versions.resolve(versions, "> 0.1.1").should eq(["0.1.2", "0.2.0", "0.10.0"])
+      resolve(versions, "> 0.1.2").should eq(["0.2.0", "0.10.0"])
+      resolve(versions, "> 0.1.1").should eq(["0.1.2", "0.2.0", "0.10.0"])
     end
 
     it "resolve gte" do
       versions = %w(0.0.1 0.1.0 0.1.1 0.1.2 0.2.0 0.10.0)
 
-      Versions.resolve(versions, ">= 0.2.0").should eq(["0.2.0", "0.10.0"])
-      Versions.resolve(versions, ">= 0.1.2").should eq(["0.1.2", "0.2.0", "0.10.0"])
+      resolve(versions, ">= 0.2.0").should eq(["0.2.0", "0.10.0"])
+      resolve(versions, ">= 0.1.2").should eq(["0.1.2", "0.2.0", "0.10.0"])
     end
 
     it "resolve lt" do
       versions = %w(0.0.1 0.1.0 0.1.1 0.1.2 0.2.0 0.10.0)
 
-      Versions.resolve(versions, "< 0.1.0").should eq(["0.0.1"])
-      Versions.resolve(versions, "< 0.2.0").should eq(["0.0.1", "0.1.0", "0.1.1", "0.1.2"])
+      resolve(versions, "< 0.1.0").should eq(["0.0.1"])
+      resolve(versions, "< 0.2.0").should eq(["0.0.1", "0.1.0", "0.1.1", "0.1.2"])
     end
 
     it "resolve lte" do
       versions = %w(0.0.1 0.1.0 0.1.1 0.1.2 0.2.0 0.10.0)
 
-      Versions.resolve(versions, "<= 0.1.0").should eq(["0.0.1", "0.1.0"])
-      Versions.resolve(versions, "<= 0.2.0").should eq(["0.0.1", "0.1.0", "0.1.1", "0.1.2", "0.2.0"])
+      resolve(versions, "<= 0.1.0").should eq(["0.0.1", "0.1.0"])
+      resolve(versions, "<= 0.2.0").should eq(["0.0.1", "0.1.0", "0.1.1", "0.1.2", "0.2.0"])
     end
 
     it "resolve approximate" do
       versions = %w(0.0.1 0.1.0 0.1.1 0.1.2 0.2.0 0.10.0)
 
-      Versions.resolve(versions, "~> 0.1.0").should eq(["0.1.0", "0.1.1", "0.1.2"])
-      Versions.resolve(versions, "~> 0.1").should eq(["0.1.0", "0.1.1", "0.1.2", "0.2.0", "0.10.0"])
+      resolve(versions, "~> 0.1.0").should eq(["0.1.0", "0.1.1", "0.1.2"])
+      resolve(versions, "~> 0.1").should eq(["0.1.0", "0.1.1", "0.1.2", "0.2.0", "0.10.0"])
 
-      Versions.resolve(["0.1"], "~> 0.1").should eq(["0.1"])
-      Versions.resolve(["0.1"], "~> 0.1.0").should eq(["0.1"])
+      resolve(["0.1"], "~> 0.1").should eq(["0.1"])
+      resolve(["0.1"], "~> 0.1.0").should eq(["0.1"])
     end
 
     it "matches?" do
-      Versions.matches?("0.1.0", "*").should be_true
-      Versions.matches?("1.0.0", "*").should be_true
+      matches?("0.1.0", "*").should be_true
+      matches?("1.0.0", "*").should be_true
 
-      Versions.matches?("1.0.0", "1.0.0").should be_true
-      Versions.matches?("1.0.0", "1.0").should be_true
-      Versions.matches?("1.0.0", "1.0.1").should be_false
+      matches?("1.0.0", "1.0.0").should be_true
+      matches?("1.0.0", "1.0").should be_true
+      matches?("1.0.0", "1.0.1").should be_false
 
-      Versions.matches?("1.0.0", ">= 1.0.0").should be_true
-      Versions.matches?("1.0.0", ">= 1.0").should be_true
-      Versions.matches?("1.0.1", ">= 1.0.0").should be_true
-      Versions.matches?("1.0.0", ">= 1.0.1").should be_false
+      matches?("1.0.0", ">= 1.0.0").should be_true
+      matches?("1.0.0", ">= 1.0").should be_true
+      matches?("1.0.1", ">= 1.0.0").should be_true
+      matches?("1.0.0", ">= 1.0.1").should be_false
 
-      Versions.matches?("1.0.0", "> 1.0.0").should be_false
-      Versions.matches?("1.0.0", "> 1.0").should be_false
-      Versions.matches?("1.0.1", "> 1.0.0").should be_true
-      Versions.matches?("1.0.0", "> 1.0.1").should be_false
+      matches?("1.0.0", "> 1.0.0").should be_false
+      matches?("1.0.0", "> 1.0").should be_false
+      matches?("1.0.1", "> 1.0.0").should be_true
+      matches?("1.0.0", "> 1.0.1").should be_false
 
-      Versions.matches?("1.0.0", "<= 1.0.0").should be_true
-      Versions.matches?("1.0.0", "<= 1.0").should be_true
-      Versions.matches?("1.0.1", "<= 1.0.0").should be_false
-      Versions.matches?("1.0.0", "<= 1.0.1").should be_true
+      matches?("1.0.0", "<= 1.0.0").should be_true
+      matches?("1.0.0", "<= 1.0").should be_true
+      matches?("1.0.1", "<= 1.0.0").should be_false
+      matches?("1.0.0", "<= 1.0.1").should be_true
 
-      Versions.matches?("1.0.0", "< 1.0.0").should be_false
-      Versions.matches?("1.0.0", "< 1.0").should be_false
-      Versions.matches?("1.0.1", "< 1.0.0").should be_false
-      Versions.matches?("1.0.0", "< 1.0.1").should be_true
+      matches?("1.0.0", "< 1.0.0").should be_false
+      matches?("1.0.0", "< 1.0").should be_false
+      matches?("1.0.1", "< 1.0.0").should be_false
+      matches?("1.0.0", "< 1.0.1").should be_true
 
-      Versions.matches?("1.0.0", "~> 1.0.0").should be_true
-      Versions.matches?("1.0.0", "~> 1.0").should be_true
-      Versions.matches?("1.0.0", "~> 1.1").should be_false
-      Versions.matches?("1.0.1", "~> 1.0.0").should be_true
-      Versions.matches?("1.0.0", "~> 1.0.1").should be_false
+      matches?("1.0.0", "~> 1.0.0").should be_true
+      matches?("1.0.0", "~> 1.0").should be_true
+      matches?("1.0.0", "~> 1.1").should be_false
+      matches?("1.0.1", "~> 1.0.0").should be_true
+      matches?("1.0.0", "~> 1.0.1").should be_false
     end
   end
 end

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -33,7 +33,7 @@ module Shards
       private def validate(packages)
         packages.each do |package|
           if lock = locks.find { |d| d.name == package.name }
-            if version = lock.version?
+            if version = lock.requirement.as?(Shards::Version)
               validate_locked_version(package, version)
             else
               raise InvalidLock.new # unknown lock resolver
@@ -79,7 +79,7 @@ module Shards
 
       private def outdated_lockfile?(packages)
         a = packages.map { |x| {x.name, x.version} }
-        b = locks.map { |x| {x.name, x.version?} }
+        b = locks.map { |x| {x.name, x.requirement.as?(Version)} }
         a != b
       end
     end

--- a/src/commands/list.cr
+++ b/src/commands/list.cr
@@ -14,7 +14,7 @@ module Shards
 
       private def list(dependencies, level = 1)
         dependencies.each do |dependency|
-          resolver = Shards.find_resolver(dependency)
+          resolver = dependency.resolver
 
           # FIXME: duplicated from Check#verify
           unless _spec = resolver.installed_spec
@@ -23,7 +23,7 @@ module Shards
           end
 
           indent = "  " * level
-          puts "#{indent}* #{_spec.name} (#{_spec.version})"
+          puts "#{indent}* #{_spec.name} (#{resolver.report_version _spec.version})"
 
           indent_level = @tree ? level + 1 : level
           list(_spec.dependencies, indent_level)

--- a/src/commands/lock.cr
+++ b/src/commands/lock.cr
@@ -33,26 +33,6 @@ module Shards
           write_lockfile(packages)
         end
       end
-
-      private def to_lockfile(packages, io)
-        io << "version: 1.0\n"
-        io << "shards:\n"
-
-        packages.sort_by!(&.name).each do |package|
-          key = package.resolver.class.key
-
-          io << "  " << package.name << ":\n"
-          io << "    " << key << ": " << package.resolver.dependency[key] << '\n'
-
-          if package.commit
-            io << "    commit: " << package.commit << '\n'
-          else
-            io << "    version: " << package.version << '\n'
-          end
-
-          io << '\n'
-        end
-      end
     end
   end
 end

--- a/src/commands/outdated.cr
+++ b/src/commands/outdated.cr
@@ -50,15 +50,15 @@ module Shards
         @up_to_date = false
 
         @output << "  * " << package.name
-        @output << " (installed: " << installed
+        @output << " (installed: " << resolver.report_version(installed)
 
         unless installed == package.version
-          @output << ", available: " << package.version
+          @output << ", available: " << resolver.report_version(package.version)
         end
 
         # also report latest version:
         if Versions.compare(latest, package.version) < 0
-          @output << ", latest: " << latest
+          @output << ", latest: " << resolver.report_version(latest)
         end
 
         @output.puts ')'

--- a/src/config.cr
+++ b/src/config.cr
@@ -7,7 +7,7 @@ module Shards
 
   VERSION_REFERENCE     = /^v?\d+[-.][-.a-zA-Z\d]+$/
   VERSION_TAG           = /^v(\d+[-.][-.a-zA-Z\d]+)$/
-  VERSION_AT_GIT_COMMIT = /\+git\.commit\.([0-9a-f]+)$/
+  VERSION_AT_GIT_COMMIT = /^(\d+[-.][-.a-zA-Z\d]+)\+git\.commit\.([0-9a-f]+)$/
 
   def self.cache_path
     @@cache_path ||= find_or_create_cache_path

--- a/src/lock.cr
+++ b/src/lock.cr
@@ -25,7 +25,7 @@ module Shards
             case key = pull.read_scalar
             when "shards"
               pull.each_in_mapping do
-                dependencies << Dependency.new(pull)
+                dependencies << Dependency.new(pull, is_lock: true)
               end
             else
               pull.raise "No such attribute #{key} in lock version 1.0"
@@ -53,15 +53,11 @@ module Shards
       io << "shards:\n"
 
       packages.sort_by!(&.name).each do |package|
-        dependency = package.resolver.dependency
+        key = package.resolver.class.key
 
         io << "  " << package.name << ":\n"
-        if path = dependency.path
-          io << "    path: " << path << '\n'
-        else
-          io << "    git: " << dependency.git << '\n'
-        end
-        io << "    version: " << package.version << '\n'
+        io << "    " << key << ": " << package.resolver.source << '\n'
+        io << "    version: " << package.version.value << '\n'
         io << '\n'
       end
     end

--- a/src/lock.cr
+++ b/src/lock.cr
@@ -25,7 +25,7 @@ module Shards
             case key = pull.read_scalar
             when "shards"
               pull.each_in_mapping do
-                dependencies << Dependency.new(pull, is_lock: true)
+                dependencies << Dependency.from_yaml(pull, is_lock: true)
               end
             else
               pull.raise "No such attribute #{key} in lock version 1.0"

--- a/src/package.cr
+++ b/src/package.cr
@@ -5,18 +5,14 @@ module Shards
   class Package
     getter name : String
     getter resolver : Resolver
-    getter version : String
+    getter version : Version
     @spec : Spec?
 
     def initialize(@name, @resolver, @version)
     end
 
     def report_version
-      if (resolver = self.resolver).is_a?(PathResolver)
-        "#{version} at #{resolver.dependency_path}"
-      else
-        version
-      end
+      resolver.report_version(version)
     end
 
     def spec

--- a/src/requirement.cr
+++ b/src/requirement.cr
@@ -1,0 +1,36 @@
+module Shards
+  struct VersionReq
+    getter pattern : String
+
+    def initialize(@pattern)
+    end
+
+    def prerelease?
+      Versions.prerelease? @pattern
+    end
+  end
+
+  struct Version
+    getter value : String
+
+    def initialize(@value)
+    end
+
+    def has_metadata?
+      Versions.has_metadata? @value
+    end
+
+    def prerelease?
+      Versions.prerelease? @value
+    end
+  end
+
+  abstract struct Ref
+  end
+
+  module Any
+    extend self
+  end
+
+  alias Requirement = VersionReq | Version | Ref | Any
+end

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -189,24 +189,20 @@ module Shards
       source.strip
     end
 
-    def parse_requirement(pull : YAML::PullParser) : Requirement
-      if pull.kind.mapping_end?
-        Any
-      else
-        location = pull.location
-        case key = pull.read_scalar
-        when "version"
-          VersionReq.new pull.read_scalar
+    def parse_requirement(params : Hash(String, String)) : Requirement
+      params.each do |key, value|
+        case key
         when "branch"
-          GitBranchRef.new pull.read_scalar
+          return GitBranchRef.new value
         when "tag"
-          GitTagRef.new pull.read_scalar
+          return GitTagRef.new value
         when "commit"
-          GitCommitRef.new pull.read_scalar
+          return GitCommitRef.new value
         else
-          raise_unknown_attribute(key, location)
         end
       end
+
+      super
     end
 
     record GitVersion, value : String, commit : String? = nil

--- a/src/resolvers/path.cr
+++ b/src/resolvers/path.cr
@@ -12,22 +12,14 @@ module Shards
       if File.exists?(spec_path)
         File.read(spec_path)
       else
-        raise Error.new("Missing #{SPEC_FILENAME.inspect} for #{dependency.name.inspect}")
+        raise Error.new("Missing #{SPEC_FILENAME.inspect} for #{name.inspect}")
       end
-    end
-
-    def dependency_path
-      local_path
     end
 
     def spec(version = nil)
       spec = Spec.from_yaml(read_spec(version))
       spec.resolver = self
       spec
-    end
-
-    def installed_spec
-      Spec.from_yaml(read_spec) if installed?
     end
 
     def installed?
@@ -56,15 +48,15 @@ module Shards
       {% end %}
     end
 
-    def available_releases : Array(String)
-      [spec.version] of String
+    def available_releases : Array(Version)
+      [spec(nil).version]
     end
 
-    def latest_version_for_ref(ref : String?) : String?
+    def latest_version_for_ref(ref : Ref?) : Version?
     end
 
     def local_path
-      dependency.path.not_nil!
+      source
     end
 
     private def expanded_local_path
@@ -79,7 +71,11 @@ module Shards
       Dir.mkdir_p(File.dirname(install_path))
       File.symlink(path, install_path)
     end
-  end
 
-  register_resolver PathResolver
+    def report_version(version : Version) : String
+      "#{version.value} at #{source}"
+    end
+
+    register_resolver "path", PathResolver
+  end
 end

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -114,17 +114,11 @@ module Shards
       FileUtils.rm_rf(install_path)
     end
 
-    def parse_requirement(pull : YAML::PullParser) : Requirement
-      if pull.kind.mapping_end?
-        Any
+    def parse_requirement(params : Hash(String, String)) : Requirement
+      if version = params["version"]?
+        VersionReq.new version
       else
-        location = pull.location
-        case key = pull.read_scalar
-        when "version"
-          VersionReq.new pull.read_scalar
-        else
-          raise_unknown_attribute(key, location)
-        end
+        Any
       end
     end
 
@@ -155,10 +149,6 @@ module Shards
       RESOLVER_CACHE[name] ||= begin
         resolver_class.build(key, name, source)
       end
-    end
-
-    def raise_unknown_attribute(key, location)
-      raise YAML::ParseException.new("Unknown attribute #{key.inspect} for dependency #{@name.inspect}", *location)
     end
   end
 end

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -69,8 +69,8 @@ module Shards
     end
 
     getter! name : String?
-    getter! version : String?
-    getter! original_version : String?
+    getter! version : Version?
+    getter! original_version : Version?
     getter description : String?
     getter license : String?
     getter crystal : String?
@@ -89,7 +89,7 @@ module Shards
         when "name"
           @name = pull.read_scalar
         when "version"
-          @original_version = @version = pull.read_scalar
+          @original_version = @version = Version.new(pull.read_scalar)
         when "description"
           @description = pull.read_scalar
         when "license"
@@ -143,7 +143,7 @@ module Shards
     def name=(@name : String)
     end
 
-    def version=(@version : String)
+    def version=(@version : Version)
     end
 
     def authors

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -102,11 +102,11 @@ module Shards
           end
         when "dependencies"
           pull.each_in_mapping do
-            dependencies << Dependency.new(pull)
+            dependencies << Dependency.from_yaml(pull)
           end
         when "development_dependencies"
           pull.each_in_mapping do
-            development_dependencies << Dependency.new(pull)
+            development_dependencies << Dependency.from_yaml(pull)
           end
         when "targets"
           pull.each_in_mapping do


### PR DESCRIPTION
This is a refactor of dependency requirements (specifications of which versions are suitable for each dependency).

Currently, each dependency has different fields (`version`, `branch`, `tag`, `commit`) that declares the requirement. But this model is imprecise (allows invalid states), difficult to reason in code (`version` is sometimes a pattern, others an exact version) and requires constant parsing of the `version` field (for example to differentiate patterns, or exact version).

With this change, each `Dependency` now has only three fields: `name`, `resolver` and `requirement`. Also note that the relationship between `Dependency` and `Resolver` is now inverted. (In a future refactor I also plan to remove the `name` from `Resolver` making it totally independent from the dependency that it pretends to install).

`Requirement` is actually a union of these types (structs):
  * `Version`: represents an exact version already resolved. Used in dependencies read from lock files and internally during dependency resolution.
  * `VersionReq`: a version pattern. This corresponds to the `version` field entered in the `shard.yml`
  * `Ref`: an abstract struct representing any reference specific for the resolver
  * `Any`: a wildcard, specifying that any version is suitable

Currently we only have only one resolver (git) that defines subclasses of `Ref`:
  * `GitBranchRef`: corresponds to the `branch` attribute in `shard.yml`
  * `GitTagRef`: corresponds to the `tag` attribute in `shard.yml`
  * `GitCommitRef`: corresponds to the `commit` attribute in `shard.yml`
  * `GitHeadRef`: used internally when there is no version specified and no tags

The parsing of `Ref` is delegated to the resolver.
Also, printing of exact versions is delegated to resolvers, thus producing better output without introducing ad-hoc code.