### PR TITLE
Use `crystal` property to filter shard compatibility

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -666,6 +666,14 @@ describe "install" do
     end
   end
 
+  it "install version ignoring current crystal version if --ignore-crystal-version" do
+    metadata = {dependencies: {incompatible: "*"}}
+    with_shard(metadata) do
+      run "shards install --ignore-crystal-version", env: {"CRYSTAL_VERSION" => "0.3.0"}
+      assert_installed "incompatible", "1.0.0"
+    end
+  end
+
   it "doesn't match crystal version for major upgrade" do
     metadata = {dependencies: {incompatible: "*"}}
     with_shard(metadata) do

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -673,4 +673,12 @@ describe "install" do
       refute_installed "incompatible"
     end
   end
+
+  it "does match crystal prerelease" do
+    metadata = {dependencies: {incompatible: "*"}}
+    with_shard(metadata) do
+      run "shards install", env: {"CRYSTAL_VERSION" => "1.0.0-pre1"}
+      assert_installed "incompatible", "1.0.0"
+    end
+  end
 end

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -8,7 +8,7 @@ describe "install" do
     }
 
     with_shard(metadata) do
-      run "shards install"
+      debug "shards install"
 
       # it installed dependencies (recursively)
       assert_installed "web", "2.1.0"
@@ -184,8 +184,8 @@ describe "install" do
 
   it "resolves dependency spec at locked commit" do
     create_git_repository "locked"
