### PR TITLE
Fix spec for running under 32-bit Linux

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -419,7 +419,7 @@ describe "install" do
 
     with_shard(metadata) do
       run "shards install"
-      File.touch "shard.lock", Time.utc(1900, 1, 1)
+      File.touch "shard.lock", Time.utc(1901, 12, 14)
       mtime = File.info("shard.lock").modification_time
       run "shards install"
       File.info("shard.lock").modification_time.should eq(mtime)


### PR DESCRIPTION
* 1900/01/01 is not a representable date on 32-bit Linux and restricted to the oldest date which is representable.

See crystal-lang/crystal#9542 for more info.