### PR TITLE
Make errors with git refs more descriptive

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -605,4 +605,36 @@ describe "install" do
       stdout.should contain(%(W: Shard "noshardyml" version (0.1.0) doesn't have a shard.yml file))
     end
   end
+
+  it "shows error when branch does not exist" do
+    metadata = {dependencies: {web: {git: git_url(:web), branch: "foo"}}}
+    with_shard(metadata) do
+      ex = expect_raises(FailedCommand) { run "shards install --no-color" }
+      ex.stdout.should contain(%(E: Could not find branch foo in the repository #{git_url(:web)} for shard "web"))
+    end
+  end
+
+  it "shows error when tag does not exist" do
+    metadata = {dependencies: {web: {git: git_url(:web), tag: "foo"}}}
+    with_shard(metadata) do
+      ex = expect_raises(FailedCommand) { run "shards install --no-color" }
+      ex.stdout.should contain(%(E: Could not find tag foo in the repository #{git_url(:web)} for shard "web"))
+    end
+  end
+
+  it "shows error when commit does not exist" do
+    metadata = {dependencies: {web: {git: git_url(:web), commit: "f8f67cc67d6bd3479811825a49a16260a8c767a3"}}}
+    with_shard(metadata) do
+      ex = expect_raises(FailedCommand) { run "shards install --no-color" }
+      ex.stdout.should contain(%(E: Could not find commit f8f67cc67d6bd3479811825a49a16260a8c767a3 in the repository #{git_url(:web)} for shard "web"))
+    end
+  end
+
+  it "shows error when installing by ref and shard.yml doesn't exist" do
+    metadata = {dependencies: {noshardyml: {git: git_url(:noshardyml), tag: "v0.1.0"}}}
+    with_shard(metadata) do
+      ex = expect_raises(FailedCommand) { run "shards install --no-color" }
+      ex.stdout.should contain(%(E: No shard.yml was found for shard "noshardyml" at commit #{git_commits(:noshardyml)[1]}))
+    end
+  end
 end

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -610,7 +610,7 @@ describe "install" do
     metadata = {dependencies: {web: {git: git_url(:web), branch: "foo"}}}
     with_shard(metadata) do
       ex = expect_raises(FailedCommand) { run "shards install --no-color" }
-      ex.stdout.should contain(%(E: Could not find branch foo in the repository #{git_url(:web)} for shard "web"))
+      ex.stdout.should contain(%(E: Could not find branch foo for shard "web" in the repository #{git_url(:web)}))
     end
   end
 
@@ -618,7 +618,7 @@ describe "install" do
     metadata = {dependencies: {web: {git: git_url(:web), tag: "foo"}}}
     with_shard(metadata) do
       ex = expect_raises(FailedCommand) { run "shards install --no-color" }
-      ex.stdout.should contain(%(E: Could not find tag foo in the repository #{git_url(:web)} for shard "web"))
+      ex.stdout.should contain(%(E: Could not find tag foo for shard "web" in the repository #{git_url(:web)}))
     end
   end
 
@@ -626,7 +626,7 @@ describe "install" do
     metadata = {dependencies: {web: {git: git_url(:web), commit: "f8f67cc67d6bd3479811825a49a16260a8c767a3"}}}
     with_shard(metadata) do
       ex = expect_raises(FailedCommand) { run "shards install --no-color" }
-      ex.stdout.should contain(%(E: Could not find commit f8f67cc67d6bd3479811825a49a16260a8c767a3 in the repository #{git_url(:web)} for shard "web"))
+      ex.stdout.should contain(%(E: Could not find commit f8f67cc67d6bd3479811825a49a16260a8c767a3 for shard "web" in the repository #{git_url(:web)}))
     end
   end
 

--- a/spec/unit/git_resolver_spec.cr
+++ b/spec/unit/git_resolver_spec.cr
@@ -46,7 +46,7 @@ module Shards
       resolver("unreleased").latest_version_for_ref(nil).should eq(version "0.1.0+git.commit.#{git_commits(:unreleased)[0]}")
       resolver("library").latest_version_for_ref(branch "master").should eq(version "0.2.0+git.commit.#{git_commits(:library)[0]}")
       resolver("library").latest_version_for_ref(nil).should eq(version "0.2.0+git.commit.#{git_commits(:library)[0]}")
-      expect_raises(Shards::Error, "Could not find branch foo in the repository file://#{git_path(:library)} for shard \"library\"") do
+      expect_raises(Shards::Error, "Could not find branch foo for shard \"library\" in the repository file://#{git_path(:library)}") do
         resolver("library").latest_version_for_ref(branch "foo")
       end
     end

--- a/spec/unit/git_resolver_spec.cr
+++ b/spec/unit/git_resolver_spec.cr
@@ -35,18 +35,26 @@ module Shards
     end
 
     it "latest version for ref" do
-      resolver("empty").latest_version_for_ref(branch "master").should be_nil
-      resolver("empty").latest_version_for_ref(nil).should be_nil
+      expect_raises(Shards::Error, "No shard.yml was found for shard \"empty\" at commit #{git_commits(:empty)[0]}") do
+        resolver("empty").latest_version_for_ref(branch "master")
+      end
+      expect_raises(Shards::Error, "No shard.yml was found for shard \"empty\" at commit #{git_commits(:empty)[0]}") do
+        resolver("empty").latest_version_for_ref(nil)
+      end
       resolver("unreleased").latest_version_for_ref(branch "master").should eq(version "0.1.0+git.commit.#{git_commits(:unreleased)[0]}")
       resolver("unreleased").latest_version_for_ref(branch "branch").should eq(version "0.1.0+git.commit.#{git_commits(:unreleased, "branch")[0]}")
       resolver("unreleased").latest_version_for_ref(nil).should eq(version "0.1.0+git.commit.#{git_commits(:unreleased)[0]}")
       resolver("library").latest_version_for_ref(branch "master").should eq(version "0.2.0+git.commit.#{git_commits(:library)[0]}")
       resolver("library").latest_version_for_ref(nil).should eq(version "0.2.0+git.commit.#{git_commits(:library)[0]}")
-      resolver("library").latest_version_for_ref(branch "foo").should be_nil
+      expect_raises(Shards::Error, "Could not find branch foo in the repository file://#{git_path(:library)} for shard \"library\"") do
+        resolver("library").latest_version_for_ref(branch "foo")
+      end
     end
 
     it "versions for" do
-      resolver("empty").versions_for(Any).should be_empty
+      expect_raises(Shards::Error, "No shard.yml was found for shard \"empty\" at commit #{git_commits(:empty)[0]}") do
+        resolver("empty").versions_for(Any)
+      end
       resolver("library").versions_for(Any).should eq(versions ["0.0.1", "0.1.0", "0.1.1", "0.1.2", "0.2.0"])
       resolver("library").versions_for(VersionReq.new "~> 0.1.0").should eq(versions ["0.1.0", "0.1.1", "0.1.2"])
       resolver("library").versions_for(branch "master").should eq(versions ["0.2.0+git.commit.#{git_commits(:library)[0]}"])

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -164,7 +164,7 @@ module Shards
       begin
         commit = commit_sha1_at(ref)
       rescue Error
-        raise Error.new "Could not find #{ref.full_info} in the repository #{source} for shard #{name.inspect}"
+        raise Error.new "Could not find #{ref.full_info} for shard #{name.inspect} in the repository #{source}"
       end
 
       if spec = spec_at_ref(ref)

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -4,7 +4,13 @@ require "../versions"
 require "../helpers/path"
 
 module Shards
-  struct GitBranchRef < Ref
+  abstract struct GitRef < Ref
+    def full_info
+      to_s
+    end
+  end
+
+  struct GitBranchRef < GitRef
     def initialize(@branch : String)
     end
 
@@ -22,7 +28,7 @@ module Shards
     end
   end
 
-  struct GitTagRef < Ref
+  struct GitTagRef < GitRef
     def initialize(@tag : String)
     end
 
@@ -40,7 +46,7 @@ module Shards
     end
   end
 
-  struct GitCommitRef < Ref
+  struct GitCommitRef < GitRef
     getter commit : String
 
     def initialize(@commit : String)
@@ -54,13 +60,17 @@ module Shards
       io << "commit " << @commit[0...7]
     end
 
+    def full_info
+      "commit #{@commit}"
+    end
+
     def to_yaml(yaml)
       yaml.scalar "commit"
       yaml.scalar @commit
     end
   end
 
-  struct GitHeadRef < Ref
+  struct GitHeadRef < GitRef
     def to_git_ref
       "HEAD"
     end
@@ -73,8 +83,6 @@ module Shards
       raise NotImplementedError.new("GitHeadRef is for internal use only")
     end
   end
-
-  alias GitRef = GitBranchRef | GitTagRef | GitCommitRef | GitHeadRef
 
   class GitResolver < Resolver
     @@has_git_command : Bool?
@@ -150,11 +158,19 @@ module Shards
       versions_from_tags
     end
 
-    def latest_version_for_ref(ref : GitRef?) : Version?
+    def latest_version_for_ref(ref : GitRef?) : Version
+      update_local_cache
       ref ||= GitHeadRef.new
-      if spec = spec_at_ref(ref)
+      begin
         commit = commit_sha1_at(ref)
+      rescue Error
+        raise Error.new "Could not find #{ref.full_info} in the repository #{source} for shard #{name.inspect}"
+      end
+
+      if spec = spec_at_ref(ref)
         Version.new "#{spec.version.value}+git.commit.#{commit}"
+      else
+        raise Error.new "No #{SPEC_FILENAME} was found for shard #{name.inspect} at commit #{commit}"
       end
     end
 

--- a/src/resolvers/path.cr
+++ b/src/resolvers/path.cr
@@ -39,9 +39,6 @@ module Shards
       [spec(nil).version]
     end
 
-    def latest_version_for_ref(ref : Ref?) : Version?
-    end
-
     def local_path
       source
     end

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -76,7 +76,7 @@ module Shards
 
     abstract def available_releases : Array(Version)
 
-    def latest_version_for_ref(ref : Ref?) : Version?
+    def latest_version_for_ref(ref : Ref?) : Version
       raise "Unsupported ref type for this resolver: #{ref}"
     end
 

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -51,26 +51,18 @@ module Shards
       case req
       when Version then [req]
       when Ref
-        versions_for_ref(req)
+        [latest_version_for_ref(req)]
       when VersionReq
         Versions.resolve(available_releases, req)
       when Any
         releases = available_releases
         if releases.empty?
-          versions_for_ref(nil)
+          [latest_version_for_ref(nil)]
         else
           releases
         end
       else
         raise Error.new("Unexpected requirement type: #{req}")
-      end
-    end
-
-    private def versions_for_ref(ref : Ref?) : Array(Version)
-      if version = latest_version_for_ref(ref)
-        [version]
-      else
-        [] of Version
       end
     end
 


### PR DESCRIPTION
Currently when a git ref doesn't exist, the resolver just returns an empty array for the available versions. This makes the solver to fail with a confusing message. For example:
```
Unable to satisfy the following requirements:

- `db (branch foo)` required by `shard.yml`
```

With this PR, the error is handled more prematurely, thus providing better info:
```
Could not find branch foo in the repository https://github.com/crystal-lang/crystal-db.git for shard "db"
```

Also, if a commit hash is used, the full hash is displayed:
```
Could not find commit fd686ad3015f48f8b22cf4fbec80e8c8088ef44b in the repository https://github.com/crystal-lang/crystal-db.git for shard "db"
```

Related to #384, #386 