### PR TITLE
Explicitly state build_options in help output, fixes #363

### DIFF
--- a/man/shards.1
+++ b/man/shards.1
@@ -21,7 +21,7 @@ more information on its format.
 Builds the specified \fItargets\fR in \fBbin\fR path. If no targets are specified, all are built.
 This command ensures all dependencies are installed, so it is not necessary to run \fBshards install\fR before.
 .PP
-All \fIoptions\fP following the command are delegated to \fBcrystal build\fR.
+All \fIbuild_options\fP following the command are delegated to \fBcrystal build\fR.
 .RE
 .PP
 \fBcheck\fR
@@ -92,7 +92,7 @@ Eventually generates a new \fIshard.lock\fR file.
 .RS 4
 Print the current version of the shard located at \fIpath\fR.
 .RE
-.SH OPTIONS
+.SH GENERAL OPTIONS
 .PP
 \fB\-\-version\fR
 .RS 4

--- a/man/shards.1
+++ b/man/shards.1
@@ -16,7 +16,7 @@ Requires the presence of a \fIshard.yml\fR file. See \fBshard.yml\fR(5) for
 more information on its format.
 .SH COMMANDS
 .PP
-\fBbuild\fR [\fI<targets>\fR] [\fI<options>\fR...]
+\fBbuild\fR [\fI<targets>\fR] [\fI<build_options>\fR...]
 .RS 4
 Builds the specified \fItargets\fR in \fBbin\fR path. If no targets are specified, all are built.
 This command ensures all dependencies are installed, so it is not necessary to run \fBshards install\fR before.

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -7,7 +7,7 @@ module Shards
       shards [<options>...] [<command>]
 
       Commands:
-          build [<targets>] [<build_options>]  - Build the specified <targets> in `bin` path.
+          build [<targets>] [<build_options>]  - Build the specified <targets> in `bin` path, all build_options are delegated to `crystal build`.
           check                                - Verify all dependencies are installed.
           init                                 - Initialize a `shard.yml` file.
           install                              - Install dependencies, creating or using the `shard.lock` file.
@@ -17,10 +17,7 @@ module Shards
           prune                                - Remove unused dependencies from `lib` folder.
           update [<shards>]                    - Update dependencies and `shard.lock`.
           version [<path>]                     - Print the current version of the shard.
-      
-      Build options:
-          Use "crystal build --help" to see available build options.
-      
+
       General options:
       HELP
     puts opts

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -7,18 +7,21 @@ module Shards
       shards [<options>...] [<command>]
 
       Commands:
-          build [<targets>] [<options>]  - Build the specified <targets> in `bin` path.
-          check                          - Verify all dependencies are installed.
-          init                           - Initialize a `shard.yml` file.
-          install                        - Install dependencies, creating or using the `shard.lock` file.
-          list [--tree]                  - List installed dependencies.
-          lock [--update] [<shards>]     - Lock dependencies in `shard.lock` but doesn't install them.
-          outdated [--pre]               - List dependencies that are outdated.
-          prune                          - Remove unused dependencies from `lib` folder.
-          update [<shards>]              - Update dependencies and `shard.lock`.
-          version [<path>]               - Print the current version of the shard.
-
-      Options:
+          build [<targets>] [<build_options>]  - Build the specified <targets> in `bin` path.
+          check                                - Verify all dependencies are installed.
+          init                                 - Initialize a `shard.yml` file.
+          install                              - Install dependencies, creating or using the `shard.lock` file.
+          list [--tree]                        - List installed dependencies.
+          lock [--update] [<shards>]           - Lock dependencies in `shard.lock` but doesn't install them.
+          outdated [--pre]                     - List dependencies that are outdated.
+          prune                                - Remove unused dependencies from `lib` folder.
+          update [<shards>]                    - Update dependencies and `shard.lock`.
+          version [<path>]                     - Print the current version of the shard.
+      
+      Build options:
+          Use "crystal build --help" to see available build options.
+      
+      General options:
       HELP
     puts opts
     exit


### PR DESCRIPTION
The `[<options>]` in the `build` argument was a bit misleading, it's more clear now on what options to use with `build`