### PR TITLE
Bump lock version

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -308,6 +308,21 @@ describe "install" do
     end
   end
 
+  it "upgrade lock file from 1.0" do
+    metadata = {dependencies: {web: "*"}}
+
+    with_shard(metadata) do
+      File.write "shard.lock", YAML.dump({
+        version: "1.0",
+        shards:  {web: {git: git_url(:web), commit: git_commits(:web).first}},
+      })
+
+      run "shards install"
+      Shards::Lock.from_file("shard.lock").version.should eq(Shards::Lock::CURRENT_VERSION)
+      assert_locked "web", "2.1.0", git: git_commits(:web).first
+    end
+  end
+
   it "production doesn't install development dependencies" do
     metadata = {
       dependencies:             {web: "*", orm: "*"},

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -157,7 +157,7 @@ def assert_locked(name, version = nil, file = __FILE__, line = __LINE__, *, git 
   path = File.join(application_path, "shard.lock")
   assert File.exists?(path), "expected shard.lock to have been generated", file, line
   locks = Shards::Lock.from_file(path)
-  assert lock = locks.find { |d| d.name == name }, "expected #{name} dependency to have been locked", file, line
+  assert lock = locks.shards.find { |d| d.name == name }, "expected #{name} dependency to have been locked", file, line
 
   if lock && version
     expected_version = git ? "#{version}+git.commit.#{git}" : version
@@ -169,7 +169,7 @@ def refute_locked(name, version = nil, file = __FILE__, line = __LINE__)
   path = File.join(application_path, "shard.lock")
   assert File.exists?(path), "expected shard.lock to have been generated", file, line
   locks = Shards::Lock.from_file(path)
-  refute locks.find { |d| d.name == name }, "expected #{name} dependency to not have been locked", file, line
+  refute locks.shards.find { |d| d.name == name }, "expected #{name} dependency to not have been locked", file, line
 end
 
 def install_path(*path_names)

--- a/spec/support/cli.cr
+++ b/spec/support/cli.cr
@@ -71,7 +71,7 @@ def to_lock_yaml(lock)
   return unless lock
 
   YAML.dump({
-    version: "1.0",
+    version: Shards::Lock::CURRENT_VERSION,
     shards:  lock.to_a.to_h do |name, version|
       {name, {git: git_url(name), version: version}}
     end,

--- a/spec/unit/lock_spec.cr
+++ b/spec/unit/lock_spec.cr
@@ -4,7 +4,7 @@ require "../../src/lock"
 module Shards
   describe Lock do
     it "parses" do
-      shards = Lock.from_yaml <<-YAML
+      lock = Lock.from_yaml <<-YAML
       version: 1.0
       shards:
         repo:
@@ -21,6 +21,9 @@ module Shards
           version: 0.1.2
       YAML
 
+      lock.version.should eq("1.0")
+
+      shards = lock.shards
       shards.size.should eq(4)
 
       shards[0].name.should eq("repo")

--- a/src/commands/check.cr
+++ b/src/commands/check.cr
@@ -36,7 +36,7 @@ module Shards
       end
 
       private def installed?(dependency, spec)
-        unless lock = locks.find { |d| d.name == spec.name }
+        unless lock = locks.shards.find { |d| d.name == spec.name }
           Log.debug { "#{dependency.name}: not locked" }
           return false
         end

--- a/src/commands/command.cr
+++ b/src/commands/command.cr
@@ -8,7 +8,7 @@ module Shards
     getter lockfile_path : String
 
     @spec : Spec?
-    @locks : Array(Dependency)?
+    @locks : Lock?
 
     def initialize(path)
       if File.directory?(path)

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -82,6 +82,7 @@ module Shards
       end
 
       private def outdated_lockfile?(packages)
+        return true if locks.version != Shards::Lock::CURRENT_VERSION
         return true if packages.size != locks.shards.size
         a = packages.to_h { |x| {x.name, x.version} }
         b = locks.shards.to_h { |x| {x.name, x.requirement.as?(Shards::Version)} }

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -11,7 +11,7 @@ module Shards
 
         if lockfile?
           # install must be as conservative as possible:
-          solver.locks = locks
+          solver.locks = locks.shards
         end
 
         solver.prepare(development: !Shards.production?)
@@ -32,7 +32,7 @@ module Shards
 
       private def validate(packages)
         packages.each do |package|
-          if lock = locks.find { |d| d.name == package.name }
+          if lock = locks.shards.find { |d| d.name == package.name }
             if version = lock.requirement.as?(Shards::Version)
               validate_locked_version(package, version)
             else
@@ -82,9 +82,9 @@ module Shards
       end
 
       private def outdated_lockfile?(packages)
-        return true if packages.size != locks.size
+        return true if packages.size != locks.shards.size
         a = packages.to_h { |x| {x.name, x.version} }
-        b = locks.to_h { |x| {x.name, x.requirement.as?(Shards::Version)} }
+        b = locks.shards.to_h { |x| {x.name, x.requirement.as?(Shards::Version)} }
         a != b
       end
     end

--- a/src/commands/lock.cr
+++ b/src/commands/lock.cr
@@ -14,11 +14,11 @@ module Shards
             # update selected dependencies to latest possible versions, but
             # avoid to update unspecified dependencies, if possible:
             unless shards.empty?
-              solver.locks = locks.reject { |d| shards.includes?(d.name) }
+              solver.locks = locks.shards.reject { |d| shards.includes?(d.name) }
             end
           else
             # install must be as conservative as possible:
-            solver.locks = locks
+            solver.locks = locks.shards
           end
         end
 

--- a/src/commands/prune.cr
+++ b/src/commands/prune.cr
@@ -12,7 +12,7 @@ module Shards
           next unless File.directory?(path)
           name = File.basename(path)
 
-          if locks.none? { |d| d.name == name }
+          if locks.shards.none? { |d| d.name == name }
             Log.debug { "rm -rf '#{Helpers::Path.escape(path)}'" }
             FileUtils.rm_rf(path)
 

--- a/src/commands/update.cr
+++ b/src/commands/update.cr
@@ -12,7 +12,7 @@ module Shards
         if lockfile? && !shards.empty?
           # update selected dependencies to latest possible versions, but
           # avoid to update unspecified dependencies, if possible:
-          solver.locks = locks.reject { |d| shards.includes?(d.name) }
+          solver.locks = locks.shards.reject { |d| shards.includes?(d.name) }
         end
 
         solver.prepare(development: !Shards.production?)

--- a/src/info.cr
+++ b/src/info.cr
@@ -11,7 +11,7 @@ class Shards::Info
   def reload
     path = info_path
     if File.exists?(path)
-      @installed = Lock.from_file(path).index_by &.name
+      @installed = Lock.from_file(path).shards.index_by &.name
     end
   end
 

--- a/src/lock.cr
+++ b/src/lock.cr
@@ -2,7 +2,13 @@ require "./ext/yaml"
 require "./dependency"
 
 module Shards
-  module Lock
+  class Lock
+    property version : String
+    property shards : Array(Dependency)
+
+    def initialize(@version : String, @shards : Array(Dependency))
+    end
+
     def self.from_file(path)
       raise Error.new("Missing #{File.basename(path)}") unless File.exists?(path)
       from_yaml(File.read(path))
@@ -15,9 +21,9 @@ module Shards
       pull.read_stream do
         pull.read_document do
           pull.read_mapping do
-            key, value = pull.read_scalar, pull.read_scalar
+            key, version = pull.read_scalar, pull.read_scalar
 
-            unless key == "version" && value == "1.0"
+            unless key == "version" && version == "1.0"
               raise InvalidLock.new
             end
 
@@ -29,13 +35,12 @@ module Shards
             else
               pull.raise "No such attribute #{key} in lock version 1.0"
             end
+
+            Lock.new(version, dependencies)
           end
         end
       end
-
-      dependencies
     rescue ex : YAML::ParseException
-      # raise ParseError.new(ex.message, str, LOCK_FILENAME, ex.line_number, ex.column_number)
       raise Error.new("Invalid #{LOCK_FILENAME}. Please delete it and run install again.")
     ensure
       pull.close if pull

--- a/src/lock.cr
+++ b/src/lock.cr
@@ -6,6 +6,8 @@ module Shards
     property version : String
     property shards : Array(Dependency)
 
+    CURRENT_VERSION = "2.0"
+
     def initialize(@version : String, @shards : Array(Dependency))
     end
 
@@ -23,7 +25,7 @@ module Shards
           pull.read_mapping do
             key, version = pull.read_scalar, pull.read_scalar
 
-            unless key == "version" && version == "1.0"
+            unless key == "version" && version.in?("1.0", "2.0")
               raise InvalidLock.new
             end
 
@@ -33,7 +35,7 @@ module Shards
                 dependencies << Dependency.from_yaml(pull, is_lock: true)
               end
             else
-              pull.raise "No such attribute #{key} in lock version 1.0"
+              pull.raise "No such attribute #{key} in lock version #{version}"
             end
 
             Lock.new(version, dependencies)
@@ -53,7 +55,7 @@ module Shards
     end
 
     def self.write(packages : Array(Package), io : IO)
-      io << "version: 1.0\n"
+      io << "version: #{CURRENT_VERSION}\n"
       io << "shards:\n"
 
       packages.sort_by!(&.name).each do |package|


### PR DESCRIPTION
This upgrades the `version` in `shards.lock` to `2.0`, because it effectively cannot be used by previous versions (git refs are stored as part of the version metadata).
