### PR TITLE
Add compatibility with Crystal 0.35. Drop compatibility with < 0.34

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -12,6 +12,6 @@ targets:
   shards:
     main: src/shards.cr
 
-crystal: 0.33.0
+crystal: 0.34.0
 
 license: Apache-2.0

--- a/src/config.cr
+++ b/src/config.cr
@@ -30,19 +30,11 @@ module Shards
       path = File.expand_path(candidate)
       return path if File.exists?(path)
 
-      {% if compare_versions(Crystal::VERSION, "0.34.0-0") > 0 %}
-        begin
-          Dir.mkdir_p(path)
-          return path
-        rescue File::Error
-        end
-      {% else %}
-        begin
-          Dir.mkdir_p(path)
-          return path
-        rescue Errno
-        end
-      {% end %}
+      begin
+        Dir.mkdir_p(path)
+        return path
+      rescue File::Error
+      end
     end
 
     raise Error.new("Failed to find or create cache directory")

--- a/src/logger.cr
+++ b/src/logger.cr
@@ -1,4 +1,5 @@
 require "colorize"
+require "log"
 
 module Shards
   @@colors = true
@@ -8,105 +9,54 @@ module Shards
   end
 end
 
-{% if compare_versions(Crystal::VERSION, "0.34.0-0") > 0 %}
-  require "log"
-
+{% if compare_versions(Crystal::VERSION, "0.35.0-0") > 0 %}
   Log.setup_from_env(
-    level: ENV.fetch("CRYSTAL_LOG_LEVEL", "INFO"),
-    sources: ENV.fetch("CRYSTAL_LOG_SOURCES", "shards.*"),
+    default_sources: "shards.*",
+    backend: Log::IOBackend.new(formatter: Shards::FORMATTER)
+  )
+{% else %}
+  Log.setup_from_env(
+    level: ENV.fetch("LOG_LEVEL", "INFO"),
+    sources: "shards.*",
     backend: Log::IOBackend.new.tap do |backend|
       backend.formatter = Shards::FORMATTER
     end
   )
+{% end %}
 
-  module Shards
-    Log = ::Log.for(self)
+module Shards
+  Log = ::Log.for(self)
 
-    def self.set_warning_log_level
-      Log.level = ::Log::Severity::Warning
-    end
+  def self.set_warning_log_level
+    Log.level = ::Log::Severity::Warning
+  end
 
-    def self.set_debug_log_level
-      Log.level = ::Log::Severity::Debug
-    end
+  def self.set_debug_log_level
+    Log.level = ::Log::Severity::Debug
+  end
 
-    LOGGER_COLORS = {
-      ::Log::Severity::Error   => :red,
-      ::Log::Severity::Warning => :yellow,
-      ::Log::Severity::Info    => :green,
-      ::Log::Severity::Debug   => :light_gray,
-    }
+  LOGGER_COLORS = {
+    ::Log::Severity::Error   => :red,
+    ::Log::Severity::Warning => :yellow,
+    ::Log::Severity::Info    => :green,
+    ::Log::Severity::Debug   => :light_gray,
+  }
 
-    FORMATTER = ::Log::Formatter.new do |entry, io|
-      message = entry.message
+  FORMATTER = ::Log::Formatter.new do |entry, io|
+    message = entry.message
 
-      if @@colors
-        io << if color = LOGGER_COLORS[entry.severity]?
-          if idx = message.index(' ')
-            message[0...idx].colorize(color).to_s + message[idx..-1]
-          else
-            message.colorize(color)
-          end
+    if @@colors
+      io << if color = LOGGER_COLORS[entry.severity]?
+        if idx = message.index(' ')
+          message[0...idx].colorize(color).to_s + message[idx..-1]
         else
-          message
+          message.colorize(color)
         end
       else
-        io << entry.severity.label[0] << ": " << message
+        message
       end
+    else
+      io << entry.severity.label[0] << ": " << message
     end
   end
-{% else %}
-  require "logger"
-
-  module Shards
-    LOGGER_COLORS = {
-      "ERROR" => :red,
-      "WARN"  => :yellow,
-      "INFO"  => :green,
-      "DEBUG" => :light_gray,
-    }
-
-    @@logger : Logger?
-
-    def self.logger
-      @@logger ||= Logger.new(STDOUT).tap do |logger|
-        logger.progname = "shards"
-        logger.level = Logger::Severity::INFO
-
-        logger.formatter = Logger::Formatter.new do |severity, _datetime, _progname, message, io|
-          if @@colors
-            io << if color = LOGGER_COLORS[severity.to_s]?
-              if idx = message.index(' ')
-                message[0...idx].colorize(color).to_s + message[idx..-1]
-              else
-                message.colorize(color)
-              end
-            else
-              message
-            end
-          else
-            io << severity.to_s[0] << ": " << message
-          end
-        end
-      end
-    end
-
-    def self.set_warning_log_level
-      logger.level = Logger::Severity::WARN
-    end
-
-    def self.set_debug_log_level
-      logger.level = Logger::Severity::DEBUG
-    end
-
-    module Log
-      {% for severity in %w(debug info warn error fatal) %}
-        def self.{{severity.id}}
-          Shards.logger.{{severity.id}} do
-            yield
-          end
-        end
-      {% end %}
-    end
-  end
-{% end %}
+end

--- a/src/package.cr
+++ b/src/package.cr
@@ -61,23 +61,11 @@ module Shards
           File.delete(destination)
         end
 
-        {% if compare_versions(Crystal::VERSION, "0.34.0-0") > 0 %}
-          begin
-            File.link(source, destination)
-          rescue File::Error
-            FileUtils.cp(source, destination)
-          end
-        {% else %}
-          begin
-            File.link(source, destination)
-          rescue ex : Errno
-            if {Errno::EPERM, Errno::EXDEV}.includes?(ex.errno)
-              FileUtils.cp(source, destination)
-            else
-              raise ex
-            end
-          end
-        {% end %}
+        begin
+          File.link(source, destination)
+        rescue File::Error
+          FileUtils.cp(source, destination)
+        end
       end
     end
   end

--- a/src/resolvers/path.cr
+++ b/src/resolvers/path.cr
@@ -27,25 +27,12 @@ module Shards
     end
 
     private def check_install_path_target
-      {% if compare_versions(Crystal::VERSION, "0.34.0-0") > 0 %}
-        begin
-          real_install_path = File.real_path(install_path)
-        rescue File::NotFoundError
-          return false
-        end
-        real_install_path == expanded_local_path
-      {% else %}
-        begin
-          real_install_path = File.real_path(install_path)
-        rescue errno : Errno
-          if errno.errno == Errno::ENOENT
-            return false
-          else
-            raise errno
-          end
-        end
-        real_install_path == expanded_local_path
-      {% end %}
+      begin
+        real_install_path = File.real_path(install_path)
+      rescue File::NotFoundError
+        return false
+      end
+      real_install_path == expanded_local_path
     end
 
     def available_releases : Array(Version)


### PR DESCRIPTION
This makes Crystal 0.34 the minimal version to compile Shards. 