### PR TITLE
Change install dir to `.crystal/shards`

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -45,7 +45,7 @@ describe "install" do
     with_shard(NamedTuple.new) do
       Dir.mkdir "lib"
       stdout = run "shards install --no-color"
-      stdout.should contain(%(W: Shards now installs dependencies into the '_crystal/shards' directory. You may move or delete the legacy 'lib' directory.\n))
+      stdout.should contain(%(W: Shards now installs dependencies into the '.crystal/shards' directory. You may move or delete the legacy 'lib' directory.\n))
     end
   end
 

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -45,14 +45,14 @@ describe "install" do
     with_shard(NamedTuple.new) do
       Dir.mkdir "lib"
       stdout = run "shards install --no-color"
-      stdout.should contain(%(W: Shards now installs dependencies into the 'crystal_shards' directory. You may move or delete the legacy 'lib' directory.\n))
+      stdout.should contain(%(W: Shards now installs dependencies into the '_crystal/shards' directory. You may move or delete the legacy 'lib' directory.\n))
     end
   end
 
   it "doesn't show warning if both legacy and current install path are present" do
     with_shard(NamedTuple.new) do
       Dir.mkdir "lib"
-      Dir.mkdir Shards::INSTALL_DIR
+      Dir.mkdir_p Shards::INSTALL_DIR
       stdout = run "shards install --no-color"
       stdout.should eq(%(I: Resolving dependencies\n))
     end

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -397,7 +397,11 @@ describe "install" do
 
   it "runs postinstall with transitive dependencies" do
     with_shard({dependencies: {transitive: "*"}}) do
-      run "shards install"
+      # Passing this env is needed until the next Crystal release
+      env = {
+        "CRYSTAL_PATH" => "#{Shards::INSTALL_DIR}:#{`crystal env CRYSTAL_PATH`.chomp}",
+      }
+      run "shards install", env: env
       binary = install_path("transitive", "version")
       File.exists?(binary).should be_true
       `#{binary}`.should eq("version @ 0.1.0\n")

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -423,11 +423,7 @@ describe "install" do
 
   it "runs postinstall with transitive dependencies" do
     with_shard({dependencies: {transitive: "*"}}) do
-      # Passing this env is needed until the next Crystal release
-      env = {
-        "CRYSTAL_PATH" => "#{Shards::INSTALL_DIR}:#{`crystal env CRYSTAL_PATH`.chomp}",
-      }
-      run "shards install", env: env
+      run "shards install"
       binary = install_path("transitive", "version")
       File.exists?(binary).should be_true
       `#{binary}`.should eq("version @ 0.1.0\n")

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -53,7 +53,7 @@ describe "install" do
     metadata = {dependencies: {web: "*"}}
     with_shard(metadata) do
       run "shards install"
-      File.delete("lib/.shards.info")
+      File.delete("#{Shards::INSTALL_DIR}/.shards.info")
       run "shards install"
     end
   end
@@ -381,7 +381,7 @@ describe "install" do
   it "runs postinstall script" do
     with_shard({dependencies: {post: "*"}}) do
       output = run "shards install --no-color"
-      File.exists?(File.join(application_path, "lib", "post", "made.txt")).should be_true
+      File.exists?(install_path("post", "made.txt")).should be_true
       output.should contain("Postinstall of post: make")
     end
   end
@@ -391,14 +391,14 @@ describe "install" do
       ex = expect_raises(FailedCommand) { run "shards install --no-color" }
       ex.stdout.should contain("E: Failed postinstall of fails on make:\n")
       ex.stdout.should contain("test -n ''\n")
-      Dir.exists?(File.join(application_path, "lib", "fails")).should be_false
+      Dir.exists?(install_path("fails")).should be_false
     end
   end
 
   it "runs postinstall with transitive dependencies" do
     with_shard({dependencies: {transitive: "*"}}) do
       run "shards install"
