### PR TITLE
Fix crash when a shard version didn't contain a shard.yml

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -555,4 +555,30 @@ describe "install" do
         ERROR
     end
   end
+
+  it "installs dependency with shard.yml created in latest version" do
+    metadata = {dependencies: {noshardyml: "*"}}
+    with_shard(metadata) do
+      run "shards install"
+      assert_installed "noshardyml", "0.2.0"
+    end
+  end
+
+  it "shows missing shard.yml in debug info" do
+    metadata = {dependencies: {noshardyml: "*"}}
+    with_shard(metadata) do
+      stdout = run "shards install --no-color -v"
+      assert_installed "noshardyml", "0.2.0"
+      stdout.should contain(%(D: Missing "shard.yml" for "noshardyml" at tag v0.1.0))
+    end
+  end
+
+  it "install dependency with no shard.yml and show warning" do
+    metadata = {dependencies: {noshardyml: "0.1.0"}}
+    with_shard(metadata) do
+      stdout = run "shards install --no-color"
+      assert_installed "noshardyml", "0.1.0"
+      stdout.should contain(%(W: Shard "noshardyml" version (0.1.0) doesn't have a shard.yml file))
+    end
+  end
 end

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -48,6 +48,10 @@ private def setup_repositories
   create_shard "missing", "name: missing\nversion: 0.1.0\n"
   create_git_commit "missing", "initial release"
 
+  create_git_repository "noshardyml"
+  create_git_release "noshardyml", "0.1.0", false
+  create_git_release "noshardyml", "0.2.0"
+
   # dependencies with postinstall scripts:
   create_git_repository "post"
   create_file "post", "Makefile", "all:\n\ttouch made.txt\n"

--- a/spec/unit/spec_spec.cr
+++ b/spec/unit/spec_spec.cr
@@ -9,6 +9,13 @@ module Shards
       spec.description.should be_nil
       spec.license.should be_nil
       spec.authors.should be_empty
+      spec.read_from_yaml?.should be_true
+    end
+
+    it "create without yaml" do
+      spec = Spec.new("name", version "0.1.0")
+      spec.version.should eq(version "0.1.0")
+      spec.read_from_yaml?.should be_false
     end
 
     it "parse description" do

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -74,8 +74,12 @@ module Shards
           unless dependency.name == spec.name
             raise Error.new("Error shard name (#{spec.name}) doesn't match dependency name (#{dependency.name})")
           end
-          if spec.mismatched_version?
-            Log.warn { "Shard \"#{spec.name}\" version (#{spec.original_version.value}) doesn't match tag version (#{spec.version.value})" }
+          if spec.read_from_yaml?
+            if spec.mismatched_version?
+              Log.warn { "Shard \"#{spec.name}\" version (#{spec.original_version.value}) doesn't match tag version (#{spec.version.value})" }
+            end
+          else
+            Log.warn { "Shard \"#{spec.name}\" version (#{spec.version}) doesn't have a shard.yml file" }
           end
         end
         resolver = spec.resolver || raise "BUG: returned Spec has no resolver"

--- a/src/resolvers/path.cr
+++ b/src/resolvers/path.cr
@@ -6,7 +6,7 @@ module Shards
       "path"
     end
 
-    def read_spec(version = nil)
+    def read_spec(version = nil) : String?
       spec_path = File.join(local_path, SPEC_FILENAME)
 
       if File.exists?(spec_path)

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -68,6 +68,11 @@ module Shards
       parser.close if parser
     end
 
+    def initialize(@name : String, @version : Version)
+      @original_version = @version
+      @read_from_yaml = false
+    end
+
     getter! name : String?
     getter! version : Version?
     getter! original_version : Version?
@@ -75,6 +80,7 @@ module Shards
     getter license : String?
     getter crystal : String?
     property resolver : Resolver?
+    getter? read_from_yaml : Bool
 
     def mismatched_version?
       Versions.compare(version, original_version) != 0
@@ -138,6 +144,7 @@ module Shards
           pull.raise "missing required attribute: {{ attr.id }}"
         end
       {% end %}
+      @read_from_yaml = true
     end
 
     def name=(@name : String)


### PR DESCRIPTION
Versions without a spec will just be considered as if they don't have dependencies, but a warning will be printed if a shard is installed without a shard.yml.

For example, `stefanwille/crystal-redis` didn't have a `shard.yml` in the first versions. But it will now install without problems if latest versions are used:

```
$ shards install
Resolving dependencies
Installing redis (1.11.0)
Writing shard.lock
```

However, when a version without spec is selected it will print the warning:

```
$ shards install
Resolving dependencies
Shard "redis" version (1.0.1) doesn't have a shard.yml file
Installing redis (1.0.1)
Writing shard.lock
```

Fixes #346 