### PR TITLE
Fix commit hash comparison with abbreviated hash

### DIFF
--- a/spec/unit/dependency_spec.cr
+++ b/spec/unit/dependency_spec.cr
@@ -69,7 +69,7 @@ module Shards
       parse_dependency({foo: {git: "", version: "~> 1.0"}}).to_s.should eq("foo (~> 1.0)")
       parse_dependency({foo: {git: "", branch: "feature"}}).to_s.should eq("foo (branch feature)")
       parse_dependency({foo: {git: "", tag: "rc-1.0"}}).to_s.should eq("foo (tag rc-1.0)")
-      parse_dependency({foo: {git: "", commit: "4478d8afe8c728f44b47d3582a270423cd7fc07d"}}).to_s.should eq("foo (commit 4478d8a)")
+      parse_dependency({foo: {git: "", commit: "4478d8afe8c728f44b47d3582a270423cd7fc07d"}}).to_s.should eq("foo (commit 4478d8afe8c728f44b47d3582a270423cd7fc07d)")
     end
   end
 end

--- a/spec/unit/git_resolver_spec.cr
+++ b/spec/unit/git_resolver_spec.cr
@@ -134,5 +134,13 @@ module Shards
       resolver("library").report_version(version "1.2.3").should eq("1.2.3")
       resolver("library").report_version(version "1.2.3+git.commit.654875c9dbfa8d72fba70d65fd548d51ffb85aff").should eq("1.2.3 at 654875c")
     end
+
+    it "#matches_ref" do
+      resolver = GitResolver.new("", "")
+      resolver.matches_ref?(GitCommitRef.new("1234567"), Shards::Version.new("0.1.0.+git.commit.1234567")).should be_true
+      resolver.matches_ref?(GitCommitRef.new("1234567890abcdef"), Shards::Version.new("0.1.0.+git.commit.1234567890abcdef")).should be_true
+      resolver.matches_ref?(GitCommitRef.new("1234567"), Shards::Version.new("0.1.0.+git.commit.1234567890abcdef")).should be_true
+      resolver.matches_ref?(GitCommitRef.new("123456"), Shards::Version.new("0.1.0.+git.commit.1234567890abcdef")).should be_false
+    end
   end
 end

--- a/spec/unit/lock_spec.cr
+++ b/spec/unit/lock_spec.cr
@@ -31,12 +31,12 @@ module Shards
       shards[1].name.should eq("example")
       shards[1].resolver.should eq(GitResolver.new("example", "https://example.com/example-crystal.git"))
       shards[1].requirement.should eq(commit "0d246ee6c52d4e758651b8669a303f04be9a2a96")
-      shards[1].to_s.should eq("example (commit 0d246ee)")
+      shards[1].to_s.should eq("example (commit 0d246ee6c52d4e758651b8669a303f04be9a2a96)")
 
       shards[2].name.should eq("new_git")
       shards[2].resolver.should eq(GitResolver.new("new_git", "https://example.com/new.git"))
       shards[2].requirement.should eq(version "1.2.3+git.commit.0d246ee6c52d4e758651b8669a303f04be9a2a96")
-      shards[2].to_s.should eq("new_git (1.2.3 at 0d246ee)")
+      shards[2].to_s.should eq("new_git (1.2.3 at 0d246ee6c52d4e758651b8669a303f04be9a2a96)")
 
       shards[3].name.should eq("new_path")
       shards[3].resolver.should eq(PathResolver.new("new_path", "../path"))

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -46,6 +46,10 @@ module Shards
     def initialize(@commit : String)
     end
 
+    def =~(other : GitCommitRef)
+      commit.size >= 7 && other.commit.starts_with?(commit)
+    end
+
     def to_git_ref
       @commit
     end
@@ -161,7 +165,7 @@ module Shards
     def matches_ref?(ref : GitRef, version : Version)
       case ref
       when GitCommitRef
-        git_ref(version) == ref
+        ref =~ git_ref(version)
       else
         # TODO: check branch and tags
         true

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -54,8 +54,8 @@ module Shards
       @commit
     end
 
-    def to_s(io)
-      io << "commit " << @commit[0...7]
+    def to_s(io, *, commit_length = nil)
+      io << "commit " << @commit[0...commit_length]
     end
 
     def to_yaml(yaml)


### PR DESCRIPTION
This also enables full-length commit hash reporting for dependencies. Maybe we could use abbreviated hashes in non-critical situations (such as error messages), but I think it might actually be better to always be explicit. Otherwise there's no indication whether the actual hash value is abbreviated or it's only abbreviated for display.

Resolves #384