### PR TITLE
Add spec for check when there is a version mismatch

### DIFF
--- a/spec/integration/check_spec.cr
+++ b/spec/integration/check_spec.cr
@@ -63,4 +63,16 @@ describe "check" do
       ex.stderr.should be_empty
     end
   end
+
+  it "succeeds when shard.yml version doesn't match git tag" do
+    metadata = {
+      dependencies: {
+        version_mismatch: {git: git_url(:version_mismatch), version: "0.2.0"},
+      },
+    }
+    with_shard(metadata) do
+      run "shards install"
+      run "shards check"
+    end
+  end
 end


### PR DESCRIPTION
To avoid regressions in the future, make sure `check` passes even when there is a version mismatch with `shard.yml`.

Closes #353 