### PR TITLE
Run postinstall for dependencies before dependents

### DIFF
--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -54,7 +54,8 @@ module Shards
         installed = packages.compact_map { |package| install(package) }
 
         # then execute the postinstall script of installed dependencies (with
-        # access to all transitive dependencies):
+        # access to all transitive dependencies), ensuring that we work our way
+        # up the dependency tree:
         installed.reverse_each(&.postinstall)
 
         # always install executables because the path resolver never actually

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -55,7 +55,7 @@ module Shards
 
         # then execute the postinstall script of installed dependencies (with
         # access to all transitive dependencies):
-        installed.each(&.postinstall)
+        installed.reverse_each(&.postinstall)
 
         # always install executables because the path resolver never actually
         # installs dependencies:


### PR DESCRIPTION
The resolver places dependent shards before dependencies, but `postinstall` script for the dependent shard may depend on the `postinstall` script in its dependencies having been run first.

For example, my `grpc` shard depends on `protobuf`, and both of them have executables they install (built via `shards build`), but installing them in this order results in this output (the `shards` command from the app and the `shards build` command in the `grpc` shard are both using `-v` here):

```
➜  omg_grpc git:(master) ✗ rm -rf bin lib shard.lock && shards -v
Resolving dependencies
git ls-remote --get-url origin
Fetching https://github.com/jgaskins/grpc.git
git fetch --all --quiet
git show test-shards-install:shard.yml
git log -n 1 --pretty=%H test-shards-install
git ls-tree -r --full-tree --name-only 389f3669e09b4d6aebf20a13fb0b031a1e784145 -- shard.yml
git show 389f3669e09b4d6aebf20a13fb0b031a1e784145:shard.yml
git ls-remote --get-url origin
Fetching https://github.com/jeromegn/protobuf.cr.git
git fetch --all --quiet
git show test-shards-install:shard.yml
git log -n 1 --pretty=%H test-shards-install
git ls-tree -r --full-tree --name-only d774a2c760ea7c25160a5cb3c145eb171a73113d -- shard.yml
git show d774a2c760ea7c25160a5cb3c145eb171a73113d:shard.yml
Installing grpc (0.1.0 at 389f3669e09b4d6aebf20a13fb0b031a1e784145)
rm -rf ''/Users/jamie/Code/omg_grpc/lib/grpc''
git ls-tree -r --full-tree --name-only 389f3669e09b4d6aebf20a13fb0b031a1e784145 -- shard.yml
git archive --format=tar --prefix= 389f3669e09b4d6aebf20a13fb0b031a1e784145 | tar -x -f - -C '/Users/jamie/Code/omg_grpc/lib/grpc'
git log -n 1 --pretty=%H 389f3669e09b4d6aebf20a13fb0b031a1e784145
Link /Users/jamie/Code/omg_grpc/lib to /Users/jamie/Code/omg_grpc/lib/grpc/lib
Installing protobuf (2.2.0 at d774a2c760ea7c25160a5cb3c145eb171a73113d)
rm -rf ''/Users/jamie/Code/omg_grpc/lib/protobuf''
git ls-tree -r --full-tree --name-only d774a2c760ea7c25160a5cb3c145eb171a73113d -- shard.yml
git archive --format=tar --prefix= d774a2c760ea7c25160a5cb3c145eb171a73113d | tar -x -f - -C '/Users/jamie/Code/omg_grpc/lib/protobuf'
git log -n 1 --pretty=%H d774a2c760ea7c25160a5cb3c145eb171a73113d
Link /Users/jamie/Code/omg_grpc/lib to /Users/jamie/Code/omg_grpc/lib/protobuf/lib
Postinstall of grpc: shards build -v
rm -rf ''/Users/jamie/Code/omg_grpc/lib/grpc''
Failed postinstall of grpc on shards build -v:
Resolving dependencies
git ls-remote --get-url origin
Fetching https://github.com/jeromegn/protobuf.cr.git
git fetch --all --quiet
git show test-shards-install:shard.yml
git log -n 1 --pretty=%H test-shards-install
git ls-tree -r --full-tree --name-only d774a2c760ea7c25160a5cb3c145eb171a73113d -- shard.yml
git show d774a2c760ea7c25160a5cb3c145eb171a73113d:shard.yml
Using protobuf (2.2.0 at d774a2c760ea7c25160a5cb3c145eb171a73113d)
git ls-tree -r --full-tree --name-only d774a2c760ea7c25160a5cb3c145eb171a73113d -- shard.yml
git show d774a2c760ea7c25160a5cb3c145eb171a73113d:shard.yml
Install bin/protoc-gen-crystal
Unhandled exception: Error opening file with mode 'r': '/Users/jamie/Code/omg_grpc/lib/grpc/lib/protobuf/bin/protoc-gen-crystal': No such file or directory (File::NotFoundError)
  from File::new<String, String, File::Permissions, Nil, Nil>:File
  from Shards::Package#install_executables:Nil
  from Shards::Commands::Install@Shards::Command::run<String>:Nil
  from ~procProc(Array(String), Array(String), Nil)@src/cli.cr:39
  from __crystal_main
  from main
```

