### PR TITLE
Ensure the compiler --release flag if we build with --production

### DIFF
--- a/src/commands/build.cr
+++ b/src/commands/build.cr
@@ -25,11 +25,10 @@ module Shards
       private def build(target, options)
         Log.info { "Building: #{target.name}" }
 
-        args = [
-          "build",
-          "-o", File.join(Shards.bin_path, target.name),
-          target.main,
-        ]
+        args = ["build", "-o", File.join(Shards.bin_path, target.name)]
+        args << "--release" if Shards.production?
+        args << target.main
+
         options.each { |option| args << option }
         Log.debug { "crystal #{args.join(' ')}" }
 


### PR DESCRIPTION
The documentation was misleading. So I thought it would be proper to automatically add the compiler release flag when building with the shards --production flag.