### PR TITLE
Format dependency and requirements

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -536,4 +536,23 @@ describe "install" do
     File.exists?(baz).should be_true    # "Expected to have installed bin/baz executable"
     File.exists?(foo).should be_false   # "Expected not to have installed bin/foo executable"
   end
+
+  it "shows conflict message" do
+    metadata = {
+      dependencies: {
+        c: "~> 0.1.0",
+        d: ">= 0.2.0",
+      },
+    }
+
+    with_shard(metadata) do
+      ex = expect_raises(FailedCommand) { run "shards install --no-color" }
+      ex.stdout.should contain <<-ERROR
+        E: Unable to satisfy the following requirements:
+
+        - `d (>= 0.2.0)` required by `shard.yml`
+        - `d (0.1.0)` required by `c 0.1.0`
+        ERROR
+    end
+  end
 end

--- a/spec/unit/dependency_spec.cr
+++ b/spec/unit/dependency_spec.cr
@@ -3,73 +3,73 @@ require "./spec_helper"
 module Shards
   describe Dependency do
     it "parse for path" do
-      parse_dependency({foo: {path: "/foo"}}) do |dep|
-        dep.name.should eq("foo")
-        dep.resolver.is_a?(PathResolver).should be_true
-        dep.resolver.source.should eq("/foo")
-        dep.requirement.should eq(Any)
-      end
+      dep = parse_dependency({foo: {path: "/foo"}})
+      dep.name.should eq("foo")
+      dep.resolver.is_a?(PathResolver).should be_true
+      dep.resolver.source.should eq("/foo")
+      dep.requirement.should eq(Any)
     end
 
     it "parse for git" do
-      parse_dependency({foo: {git: "/foo"}}) do |dep|
-        dep.name.should eq("foo")
-        dep.resolver.is_a?(GitResolver).should be_true
-        dep.resolver.source.should eq("/foo")
-        dep.requirement.should eq(Any)
-      end
+      dep = parse_dependency({foo: {git: "/foo"}})
+      dep.name.should eq("foo")
+      dep.resolver.is_a?(GitResolver).should be_true
+      dep.resolver.source.should eq("/foo")
+      dep.requirement.should eq(Any)
     end
 
     it "parse for git with version requirement" do
-      parse_dependency({foo: {git: "/foo", version: "~> 1.2"}}) do |dep|
-        dep.name.should eq("foo")
-        dep.resolver.is_a?(GitResolver).should be_true
-        dep.resolver.source.should eq("/foo")
-        dep.requirement.should eq(VersionReq.new("~> 1.2"))
-      end
+      dep = parse_dependency({foo: {git: "/foo", version: "~> 1.2"}})
+      dep.name.should eq("foo")
+      dep.resolver.is_a?(GitResolver).should be_true
+      dep.resolver.source.should eq("/foo")
+      dep.requirement.should eq(VersionReq.new("~> 1.2"))
     end
 
     it "parse for git with branch requirement" do
-      parse_dependency({foo: {git: "/foo", branch: "test"}}) do |dep|
-        dep.name.should eq("foo")
-        dep.resolver.is_a?(GitResolver).should be_true
-        dep.resolver.source.should eq("/foo")
-        dep.requirement.should eq(GitBranchRef.new("test"))
-      end
+      dep = parse_dependency({foo: {git: "/foo", branch: "test"}})
+      dep.name.should eq("foo")
+      dep.resolver.is_a?(GitResolver).should be_true
+      dep.resolver.source.should eq("/foo")
+      dep.requirement.should eq(GitBranchRef.new("test"))
     end
 
     it "parse for git with tag requirement" do
-      parse_dependency({foo: {git: "/foo", tag: "test"}}) do |dep|
-        dep.name.should eq("foo")
-        dep.resolver.is_a?(GitResolver).should be_true
-        dep.resolver.source.should eq("/foo")
-        dep.requirement.should eq(GitTagRef.new("test"))
-      end
+      dep = parse_dependency({foo: {git: "/foo", tag: "test"}})
+      dep.name.should eq("foo")
+      dep.resolver.is_a?(GitResolver).should be_true
+      dep.resolver.source.should eq("/foo")
+      dep.requirement.should eq(GitTagRef.new("test"))
     end
 
     it "parse for git with commit requirement" do
-      parse_dependency({foo: {git: "/foo", commit: "7e2e840"}}) do |dep|
-        dep.name.should eq("foo")
-        dep.resolver.is_a?(GitResolver).should be_true
-        dep.resolver.source.should eq("/foo")
-        dep.requirement.should eq(GitCommitRef.new("7e2e840"))
-      end
+      dep = parse_dependency({foo: {git: "/foo", commit: "7e2e840"}})
+      dep.name.should eq("foo")
+      dep.resolver.is_a?(GitResolver).should be_true
+      dep.resolver.source.should eq("/foo")
+      dep.requirement.should eq(GitCommitRef.new("7e2e840"))
     end
 
     it "parse for github" do
-      parse_dependency({foo: {github: "foo/bar"}}) do |dep|
-        dep.name.should eq("foo")
-        dep.resolver.is_a?(GitResolver).should be_true
-        dep.resolver.source.should eq("https://github.com/foo/bar.git")
-      end
+      dep = parse_dependency({foo: {github: "foo/bar"}})
+      dep.name.should eq("foo")
+      dep.resolver.is_a?(GitResolver).should be_true
+      dep.resolver.source.should eq("https://github.com/foo/bar.git")
     end
 
     it "allow extra arguments" do
