### PR TITLE
Add convenient makefile arguments for packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 .POSIX:
 
+release ?=      ## Compile in release mode
+debug ?=        ## Add symbolic debug info
+static ?=       ## Enable static linking
+
 CRYSTAL ?= crystal
 SHARDS ?= shards
+override FLAGS += $(if $(release),--release )$(if $(debug),-d )$(if $(static),--static )
+
 SHARDS_SOURCES = $(shell find src -name '*.cr')
 MOLINILLO_SOURCES = $(shell find lib/molinillo -name '*.cr' 2> /dev/null)
 SOURCES = $(SHARDS_SOURCES) $(MOLINILLO_SOURCES)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean: phony
 
 bin/shards: $(SOURCES) $(TEMPLATES) lib
 	@mkdir -p bin
-	$(CRYSTAL) build src/shards.cr -o bin/shards
+	$(CRYSTAL) build $(FLAGS) src/shards.cr -o bin/shards
 
 install: bin/shards phony
 	$(INSTALL) -m 0755 -d "$(BINDIR)" "$(MANDIR)/man1" "$(MANDIR)/man5"


### PR DESCRIPTION
Similar to https://github.com/crystal-lang/crystal/pull/9471
Follow-up to https://github.com/crystal-lang/distribution-scripts/pull/71#discussion_r442992993

I'm only adding release, debug, static to use the same in crystal repo. But I think having FLAGS is enough.