### PR TITLE
Remove unnecessary require to break loop

### DIFF
--- a/src/dependency.cr
+++ b/src/dependency.cr
@@ -1,5 +1,6 @@
 require "./ext/yaml"
 require "./requirement"
+require "./resolvers/resolver"
 
 module Shards
   class Dependency

--- a/src/lock.cr
+++ b/src/lock.cr
@@ -1,6 +1,5 @@
 require "./ext/yaml"
 require "./dependency"
-require "./package"
 
 module Shards
   module Lock

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -1,4 +1,5 @@
 require "molinillo"
+require "./package"
 
 module Shards
   class MolinilloSolver

--- a/src/package.cr
+++ b/src/package.cr
@@ -1,5 +1,4 @@
 require "file_utils"
-require "./resolvers/*"
 
 module Shards
   class Package

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -164,3 +164,5 @@ module Shards
     end
   end
 end
+
+require "./*"


### PR DESCRIPTION
There was a require loop `resolvers/resolver > spec > config > info > lock > package > resolvers/*` which would cause code like the following to fail:

```Cr
require "./src/resolvers/git"
require "./src/resolvers/path"
```
```
In src/resolvers/path.cr:4:24

 4 | class PathResolver < Resolver
                          ^-------
Error: undefined constant Resolver
```

Lock doesn't depend on Package, so there's no need to require it there.