-      binary = File.join(application_path, "lib", "transitive", "version")
+      binary = install_path("transitive", "version")
       File.exists?(binary).should be_true
       `#{binary}`.should eq("version @ 0.1.0\n")
     end

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -41,6 +41,32 @@ describe "install" do
     end
   end
 
+  it "shows warning if legacy path is present" do
+    with_shard(NamedTuple.new) do
+      Dir.mkdir "lib"
+      stdout = run "shards install --no-color"
+      stdout.should contain(%(W: Shards now installs dependencies into the 'crystal_shards' directory. You may move or delete the legacy 'lib' directory.\n))
+    end
+  end
+
+  it "doesn't show warning if both legacy and current install path are present" do
+    with_shard(NamedTuple.new) do
+      Dir.mkdir "lib"
+      Dir.mkdir Shards::INSTALL_DIR
+      stdout = run "shards install --no-color"
+      stdout.should eq(%(I: Resolving dependencies\n))
+    end
+  end
+
+  it "doesn't show warning when explicit install path is set" do
+    with_shard(NamedTuple.new) do
+      Dir.mkdir "lib"
+      env = {"SHARDS_INSTALL_PATH" => "foo"}
+      stdout = run "shards install --no-color", env: env
+      stdout.should eq(%(I: Resolving dependencies\n))
+    end
+  end
+
   it "fails when spec is missing" do
     Dir.cd(application_path) do
       ex = expect_raises(FailedCommand) { run "shards install --no-color" }

--- a/spec/integration/prune_spec.cr
+++ b/spec/integration/prune_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 
 private def installed_dependencies
-  Dir.glob(File.join(application_path, "lib", "*"), match_hidden: true)
+  Dir.glob(install_path("*"), match_hidden: true)
     .map { |path| File.basename(path) }
     .reject(".shards.info")
 end
@@ -27,14 +27,14 @@ describe "prune" do
   end
 
   it "removes directories" do
-    Dir.mkdir(File.join(application_path, "lib", "test"))
+    Dir.mkdir(install_path("test"))
     Dir.cd(application_path) { run "shards prune" }
     installed_dependencies.should eq(["web"])
   end
 
   it "won't remove files" do
-    File.write(File.join(application_path, "lib", ".keep_hidden"), "")
-    File.write(File.join(application_path, "lib", "keep_not_hidden"), "")
+    File.write(install_path(".keep_hidden"), "")
+    File.write(install_path("keep_not_hidden"), "")
     Dir.cd(application_path) { run "shards prune" }
     installed_dependencies.sort.should eq([".keep_hidden", "keep_not_hidden", "web"])
   end

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -173,7 +173,7 @@ def refute_locked(name, version = nil, file = __FILE__, line = __LINE__)
 end
 
 def install_path(*path_names)
-  File.join(application_path, "lib", *path_names)
+  File.join(application_path, Shards::INSTALL_DIR, *path_names)
 end
 
 def debug(command)

--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -222,7 +222,11 @@ describe "update" do
 
   it "runs postinstall with transitive dependencies" do
     with_shard({dependencies: {transitive: "*"}}, {transitive: "0.1.0"}) do
-      run "shards update"
+      # Passing this env is needed until the next Crystal release
+      env = {
+        "CRYSTAL_PATH" => "#{Shards::INSTALL_DIR}:#{`crystal env CRYSTAL_PATH`.chomp}",
+      }
+      run "shards update", env: env
       binary = install_path("transitive", "version")
       File.exists?(binary).should be_true
       `#{binary}`.should eq("version @ 0.1.0\n")

--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -222,11 +222,7 @@ describe "update" do
 
   it "runs postinstall with transitive dependencies" do
     with_shard({dependencies: {transitive: "*"}}, {transitive: "0.1.0"}) do
-      # Passing this env is needed until the next Crystal release
-      env = {
-        "CRYSTAL_PATH" => "#{Shards::INSTALL_DIR}:#{`crystal env CRYSTAL_PATH`.chomp}",
-      }
-      run "shards update", env: env
+      run "shards update"
       binary = install_path("transitive", "version")
       File.exists?(binary).should be_true
       `#{binary}`.should eq("version @ 0.1.0\n")

