### PR TITLE
Makefile: touch lib directory after installing dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ test_integration: bin/shards phony
 lib: shard.lock
 	mkdir -p lib/molinillo
 	$(SHARDS) install || (curl -L $(MOLINILLO_URL) | tar -xzf - -C lib/molinillo --strip-components=1)
+	touch lib
 
 shard.lock: shard.yml
 	$(SHARDS) update


### PR DESCRIPTION
This is to avoid the situation where, if the `shard.lock` has a mtime more recent than `lib` directory, the dependencies are installed every time. Is there a better solution for this?