### PR TITLE
Fix: allow commit hashes to be abbreviated

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -136,6 +136,18 @@ describe "install" do
     assert_installed "missing", "0.1.0", git: git_commits(:missing).first
   end
 
+  it "install specific commit" do
+    metadata = {dependencies: {"web": {git: git_url(:web), commit: git_commits(:web)[2]}}}
+    with_shard(metadata) { run "shards install" }
+    assert_installed "web", "1.2.0", git: git_commits(:web)[2]
+  end
+
+  it "install specific abbreviated commit" do
+    metadata = {dependencies: {"web": {git: git_url(:web), commit: git_commits(:web)[2][0...5]}}}
+    with_shard(metadata) { debug "shards install" }
+    assert_installed "web", "1.2.0", git: git_commits(:web)[2]
+  end
+
   it "installs dependency at locked commit when refs is a branch" do
     metadata = {
       dependencies: {

--- a/spec/unit/git_resolver_spec.cr
+++ b/spec/unit/git_resolver_spec.cr
@@ -134,5 +134,12 @@ module Shards
       resolver("library").report_version(version "1.2.3").should eq("1.2.3")
       resolver("library").report_version(version "1.2.3+git.commit.654875c9dbfa8d72fba70d65fd548d51ffb85aff").should eq("1.2.3 at 654875c")
     end
+
+    it "#matches_ref" do
+      resolver = GitResolver.new("", "")
+      resolver.matches_ref?(GitCommitRef.new("1234567890abcdef"), Shards::Version.new("0.1.0.+git.commit.1234567")).should be_true
+      resolver.matches_ref?(GitCommitRef.new("1234567890abcdef"), Shards::Version.new("0.1.0.+git.commit.1234567890abcdef")).should be_true
+      resolver.matches_ref?(GitCommitRef.new("1234567"), Shards::Version.new("0.1.0.+git.commit.1234567890abcdef")).should be_true
+    end
   end
 end

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -46,6 +46,10 @@ module Shards
     def initialize(@commit : String)
     end
 
+    def =~(other : GitCommitRef)
+      commit.starts_with?(other.commit) || other.commit.starts_with?(commit)
+    end
+
     def to_git_ref
       @commit
     end
@@ -161,7 +165,7 @@ module Shards
     def matches_ref?(ref : GitRef, version : Version)
       case ref
       when GitCommitRef
-        git_ref(version) == ref
+        ref =~ git_ref(version)
       else
         # TODO: check branch and tags
         true


### PR DESCRIPTION
Based on the work done by @straight-shoota in #386 
I will submit the changes to show the full hash on errors on a different PR.

Fixes: #384 