--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -223,7 +223,7 @@ describe "update" do
   it "runs postinstall with transitive dependencies" do
     with_shard({dependencies: {transitive: "*"}}, {transitive: "0.1.0"}) do
       run "shards update"
-      binary = File.join(application_path, "lib", "transitive", "version")
+      binary = install_path("transitive", "version")
       File.exists?(binary).should be_true
       `#{binary}`.should eq("version @ 0.1.0\n")
     end

--- a/spec/support/cli.cr
+++ b/spec/support/cli.cr
@@ -3,6 +3,7 @@ Spec.before_each do
 
   if File.exists?(path)
     run("rm -rf #{path}/*")
+    run("rm -rf #{path}/.crystal")
     run("rm -rf #{path}/.shards")
   else
     Dir.mkdir_p(path)

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -118,8 +118,12 @@ def tmp_path
 end
 
 def run(command, *, env = nil)
+  cmd_env = {
+    "CRYSTAL_PATH" => "#{Shards::INSTALL_DIR}:#{`crystal env CRYSTAL_PATH`.chomp}",
+  }
+  cmd_env.merge!(env) if env
   output, error = IO::Memory.new, IO::Memory.new
-  status = Process.run("/bin/sh", env: env, input: IO::Memory.new(command), output: output, error: error)
+  status = Process.run("/bin/sh", env: cmd_env, input: IO::Memory.new(command), output: output, error: error)
 
   if status.success?
     output.to_s

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -117,10 +117,9 @@ def tmp_path
   Shards::Specs.tmp_path
 end
 
-def run(command)
-  # puts command
+def run(command, *, env = nil)
   output, error = IO::Memory.new, IO::Memory.new
-  status = Process.run("/bin/sh", input: IO::Memory.new(command), output: output, error: error)
+  status = Process.run("/bin/sh", env: env, input: IO::Memory.new(command), output: output, error: error)
 
   if status.success?
     output.to_s

--- a/src/commands/command.cr
+++ b/src/commands/command.cr
@@ -24,6 +24,7 @@ module Shards
     abstract def run(*args, **kwargs)
 
     def self.run(path, *args, **kwargs)
+      Shards.warn_about_legacy_libs_path
       new(path).run(*args, **kwargs)
     end
 

--- a/src/config.cr
+++ b/src/config.cr
@@ -3,7 +3,7 @@ require "./info"
 module Shards
   SPEC_FILENAME = "shard.yml"
   LOCK_FILENAME = "shard.lock"
-  INSTALL_DIR   = "_crystal/shards"
+  INSTALL_DIR   = ".crystal/shards"
 
   DEFAULT_COMMAND = "install"
   DEFAULT_VERSION = "0"
@@ -63,7 +63,7 @@ module Shards
     legacy_install_path = File.join(Dir.current, "lib")
 
     if File.exists?(legacy_install_path) && !File.exists?(install_path)
-      Log.warn { "Shards now installs dependencies into the '_crystal/shards' directory. You may move or delete the legacy 'lib' directory." }
+      Log.warn { "Shards now installs dependencies into the '.crystal/shards' directory. You may move or delete the legacy 'lib' directory." }
     end
   end
 

--- a/src/config.cr
+++ b/src/config.cr
@@ -3,7 +3,7 @@ require "./info"
 module Shards
   SPEC_FILENAME = "shard.yml"
   LOCK_FILENAME = "shard.lock"
-  INSTALL_DIR   = "crystal_shards"
+  INSTALL_DIR   = "_crystal/shards"
 
   DEFAULT_COMMAND = "install"
   DEFAULT_VERSION = "0"
@@ -63,7 +63,7 @@ module Shards
     legacy_install_path = File.join(Dir.current, "lib")
 
     if File.exists?(legacy_install_path) && !File.exists?(install_path)
-      Log.warn { "Shards now installs dependencies into the 'crystal_shards' directory. You may move or delete the legacy 'lib' directory." }
+      Log.warn { "Shards now installs dependencies into the '_crystal/shards' directory. You may move or delete the legacy 'lib' directory." }
     end
   end
 