-      parse_dependency({foo: {path: "/foo", branch: "master"}}) do |dep|
-        dep.name.should eq("foo")
-        dep.resolver.is_a?(PathResolver).should be_true
-        dep.requirement.should eq(Any)
-      end
+      dep = parse_dependency({foo: {path: "/foo", branch: "master"}})
+      dep.name.should eq("foo")
+      dep.resolver.is_a?(PathResolver).should be_true
+      dep.requirement.should eq(Any)
+    end
+
+    it "format with to_s" do
+      parse_dependency({foo: {git: ""}}).to_s.should eq("foo (*)")
+      parse_dependency({foo: {git: "", version: "~> 1.0"}}).to_s.should eq("foo (~> 1.0)")
+      parse_dependency({foo: {git: "", branch: "feature"}}).to_s.should eq("foo (branch feature)")
+      parse_dependency({foo: {git: "", tag: "rc-1.0"}}).to_s.should eq("foo (tag rc-1.0)")
+      parse_dependency({foo: {git: "", commit: "4478d8afe8c728f44b47d3582a270423cd7fc07d"}}).to_s.should eq("foo (commit 4478d8a)")
     end
   end
 end
@@ -79,7 +79,7 @@ private def parse_dependency(dep)
   pull.read_stream do
     pull.read_document do
       pull.read_mapping do
-        yield Shards::Dependency.from_yaml(pull)
+        Shards::Dependency.from_yaml(pull)
       end
     end
   end

--- a/spec/unit/lock_spec.cr
+++ b/spec/unit/lock_spec.cr
@@ -13,17 +13,35 @@ module Shards
         example:
           git: https://example.com/example-crystal.git
           commit: 0d246ee6c52d4e758651b8669a303f04be9a2a96
+        new_git:
+          git: https://example.com/new.git
+          version: 1.2.3+git.commit.0d246ee6c52d4e758651b8669a303f04be9a2a96
+        new_path:
+          path: ../path
+          version: 0.1.2
       YAML
 
-      shards.size.should eq(2)
+      shards.size.should eq(4)
 
       shards[0].name.should eq("repo")
       shards[0].resolver.should eq(GitResolver.new("repo", "https://github.com/user/repo.git"))
       shards[0].requirement.should eq(version "1.2.3")
+      shards[0].to_s.should eq("repo (1.2.3)")
 
       shards[1].name.should eq("example")
       shards[1].resolver.should eq(GitResolver.new("example", "https://example.com/example-crystal.git"))
       shards[1].requirement.should eq(commit "0d246ee6c52d4e758651b8669a303f04be9a2a96")
+      shards[1].to_s.should eq("example (commit 0d246ee)")
+
+      shards[2].name.should eq("new_git")
+      shards[2].resolver.should eq(GitResolver.new("new_git", "https://example.com/new.git"))
+      shards[2].requirement.should eq(version "1.2.3+git.commit.0d246ee6c52d4e758651b8669a303f04be9a2a96")
+      shards[2].to_s.should eq("new_git (1.2.3 at 0d246ee)")
+
+      shards[3].name.should eq("new_path")
+      shards[3].resolver.should eq(PathResolver.new("new_path", "../path"))
+      shards[3].requirement.should eq(version "0.1.2")
+      shards[3].to_s.should eq("new_path (0.1.2 at ../path)")
     end
 
     it "raises on unknown version" do

--- a/src/dependency.cr
+++ b/src/dependency.cr
@@ -59,8 +59,17 @@ module Shards
       end
     end
 
+    private def report_requirement
+      case req = requirement
+      when Version
+        resolver.report_version(req)
+      else
+        req.to_s
+      end
+    end
+
     def to_s(io)
-      io << name << " (" << requirement << ")"
+      io << name << " (" << report_requirement << ")"
     end
 
     def matches?(version : Version)

--- a/src/requirement.cr
+++ b/src/requirement.cr
@@ -8,6 +8,10 @@ module Shards
     def prerelease?
       Versions.prerelease? @pattern
     end
+
+    def to_s(io)
+      io << pattern
+    end
   end
 
   struct Version
@@ -23,6 +27,10 @@ module Shards
     def prerelease?
       Versions.prerelease? @value
     end
+
+    def to_s(io)
+      io << value
+    end
   end
 
   abstract struct Ref
@@ -30,6 +38,10 @@ module Shards
 
   module Any
     extend self
+
+    def to_s(io)
+      io << "*"
+    end
   end
 
   alias Requirement = VersionReq | Version | Ref | Any

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -11,6 +11,10 @@ module Shards
     def to_git_ref
       "refs/heads/#{@branch}"
     end
+
+    def to_s(io)
+      io << "branch " << @branch
+    end
   end
 
   struct GitTagRef < Ref
@@ -19,6 +23,10 @@ module Shards
 
     def to_git_ref
       "refs/tags/#{@tag}"
+    end
+
+    def to_s(io)
+      io << "tag " << @tag
     end
   end
 
@@ -31,11 +39,19 @@ module Shards
     def to_git_ref
       @commit
     end
+
+    def to_s(io)
+      io << "commit " << @commit[0...7]
+    end
   end
 
   struct GitHeadRef < Ref
     def to_git_ref
       "HEAD"
+    end
+
+    def to_s(io)
+      io << "HEAD"
     end
   end
 


### PR DESCRIPTION
Since #354, the reporting of conflicts didn't look nice. Now it looks back again like this:

```
$ shards install
Resolving dependencies
Unable to satisfy the following requirements:

- `db (0.2.0)` required by `shard.yml`
- `db (~> 0.1.0)` required by `mysql 0.1.0`
Failed to resolve dependencies
```