### PR TITLE
Spec: Add stdout and stderr to FailedCommand message

### DIFF
--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -3,7 +3,7 @@ class FailedCommand < Exception
   getter stderr : String
 
   def initialize(message, @stdout, @stderr)
-    super message
+    super "#{message}: #{stdout} -- #{stderr}"
   end
 end
 


### PR DESCRIPTION
Just a tiny change that makes debugging failing specs easier.