### PR TITLE
Replace .version files with a single .shards.info

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -49,11 +49,11 @@ describe "install" do
     end
   end
 
-  it "won't fail if version file is missing (backward compatibility)" do
+  it "won't fail if info file is missing (backward compatibility)" do
     metadata = {dependencies: {web: "*"}}
     with_shard(metadata) do
       run "shards install"
-      File.delete("lib/web.version")
+      File.delete("lib/.shards.info")
       run "shards install"
     end
   end

--- a/spec/integration/prune_spec.cr
+++ b/spec/integration/prune_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 private def installed_dependencies
   Dir.glob(File.join(application_path, "lib", "*"), match_hidden: true)
     .map { |path| File.basename(path) }
-    .reject(&.ends_with?(".version"))
+    .reject(".shards.info")
 end
 
 describe "prune" do

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -121,7 +121,8 @@ def assert_installed(name, version = nil, file = __FILE__, line = __LINE__, *, g
 
   if version
     expected_version = git ? "#{version}+git.commit.#{git}" : version
-    File.read(install_path("#{name}.version")).should eq(expected_version), file, line
+    info = Shards::Info.new(install_path)
+    info.installed[name]?.try &.requirement.should eq(version expected_version), file, line
   end
 end
 
@@ -160,8 +161,8 @@ def refute_locked(name, version = nil, file = __FILE__, line = __LINE__)
   refute locks.find { |d| d.name == name }, "expected #{name} dependency to not have been locked", file, line
 end
 
-def install_path(project, *path_names)
-  File.join(application_path, "lib", project, *path_names)
+def install_path(*path_names)
+  File.join(application_path, "lib", *path_names)
 end
 
 def debug(command)

--- a/spec/unit/info_spec.cr
+++ b/spec/unit/info_spec.cr
@@ -1,0 +1,43 @@
+require "./spec_helper"
+
+module Shards
+  describe Info do
+    before_each do
+      run "rm -rf #{Shards.install_path}/.shards.info"
+    end
+
+    it "create with default install directory" do
+      info = Info.new
+      info.install_path.should eq(install_path)
+      info.installed.should be_empty
+    end
+
+    it "reads existing file" do
+      File.write File.join(install_path, ".shards.info"), SAMPLE_INFO
+      info = Info.new
+      info.installed.should eq({
+        "foo" => Dependency.new("foo", GitResolver.new("foo", "https://example.com/foo.git"), version "1.2.3"),
+      })
+    end
+
+    it "save changes" do
+      info = Info.new
+      dep = Dependency.new("foo", GitResolver.new("foo", "https://example.com/foo.git"), version "1.2.3")
+      info.installed["foo"] = dep
+      info.save
+
+      info_file = File.read File.join(install_path, ".shards.info")
+      info_file.should eq(SAMPLE_INFO)
+    end
+  end
+
+  SAMPLE_INFO = <<-YAML
+  ---
+  version: 1.0
+  shards:
+    foo:
+      git: https://example.com/foo.git
+      version: 1.2.3
+
+  YAML
+end

--- a/spec/unit/info_spec.cr
+++ b/spec/unit/info_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 module Shards
   describe Info do
     before_each do
-      run "rm -rf #{Shards.install_path}/.shards.info"
+      run "rm -rf #{Shards.install_path}"
     end
 
     it "create with default install directory" do
@@ -13,6 +13,7 @@ module Shards
     end
 
     it "reads existing file" do
+      Dir.mkdir_p(install_path)
       File.write File.join(install_path, ".shards.info"), SAMPLE_INFO
       info = Info.new
       info.installed.should eq({

--- a/src/config.cr
+++ b/src/config.cr
@@ -1,3 +1,5 @@
+require "./info"
+
 module Shards
   SPEC_FILENAME = "shard.yml"
   LOCK_FILENAME = "shard.lock"

--- a/src/config.cr
+++ b/src/config.cr
@@ -61,6 +61,10 @@ module Shards
   def self.install_path=(@@install_path : String)
   end
 
+  def self.info
+    @@info ||= Info.new
+  end
+
   private def self.warn_about_legacy_libs_path
     # TODO: drop me in a future release
 

--- a/src/dependency.cr
+++ b/src/dependency.cr
@@ -46,6 +46,15 @@ module Shards
       end
     end
 
+    def to_yaml(yaml : YAML::Builder)
+      yaml.scalar name
+      yaml.mapping do
+        yaml.scalar resolver.class.key
+        yaml.scalar resolver.source
+        requirement.to_yaml(yaml)
+      end
+    end
+
     def_equals @name, @resolver, @requirement
 
     def prerelease?

--- a/src/info.cr
+++ b/src/info.cr
@@ -1,0 +1,39 @@
+require "./lock"
+
+class Shards::Info
+  getter install_path : String
+  getter installed = Hash(String, Dependency).new
+
+  def initialize(@install_path = Shards.install_path)
+    reload
+  end
+
+  def reload
+    path = info_path
+    if File.exists?(path)
+      @installed = Lock.from_file(path).index_by &.name
+    end
+  end
+
+  def save
+    File.open(info_path, "w") do |file|
+      YAML.build(file) do |yaml|
+        yaml.mapping do
+          yaml.scalar "version"
+          yaml.scalar "1.0"
+
+          yaml.scalar "shards"
+          yaml.mapping do
+            installed.each do |name, dep|
+              dep.to_yaml(yaml)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def info_path
+    File.join(@install_path, ".shards.info")
+  end
+end

--- a/src/info.cr
+++ b/src/info.cr
@@ -16,6 +16,7 @@ class Shards::Info
   end
 
   def save
+    Dir.mkdir_p(@install_path)
     File.open(info_path, "w") do |file|
       YAML.build(file) do |yaml|
         yaml.mapping do

--- a/src/requirement.cr
+++ b/src/requirement.cr
@@ -12,6 +12,11 @@ module Shards
     def to_s(io)
       io << pattern
     end
+
+    def to_yaml(yaml)
+      yaml.scalar "version"
+      yaml.scalar @pattern
+    end
   end
 
   struct Version
@@ -31,6 +36,11 @@ module Shards
     def to_s(io)
       io << value
     end
+
+    def to_yaml(yaml)
+      yaml.scalar "version"
+      yaml.scalar value
+    end
   end
 
   abstract struct Ref
@@ -41,6 +51,9 @@ module Shards
 
     def to_s(io)
       io << "*"
+    end
+
+    def to_yaml(yaml)
     end
   end
 

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -15,6 +15,11 @@ module Shards
     def to_s(io)
       io << "branch " << @branch
     end
+
+    def to_yaml(yaml)
+      yaml.scalar "branch"
+      yaml.scalar @branch
+    end
   end
 
   struct GitTagRef < Ref
@@ -27,6 +32,11 @@ module Shards
 
     def to_s(io)
       io << "tag " << @tag
+    end
+
+    def to_yaml(yaml)
+      yaml.scalar "tag"
+      yaml.scalar @tag
     end
   end
 
@@ -43,6 +53,11 @@ module Shards
     def to_s(io)
       io << "commit " << @commit[0...7]
     end
+
+    def to_yaml(yaml)
+      yaml.scalar "commit"
+      yaml.scalar @commit
+    end
   end
 
   struct GitHeadRef < Ref
@@ -52,6 +67,10 @@ module Shards
 
     def to_s(io)
       io << "HEAD"
+    end
+
+    def to_yaml(yaml)
+      raise NotImplementedError.new("GitHeadRef is for internal use only")
     end
   end
 

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -26,7 +26,10 @@ module Shards
       return unless installed?
 
       path = File.join(install_path, SPEC_FILENAME)
-      version = Version.new(File.read(version_path)) if File.exists?(version_path)
+      if installed = Shards.info.installed[name]?
+        version = installed.requirement.as?(Version)
+      end
+
       unless File.exists?(path)
         if version
           return Spec.new(name, version)
@@ -101,11 +104,8 @@ module Shards
       cleanup_install_directory
 
       install_sources(version)
-      File.write(version_path, version.value)
-    end
-
-    def version_path
-      @version_path ||= File.join(Shards.install_path, "#{name}.version")
+      Shards.info.installed[name] = Dependency.new(name, self, version)
+      Shards.info.save
     end
 
     def run_script(name)

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -132,6 +132,8 @@ module Shards
       end
     end
 
+    # abstract def write_requirement(req : Requirement, yaml : YAML::Builder)
+
     private RESOLVER_CLASSES = {} of String => Resolver.class
     private RESOLVER_CACHE   = {} of String => Resolver
 


### PR DESCRIPTION
Since #349 every installed shard is accompanied by a `.version` file with the real installed version. This clutters the `lib` directory. This PR replaces all those files with a single `lib/.shards.info` file. This file is also a YAML so the contents could be extended in the future with any required metadata.