### PR TITLE
Allow CRYSTAL env var to determine compiler

### DIFF
--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -90,7 +90,7 @@ private def setup_repositories
   create_git_release "transitive", "0.2.0", {
     dependencies: {version: {git: git_path(:version)}},
     scripts:      {
-      postinstall: "crystal build src/version.cr",
+      postinstall: %(${CRYSTAL:-"crystal"} build src/version.cr),
     },
   }
 

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -90,7 +90,7 @@ private def setup_repositories
   create_git_release "transitive", "0.2.0", {
     dependencies: {version: {git: git_path(:version)}},
     scripts:      {
-      postinstall: %(${CRYSTAL:-"crystal"} build src/version.cr),
+      postinstall: "crystal build src/version.cr",
     },
   }
 

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -121,7 +121,7 @@ end
 
 def run(command, *, env = nil)
   cmd_env = {
-    "CRYSTAL_PATH" => "#{Shards::INSTALL_DIR}:#{`crystal env CRYSTAL_PATH`.chomp}",
+    "CRYSTAL_PATH" => "#{Shards::INSTALL_DIR}:#{`#{Shards.crystal_bin} env CRYSTAL_PATH`.chomp}",
   }
   cmd_env.merge!(env) if env
   output, error = IO::Memory.new, IO::Memory.new

--- a/src/commands/build.cr
+++ b/src/commands/build.cr
@@ -31,10 +31,11 @@ module Shards
           target.main,
         ]
         options.each { |option| args << option }
-        Log.debug { "crystal #{args.join(' ')}" }
+        Log.debug { "#{Shards.crystal_bin} #{args.join(' ')}" }
 
         error = IO::Memory.new
-        status = Process.run("crystal", args: args, output: Process::Redirect::Inherit, error: error)
+
+        status = Process.run(Shards.crystal_bin, args: args, output: Process::Redirect::Inherit, error: error)
         raise Error.new("Error target #{target.name} failed to compile:\n#{error}") unless status.success?
       end
     end

--- a/src/config.cr
+++ b/src/config.cr
@@ -64,14 +64,21 @@ module Shards
   def self.bin_path=(@@bin_path : String)
   end
 
+  def self.crystal_bin
+    @@crystal_bin ||= ENV.fetch("CRYSTAL", "crystal")
+  end
+
+  def self.crystal_bin=(@@crystal_bin : String)
+  end
+
   def self.crystal_version
     @@crystal_version ||= without_prerelease(ENV["CRYSTAL_VERSION"]? || begin
       output = IO::Memory.new
       error = IO::Memory.new
       status = begin
-        Process.run("crystal", {"env", "CRYSTAL_VERSION"}, output: output, error: error)
+        Process.run(crystal_bin, {"env", "CRYSTAL_VERSION"}, output: output, error: error)
       rescue e
-        raise Error.new("Could not execute 'crystal': #{e.message}")
+        raise Error.new("Could not execute '#{crystal_bin}': #{e.message}")
       end
       raise Error.new("Error executing crystal:\n#{error}") unless status.success?
       output.to_s.strip

--- a/src/config.cr
+++ b/src/config.cr
@@ -78,7 +78,7 @@ module Shards
     end)
   end
 
-  def self.crystal_version(@@crystal_version : String)
+  def self.crystal_version=(@@crystal_version : String)
   end
 
   private def self.without_prerelease(version)

--- a/src/script.cr
+++ b/src/script.cr
@@ -46,7 +46,7 @@ module Shards
     end
 
     private def self.prepend_path(prefix : String, suffix : String?)
-      suffix ? "#{prefix}:#{suffix}" : prefix
+      suffix ? "#{prefix}#{Process::PATH_DELIMITER}#{suffix}" : prefix
     end
   end
 end

--- a/src/script.cr
+++ b/src/script.cr
@@ -25,7 +25,7 @@ module Shards
             Dir.delete bin_path
           end
           env_path = prepend_path(bin_path, ENV["PATH"]?)
-          Log.debug { "Creating shards script environment created at #{bin_path}. PATH=#{env_path}" }
+          Log.debug { "shards script environment created at #{bin_path}. Updated PATH=#{env_path}" }
 
           add_executable bin_path, "shards", Process.executable_path
           add_executable bin_path, "crystal", Process.find_executable(Shards.crystal_bin)

--- a/src/script.cr
+++ b/src/script.cr
@@ -6,9 +6,47 @@ module Shards
     def self.run(path, command, script_name, dependency_name)
       Dir.cd(path) do
         output = IO::Memory.new
-        status = Process.run("/bin/sh", input: IO::Memory.new(command), output: output, error: output)
+        status = Process.run("/bin/sh", env: Script.environment, input: IO::Memory.new(command), output: output, error: output)
         raise Error.new("Failed #{script_name} of #{dependency_name} on #{command}:\n#{output.to_s.rstrip}") unless status.success?
       end
+    end
+
+    @@environment : Process::Env = nil
+
+    def self.environment : Process::Env
+      @@environment ||=
+        begin
+          bin_path = File.tempname(".shards-env")
+          Dir.mkdir(bin_path)
+          at_exit do
+            Dir.new(bin_path).each_child do |e|
+              File.delete(File.join(bin_path, e))
+            end
+            Dir.delete bin_path
+          end
+          env_path = prepend_path(bin_path, ENV["PATH"]?)
+          Log.debug { "Creating shards script environment created at #{bin_path}. PATH=#{env_path}" }
+
+          add_executable bin_path, "shards", Process.executable_path
+          add_executable bin_path, "crystal", Process.find_executable(Shards.crystal_bin)
+
+          {"PATH" => env_path}
+        rescue e
+          Log.error(exception: e) { "Unable to create shards script environment" }
+
+          {} of String => String
+        end
+    end
+
+    private def self.add_executable(bin_path : String, name : String, original_path : String?)
+      if original_path
+        Log.debug { "Adding #{name}=#{original_path} to shards script environment" }
+        File.symlink(original_path, File.join(bin_path, name))
+      end
+    end
+
+    private def self.prepend_path(prefix : String, suffix : String?)
+      suffix ? "#{prefix}:#{suffix}" : prefix
     end
   end
 end


### PR DESCRIPTION
Fixes #406

Shards will read CRYSTAL env var, fallback to `crystal`, to determine which crystal compiler to use.

This also enables that a compiler+shards package can force to use the compiler of that same packaging if wanted.

Something that is not handled is how the `executables` + `postinstall` can deal with this override.

A dependency is forced to use in the `postinstall` a `${CRYSTAL:-"crystal"}` instead of `crystal` which is not great.
Another alternative is to encourage `shards build` instead of `crystal build` that way shards will be invoked again and can choose the appropiate crystal compiler since the environment is preserved.
But we actually have the same problem, the `postinstall` assumes that `shards` is on the path. So what? we should have a `${SHARDS:-"shards"}`? Not great.

I think that the scenario of having executable helpers in the bin directory that are compiled by dependencies on postinstall should be more declarative. That would be a way to solve it I think.