-    create_git_release "locked", "0.1.0", "name: locked\nversion: 0.1.0\n"
-    create_git_release "locked", "0.2.0", "name: locked\nversion: 0.2.0\ndependencies:\n  pg:\n    git: #{git_path("pg")}\n"
+    create_git_release "locked", "0.1.0"
+    create_git_release "locked", "0.2.0", {dependencies: {pg: {git: git_path("pg")}}}
 
     metadata = {
       dependencies: {
@@ -438,9 +438,9 @@ describe "install" do
 
   it "fails with circular dependencies" do
     create_git_repository "a"
-    create_git_release "a", "0.1.0", "name: a\nversion: 0.1.0\ndependencies:\n  b:\n    git: #{git_path("b")}"
+    create_git_release "a", "0.1.0", {dependencies: {b: {git: git_path("b")}}}
     create_git_repository "b"
-    create_git_release "b", "0.1.0", "name: b\nversion: 0.1.0\ndependencies:\n  a:\n    git: #{git_path("a")}"
+    create_git_release "b", "0.1.0", {dependencies: {a: {git: git_path("a")}}}
 
     with_shard({dependencies: {a: "*"}}) do
       ex = expect_raises(FailedCommand) { run "shards install --no-color" }
@@ -620,7 +620,7 @@ describe "install" do
   it "install dependency with no shard.yml and show warning" do
     metadata = {dependencies: {noshardyml: "0.1.0"}}
     with_shard(metadata) do
-      stdout = run "shards install --no-color"
+      stdout = run "shards install --no-color", env: {"CRYSTAL_VERSION" => "0.34.0"}
       assert_installed "noshardyml", "0.1.0"
       stdout.should contain(%(W: Shard "noshardyml" version (0.1.0) doesn't have a shard.yml file))
     end
@@ -655,6 +655,22 @@ describe "install" do
     with_shard(metadata) do
       ex = expect_raises(FailedCommand) { run "shards install --no-color" }
       ex.stdout.should contain(%(E: No shard.yml was found for shard "noshardyml" at commit #{git_commits(:noshardyml)[1]}))
+    end
+  end
+
+  it "install version according to current crystal version" do
+    metadata = {dependencies: {incompatible: "*"}}
+    with_shard(metadata) do
+      run "shards install", env: {"CRYSTAL_VERSION" => "0.3.0"}
+      assert_installed "incompatible", "0.2.0"
+    end
+  end
+
+  it "doesn't match crystal version for major upgrade" do
+    metadata = {dependencies: {incompatible: "*"}}
+    with_shard(metadata) do
+      ex = expect_raises(FailedCommand) { run "shards install --no-color", env: {"CRYSTAL_VERSION" => "2.0.0"} }
+      refute_installed "incompatible"
     end
   end
 end

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -8,7 +8,7 @@ describe "install" do
     }
 
     with_shard(metadata) do
-      debug "shards install"
+      run "shards install"
 
       # it installed dependencies (recursively)
       assert_installed "web", "2.1.0"

--- a/spec/unit/git_resolver_spec.cr
+++ b/spec/unit/git_resolver_spec.cr
@@ -22,8 +22,7 @@ module Shards
       create_git_commit "unreleased", "testing"
       checkout_git_branch "unreleased", "master"
 
-      create_git_repository "library", "0.0.1", "0.1.0", "0.1.1", "0.1.2"
-      create_git_release "library", "0.2.0", shard: "name: library\nversion: 0.2.0\nauthors:\n  - julien <julien@portalier.com>"
+      create_git_repository "library", "0.0.1", "0.1.0", "0.1.1", "0.1.2", "0.2.0"
 
       # Create a version tag not prefixed by 'v' which should be ignored
       create_git_tag "library", "99.9.9"

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -45,7 +45,10 @@ module Shards
         when "init"
           Commands::Init.run(path)
         when "install"
-          Commands::Install.run(path)
+          Commands::Install.run(
+            path,
+            ignore_crystal_version: args.includes?("--ignore-crystal-version")
+          )
         when "list"
           Commands::List.run(path, tree: args.includes?("--tree"))
         when "lock"
@@ -53,16 +56,22 @@ module Shards
             path,
             args[1..-1].reject(&.starts_with?("--")),
             print: args.includes?("--print"),
-            update: args.includes?("--update")
+            update: args.includes?("--update"),
+            ignore_crystal_version: args.includes?("--ignore-crystal-version")
           )
         when "outdated"
-          Commands::Outdated.run(path, prereleases: args.includes?("--pre"))
+          Commands::Outdated.run(
+            path,
+            prereleases: args.includes?("--pre"),
+            ignore_crystal_version: args.includes?("--ignore-crystal-version")
+          )
         when "prune"
           Commands::Prune.run(path)
         when "update"
           Commands::Update.run(
             path,
-            args[1..-1].reject(&.starts_with?("--"))
+            args[1..-1].reject(&.starts_with?("--")),
+            ignore_crystal_version: args.includes?("--ignore-crystal-version")
           )
         when "version"
           Commands::Version.run(args[1]? || path)

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -4,10 +4,10 @@ require "../molinillo_solver"
 module Shards
   module Commands
     class Install < Command
-      def run
+      def run(*, ignore_crystal_version = false)
         Log.info { "Resolving dependencies" }
 
-        solver = MolinilloSolver.new(spec)
+        solver = MolinilloSolver.new(spec, ignore_crystal_version: ignore_crystal_version)
 
         if lockfile?
           # install must be as conservative as possible:

--- a/src/commands/lock.cr
+++ b/src/commands/lock.cr
@@ -4,10 +4,10 @@ require "../molinillo_solver"
 module Shards
   module Commands
     class Lock < Command
-      def run(shards : Array(String), print = false, update = false)
+      def run(shards : Array(String), print = false, update = false, *, ignore_crystal_version = false)
         Log.info { "Resolving dependencies" }
 
-        solver = MolinilloSolver.new(spec)
+        solver = MolinilloSolver.new(spec, ignore_crystal_version: ignore_crystal_version)
 
         if lockfile?
           if update

--- a/src/commands/outdated.cr
+++ b/src/commands/outdated.cr
@@ -8,12 +8,12 @@ module Shards
       @up_to_date = true
       @output = IO::Memory.new
 
-      def run(@prereleases = false)
+      def run(@prereleases = false, *, ignore_crystal_version = false)
         return unless has_dependencies?
 
         Log.info { "Resolving dependencies" }
 
-        solver = MolinilloSolver.new(spec, @prereleases)
+        solver = MolinilloSolver.new(spec, prereleases: @prereleases, ignore_crystal_version: ignore_crystal_version)
         solver.prepare(development: !Shards.production?)
 
         packages = handle_resolver_errors { solver.solve }

--- a/src/commands/update.cr
+++ b/src/commands/update.cr
@@ -4,10 +4,10 @@ require "../molinillo_solver"
 module Shards
   module Commands
     class Update < Command
-      def run(shards : Array(String))
+      def run(shards : Array(String), *, ignore_crystal_version = false)
         Log.info { "Resolving dependencies" }
 
-        solver = MolinilloSolver.new(spec)
+        solver = MolinilloSolver.new(spec, ignore_crystal_version: ignore_crystal_version)
 
         if lockfile? && !shards.empty?
           # update selected dependencies to latest possible versions, but

--- a/src/config.cr
+++ b/src/config.cr
@@ -65,7 +65,17 @@ module Shards
   end
 
   def self.crystal_version
-    ENV["CRYSTAL_VERSION"]? || `crystal env CRYSTAL_VERSION`.chomp
+    @@crystal_version = ENV["CRYSTAL_VERSION"]? || begin
+      output = IO::Memory.new
+      error = IO::Memory.new
+      status = begin
+        Process.run("crystal", {"env", "CRYSTAL_VERSION"}, output: output, error: error)
+      rescue e
+        raise Error.new("Could not execute 'crystal': #{e.message}")
+      end
+      raise Error.new("Error executing crystal:\n#{error}") unless status.success?
+      output.to_s.strip
+    end
   end
 
   class_property? production = false

--- a/src/config.cr
+++ b/src/config.cr
@@ -65,7 +65,7 @@ module Shards
   end
 
   def self.crystal_version
-    @@crystal_version = ENV["CRYSTAL_VERSION"]? || begin
+    @@crystal_version ||= without_prerelease(ENV["CRYSTAL_VERSION"]? || begin
       output = IO::Memory.new
       error = IO::Memory.new
       status = begin
@@ -75,6 +75,17 @@ module Shards
       end
       raise Error.new("Error executing crystal:\n#{error}") unless status.success?
       output.to_s.strip
+    end)
+  end
+
+  def self.crystal_version(@@crystal_version : String)
+  end
+
+  private def self.without_prerelease(version)
+    if version =~ /^(\d+)\.(\d+)\.(\d+)([^\w]\w+)$/
+      "#{$1}.#{$2}.#{$3}"
+    else
+      version
     end
   end
 

--- a/src/config.cr
+++ b/src/config.cr
@@ -64,6 +64,10 @@ module Shards
   def self.bin_path=(@@bin_path : String)
   end
 
+  def self.crystal_version
+    ENV["CRYSTAL_VERSION"]? || `crystal env CRYSTAL_VERSION`.chomp
+  end
+
   class_property? production = false
   class_property? local = false
 end

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -5,11 +5,15 @@ module Shards
   class MolinilloSolver
     setter locks : Array(Dependency)?
     @solution : Array(Package)?
+    @prereleases : Bool
+    @ignore_crystal_version : Bool
 
     include Molinillo::SpecificationProvider(Shards::Dependency, Shards::Spec)
     include Molinillo::UI
 
-    def initialize(@spec : Spec, @prereleases = false)
+    def initialize(@spec : Spec, *, prereleases = false, ignore_crystal_version = false)
+      @prereleases = prereleases
+      @ignore_crystal_version = ignore_crystal_version
     end
 
     def prepare(@development = true)
@@ -152,6 +156,8 @@ module Shards
 
     def dependencies_for(specification : S) : Array(R)
       return specification.dependencies if specification.name == "crystal"
+      return specification.dependencies if @ignore_crystal_version
+
       crystal_pattern =
         if crystal_version = specification.crystal
           if crystal_version =~ /^(\d+)\.(\d+)\.(\d+)$/

--- a/src/resolvers/crystal.cr
+++ b/src/resolvers/crystal.cr
@@ -1,0 +1,25 @@
+module Shards
+  class CrystalResolver < Resolver
+    INSTANCE = new("crystal", "")
+
+    def self.key
+      "crystal"
+    end
+
+    def available_releases : Array(Version)
+      [Version.new Shards.crystal_version]
+    end
+
+    def read_spec(version : Version) : String?
+      nil
+    end
+
+    def install_sources(version : Version)
+      raise NotImplementedError.new("CrystalResolver#install_sources")
+    end
+
+    def report_version(version : Version) : String
+      version.value
+    end
+  end
+end


### PR DESCRIPTION
This PR implements what's discussed in #365 

I had to also make the assumption that when the `crystal` property is not present, the expression `< 1.0.0` is assumed. This is because old shards in the past didn't specify the `crystal` version. If we don't make this assumption, once Crystal 1.0.0 is released, old shard versions will be installed by default. This has the implication that the parameter is now mandatory after `1.0.0` but I think that's a good thing and according to what was discussed.