Iterating from the dependencies first works:

```
➜  omg_grpc git:(master) ✗ rm -rf bin lib shard.lock && ../shards/bin/shards -v
Resolving dependencies
git ls-remote --get-url origin
Fetching https://github.com/jgaskins/grpc.git
git fetch --all --quiet
git ls-tree -r --full-tree --name-only refs/heads/test-shards-install -- shard.yml
git show refs/heads/test-shards-install:shard.yml
git log -n 1 --pretty=%H refs/heads/test-shards-install
git ls-tree -r --full-tree --name-only 389f3669e09b4d6aebf20a13fb0b031a1e784145 -- shard.yml
git show 389f3669e09b4d6aebf20a13fb0b031a1e784145:shard.yml
git ls-remote --get-url origin
Fetching https://github.com/jeromegn/protobuf.cr.git
git fetch --all --quiet
git ls-tree -r --full-tree --name-only refs/heads/test-shards-install -- shard.yml
git show refs/heads/test-shards-install:shard.yml
git log -n 1 --pretty=%H refs/heads/test-shards-install
git ls-tree -r --full-tree --name-only d774a2c760ea7c25160a5cb3c145eb171a73113d -- shard.yml
git show d774a2c760ea7c25160a5cb3c145eb171a73113d:shard.yml
Installing grpc (0.1.0 at 389f366)
rm -rf ''/Users/jamie/Code/omg_grpc/lib/grpc''
git ls-tree -r --full-tree --name-only 389f3669e09b4d6aebf20a13fb0b031a1e784145 -- shard.yml
git archive --format=tar --prefix= 389f3669e09b4d6aebf20a13fb0b031a1e784145 | tar -x -f - -C '/Users/jamie/Code/omg_grpc/lib/grpc'
Link /Users/jamie/Code/omg_grpc/lib to /Users/jamie/Code/omg_grpc/lib/grpc/lib
Installing protobuf (2.2.0 at d774a2c)
rm -rf ''/Users/jamie/Code/omg_grpc/lib/protobuf''
git ls-tree -r --full-tree --name-only d774a2c760ea7c25160a5cb3c145eb171a73113d -- shard.yml
git archive --format=tar --prefix= d774a2c760ea7c25160a5cb3c145eb171a73113d | tar -x -f - -C '/Users/jamie/Code/omg_grpc/lib/protobuf'
Link /Users/jamie/Code/omg_grpc/lib to /Users/jamie/Code/omg_grpc/lib/protobuf/lib
Postinstall of protobuf: shards build
Postinstall of grpc: shards build -v
git ls-tree -r --full-tree --name-only 389f3669e09b4d6aebf20a13fb0b031a1e784145 -- shard.yml
git show 389f3669e09b4d6aebf20a13fb0b031a1e784145:shard.yml
Install bin/grpc_crystal
git ls-tree -r --full-tree --name-only d774a2c760ea7c25160a5cb3c145eb171a73113d -- shard.yml
git show d774a2c760ea7c25160a5cb3c145eb171a73113d:shard.yml
Install bin/protoc-gen-crystal
Writing shard.lock
```