### PR TITLE
Delete old .sha1 files

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -66,6 +66,16 @@ describe "install" do
     end
   end
 
+  it "deletes old .sha1 files" do
+    metadata = {dependencies: {web: "*"}}
+    with_shard(metadata) do
+      Dir.mkdir_p(Shards::INSTALL_DIR)
+      File.touch("#{Shards::INSTALL_DIR}/web.sha1")
+      run "shards install"
+      File.exists?("#{Shards::INSTALL_DIR}/web.sha1").should be_false
+    end
+  end
+
   it "won't install prerelease version" do
     metadata = {
       dependencies: {unstable: "*"},

--- a/src/info.cr
+++ b/src/info.cr
@@ -17,6 +17,11 @@ class Shards::Info
 
   def save
     Dir.mkdir_p(@install_path)
+
+    unless File.exists?(info_path)
+      Dir[File.join @install_path, "*.sha1"].each { |p| File.delete(p) }
+    end
+
     File.open(info_path, "w") do |file|
       YAML.build(file) do |yaml|
         yaml.mapping do


### PR DESCRIPTION
Files `.sha1` left from previous Shards version are now deleted when the `.shards.info` is generated the first time.