### PR TITLE
Fix: shard.lock is always overwritten even when dependencies are up to date

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -366,6 +366,18 @@ describe "install" do
     end
   end
 
+  it "doesn't overwrite lockfile if no new dependencies are installed" do
+    metadata = {dependencies: {d: "*", c: "*"}}
+
+    with_shard(metadata) do
+      run "shards install"
+      File.touch "shard.lock", Time.utc(1900, 1, 1)
+      mtime = File.info("shard.lock").modification_time
+      run "shards install"
+      File.info("shard.lock").modification_time.should eq(mtime)
+    end
+  end
+
   it "runs postinstall script" do
     with_shard({dependencies: {post: "*"}}) do
       output = run "shards install --no-color"

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -78,8 +78,8 @@ module Shards
       end
 
       private def outdated_lockfile?(packages)
-        a = packages.map { |x| {x.name, x.version} }
-        b = locks.map { |x| {x.name, x.requirement.as?(Version)} }
+        a = packages.map { |x| {x.name, x.version} }.to_h
+        b = locks.map { |x| {x.name, x.requirement.as?(Shards::Version)} }.to_h
         a != b
       end
     end

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -78,8 +78,9 @@ module Shards
       end
 
       private def outdated_lockfile?(packages)
-        a = packages.map { |x| {x.name, x.version} }.to_h
-        b = locks.map { |x| {x.name, x.requirement.as?(Shards::Version)} }.to_h
+        return true if packages.size != locks.size
+        a = packages.to_h { |x| {x.name, x.version} }
+        b = locks.to_h { |x| {x.name, x.requirement.as?(Shards::Version)} }
         a != b
       end
     end


### PR DESCRIPTION
Since #354 unchanged locks are undetected and always overwritten after the "install" command