--- a/src/config.cr
+++ b/src/config.cr
@@ -3,7 +3,7 @@ require "./info"
 module Shards
   SPEC_FILENAME = "shard.yml"
   LOCK_FILENAME = "shard.lock"
-  INSTALL_DIR   = "lib"
+  INSTALL_DIR   = "crystal_shards"
 
   DEFAULT_COMMAND = "install"
   DEFAULT_VERSION = "0"

--- a/src/config.cr
+++ b/src/config.cr
@@ -46,7 +46,6 @@ module Shards
 
   def self.install_path
     @@install_path ||= begin
-      warn_about_legacy_libs_path
       ENV.fetch("SHARDS_INSTALL_PATH") { File.join(Dir.current, INSTALL_DIR) }
     end
   end
@@ -58,17 +57,13 @@ module Shards
     @@info ||= Info.new
   end
 
-  private def self.warn_about_legacy_libs_path
-    # TODO: drop me in a future release
+  def self.warn_about_legacy_libs_path
+    return if ENV["SHARDS_INSTALL_PATH"]?
 
-    legacy_install_path = if path = ENV["SHARDS_INSTALL_PATH"]?
-                            File.join(File.dirname(path), "libs")
-                          else
-                            File.join(Dir.current, "libs")
-                          end
+    legacy_install_path = File.join(Dir.current, "lib")
 
-    if File.exists?(legacy_install_path)
-      Log.warn { "Shards now installs dependencies into the 'lib' folder. You may delete the legacy 'libs' folder." }
+    if File.exists?(legacy_install_path) && !File.exists?(install_path)
+      Log.warn { "Shards now installs dependencies into the 'crystal_shards' directory. You may move or delete the legacy 'lib' directory." }
     end
   end
 

--- a/src/config.cr
+++ b/src/config.cr
@@ -3,6 +3,7 @@ require "./info"
 module Shards
   SPEC_FILENAME = "shard.yml"
   LOCK_FILENAME = "shard.lock"
+  INSTALL_DIR   = "lib"
 
   DEFAULT_COMMAND = "install"
   DEFAULT_VERSION = "0"
@@ -46,7 +47,7 @@ module Shards
   def self.install_path
     @@install_path ||= begin
       warn_about_legacy_libs_path
-      ENV.fetch("SHARDS_INSTALL_PATH") { File.join(Dir.current, "lib") }
+      ENV.fetch("SHARDS_INSTALL_PATH") { File.join(Dir.current, INSTALL_DIR) }
     end
   end
 

--- a/src/package.cr
+++ b/src/package.cr
@@ -35,7 +35,9 @@ module Shards
       unless resolver.is_a?(PathResolver)
         lib_path = File.join(resolver.install_path, Shards::INSTALL_DIR)
         Log.debug { "Link #{Shards.install_path} to #{lib_path}" }
-        File.symlink("../../#{Shards::INSTALL_DIR}", lib_path)
+        Dir.mkdir_p(File.dirname(lib_path))
+        target = File.join(Path.new(Shards::INSTALL_DIR).parts.map { ".." })
+        File.symlink(target, lib_path)
       end
     end
 

--- a/src/package.cr
+++ b/src/package.cr
@@ -33,9 +33,9 @@ module Shards
       # link the project's lib path as the shard's lib path, so the dependency
       # can access transitive dependencies:
       unless resolver.is_a?(PathResolver)
-        lib_path = File.join(resolver.install_path, "lib")
+        lib_path = File.join(resolver.install_path, Shards::INSTALL_DIR)
         Log.debug { "Link #{Shards.install_path} to #{lib_path}" }
-        File.symlink("../../lib", lib_path)
+        File.symlink("../../#{Shards::INSTALL_DIR}", lib_path)
       end
     end
 


### PR DESCRIPTION
This version will display a warning when the `lib` directory is found but not the `crystal_shards`.

Closes #258 