### PR TITLE
Allow shards to read SHARDS_OPTS for addition command options

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -710,6 +710,14 @@ describe "install" do
     end
   end
 
+  it "install version ignoring current crystal version if --ignore-crystal-version (via SHARDS_OPTS)" do
+    metadata = {dependencies: {incompatible: "*"}}
+    with_shard(metadata) do
+      run "shards install", env: {"CRYSTAL_VERSION" => "0.3.0", "SHARDS_OPTS" => "--ignore-crystal-version"}
+      assert_installed "incompatible", "1.0.0"
+    end
+  end
+
   it "doesn't match crystal version for major upgrade" do
     metadata = {dependencies: {incompatible: "*"}}
     with_shard(metadata) do

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -25,7 +25,7 @@ module Shards
   end
 
   def self.run
-    OptionParser.parse(ARGV) do |opts|
+    OptionParser.parse(cli_options) do |opts|
       path = Dir.current
 
       opts.on("--no-color", "Disable colored output.") { self.colors = false }
@@ -82,6 +82,16 @@ module Shards
         exit
       end
     end
+  end
+
+  def self.cli_options
+    shards_opts : Array(String)
+    {% if compare_versions(Crystal::VERSION, "1.0.0-0") > 0 %}
+      shards_opts = Process.parse_arguments(ENV.fetch("SHARDS_OPTS", ""))
+    {% else %}
+      shards_opts = ENV.fetch("SHARDS_OPTS", "").split
+    {% end %}
+    ARGV.concat(shards_opts)
   end
 
   def self.build(path, args)


### PR DESCRIPTION
This allows users to set `--no-color` globally
And is another way to use `--ignore-crystal-version` most likely in CI

Idea mentioned in https://github.com/crystal-lang/shards/issues/413#issuecomment-647768257