### PR TITLE
Use less bright colors for output

### DIFF
--- a/src/logger.cr
+++ b/src/logger.cr
@@ -32,8 +32,8 @@ end
 
     LOGGER_COLORS = {
       ::Log::Severity::Error   => :red,
-      ::Log::Severity::Warning => :light_yellow,
-      ::Log::Severity::Info    => :light_green,
+      ::Log::Severity::Warning => :yellow,
+      ::Log::Severity::Info    => :green,
       ::Log::Severity::Debug   => :light_gray,
     }
 
@@ -61,8 +61,8 @@ end
   module Shards
     LOGGER_COLORS = {
       "ERROR" => :red,
-      "WARN"  => :light_yellow,
-      "INFO"  => :light_green,
+      "WARN"  => :yellow,
+      "INFO"  => :green,
       "DEBUG" => :light_gray,
     }
 


### PR DESCRIPTION
This might be seen as a silly thing but it could be actually pretty annoying sometimes. I know some terminals have settings to ensure minimal contrast but I think it's better not to rely on that configuration.

Because we cannot aim for any background color, I just tested with the extremes: black and white. For each case, here is how it looks before and after the change. Bright colors look great on dark background, but I can barely see WARN on the light background. BTW, `bundler` uses the same colors.

<img width="400" alt="Screen Shot 2020-04-29 at 15 33 14" src="https://user-images.githubusercontent.com/22697/80668375-22a26c80-8a78-11ea-93b4-d17872676f1d.png">
<img width="400" alt="Screen Shot 2020-04-29 at 15 33 48" src="https://user-images.githubusercontent.com/22697/80668398-2fbf5b80-8a78-11ea-85c0-324230da6c00.png">
