### PR TITLE
make sure tags aren't signed

### DIFF
--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -48,7 +48,7 @@ end
 
 def create_git_tag(project, version)
   Dir.cd(git_path(project)) do
-    run "git tag #{version}"
+    run "git tag --no-sign #{version}"
   end
 end
 


### PR DESCRIPTION
this prevents errors if users running specs have set up gpg signing in
their git config