### PR TITLE
Disable interactive credential prompt for git resolver

### DIFF
--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -305,7 +305,7 @@ module Shards
     end
 
     private def mirror_repository
-      run_in_current_folder "git clone --mirror --quiet -- #{Helpers::Path.escape(git_url)} #{local_path}"
+      run_in_current_folder "GIT_ASKPASS=${GIT_ASKPASS:-/usr/bin/test} git clone --mirror --quiet -- #{Helpers::Path.escape(git_url)} #{local_path}"
     rescue Error
       raise Error.new("Failed to clone #{git_url}")
     end

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -305,7 +305,7 @@ module Shards
     end
 
     private def mirror_repository
-      run_in_current_folder "GIT_ASKPASS=${GIT_ASKPASS:-/usr/bin/test} git clone --mirror --quiet -- #{Helpers::Path.escape(git_url)} #{local_path}"
+      run_in_current_folder "git clone -c core.askPass=true --mirror --quiet -- #{Helpers::Path.escape(git_url)} #{local_path}"
     rescue Error
       raise Error.new("Failed to clone #{git_url}")
     end

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -305,6 +305,13 @@ module Shards
     end
 
     private def mirror_repository
+      # The git-config option core.askPass is set to a command that is to be
+      # called when git needs to ask for credentials (for example on a 401
+      # response over HTTP). Setting the command to `true` effectively
+      # disables the credential prompt, because `shards install` is not to
+      # be used interactively.
+      # This configuration can be overriden by defining the environment
+      # variable `GIT_ASKPASS`.
       run_in_current_folder "git clone -c core.askPass=true --mirror --quiet -- #{Helpers::Path.escape(git_url)} #{local_path}"
     rescue Error
       raise Error.new("Failed to clone #{git_url}")


### PR DESCRIPTION
Resolves #316

Git repository requests over HTTP can result in 401 Authentication Required status code. This is typically the case when a repository is private. Some git providers also return this status code when a repository exists to avoid disclosing the existence of private repositories.
By default, `git clone` prompts for credentials when it receives a 401 status code. When `shards install` uses `git clone`, this leads to unexpected and misleading behaviour. `shards install` is not meant to be used interactively, so this prompt should be completely disabled.

This PR implements this by using the environment variable `GIT_ASKPASS` set to a value resulting in false. It can still be overriden by setting the environment variable.