### PR TITLE
Handle ambiguous dependencies and update shard.lock on if source of dependency changes change

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -265,17 +265,68 @@ describe "install" do
     end
   end
 
-  it "updates when dependency source changed" do
-    metadata = {dependencies: {web: {path: git_path(:web)}}}
-    lock = {web: "2.1.0"}
+  it "keeps installed version if possible when dependency source changed" do
+    metadata = {dependencies: {awesome: {git: git_url(:forked_awesome)}}}
+    lock = {awesome: "0.1.0"}
 
     with_shard(metadata, lock) do
-      assert_locked "web", "2.1.0", source: {git: git_url(:web)}
+      assert_locked "awesome", "0.1.0", source: {git: git_url(:awesome)}
 
-      run "shards install"
+      output = run "shards install --no-color"
 
-      assert_locked "web", "2.1.0", source: {path: git_path(:web)}
-      assert_installed "web", "2.1.0", source: {path: git_path(:web)}
+      assert_locked "awesome", "0.1.0", source: {git: git_url(:forked_awesome)}
+      assert_installed "awesome", "0.1.0", source: {git: git_url(:forked_awesome)}
+
+      output.should contain("Ignoring source of \"awesome\" on shard.lock")
+    end
+  end
+
+  it "keeps nested dependencies locked when main dependency source changed" do
+    metadata = {dependencies: {awesome: {git: git_url(:forked_awesome)}}}
+    lock = {awesome: "0.1.0", d: "0.1.0"}
+
+    with_shard(metadata, lock) do
+      assert_locked "awesome", "0.1.0", source: {git: git_url(:awesome)}
+      assert_locked "d", "0.1.0", source: {git: git_url(:d)}
+
+      output = run "shards install --no-color"
+
+      assert_locked "awesome", "0.1.0", source: {git: git_url(:forked_awesome)}
+      assert_locked "d", "0.1.0", source: {git: git_url(:d)}
+      assert_installed "awesome", "0.1.0", source: {git: git_url(:forked_awesome)}
+      assert_installed "d", "0.1.0", source: {git: git_url(:d)}
+
+      output.should contain("Ignoring source of \"awesome\" on shard.lock")
+    end
+  end
+
+  it "fails if shard.lock and shard.yml has different sources" do
+    # The sources will not match, so the .lock is not valid regarding the specs
+    metadata = {dependencies: {awesome: {git: git_url(:forked_awesome)}}}
+    lock = {awesome: "0.1.0", d: "0.1.0"}
+
+    with_shard(metadata, lock) do
+      assert_locked "awesome", "0.1.0", source: {git: git_url(:awesome)}
+
+      ex = expect_raises(FailedCommand) { run "shards install --production --no-color" }
+      ex.stdout.should contain("Outdated shard.lock (awesome source changed)")
+      ex.stderr.should be_empty
+    end
+  end
+
+  it "fails if shard.lock and shard.yml has different sources with incompatible versions." do
+    # User should use update command in this scenario
+    # forked_awesome does not have a 0.3.0
+    # awesome has 0.3.0
+    metadata = {dependencies: {awesome: {git: git_url(:forked_awesome)}}}
+    lock = {awesome: "0.3.0"}
+
+    with_shard(metadata, lock) do
+      assert_locked "awesome", "0.3.0", source: {git: git_url(:awesome)}
+
+      ex = expect_raises(FailedCommand) { run "shards install --production --no-color" }
+      ex.stdout.should contain("Maybe a commit, branch or file doesn't exist?")
+      ex.stderr.should be_empty
     end
   end
 

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -265,6 +265,20 @@ describe "install" do
     end
   end
 
+  it "updates when dependency source changed" do
+    metadata = {dependencies: {web: {path: git_path(:web)}}}
+    lock = {web: "2.1.0"}
+
+    with_shard(metadata, lock) do
+      assert_locked "web", "2.1.0", source: {git: git_url(:web)}
+
+      run "shards install"
+
+      assert_locked "web", "2.1.0", source: {path: git_path(:web)}
+      assert_installed "web", "2.1.0", source: {path: git_path(:web)}
+    end
+  end
+
   it "install subdependency of new dependency respecting lock" do
     metadata = {dependencies: {c: "*", d: "*"}}
     lock = {d: "0.1.0"}

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -198,15 +198,15 @@ describe "install" do
   it "resolves dependency spec at locked commit" do
     create_git_repository "locked"
     create_git_release "locked", "0.1.0"
-    create_git_release "locked", "0.2.0", {dependencies: {pg: {git: git_path("pg")}}}
+    create_git_release "locked", "0.2.0", {dependencies: {pg: {git: git_url(:pg)}}}
 
     metadata = {
       dependencies: {
-        "locked": {git: git_path(:"locked"), branch: "master"},
+        "locked": {git: git_url(:locked), branch: "master"},
       },
     }
     lock = {
-      "locked": "0.1.0+git.commit.#{git_commits(:"locked").last}",
+      "locked": "0.1.0+git.commit.#{git_commits(:locked).last}",
     }
     with_shard(metadata, lock) { run "shards install" }
 

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -759,15 +759,10 @@ describe "install" do
   end
 
   it "fails on conflicting sources" do
-    create_git_repository "awesome", "0.1.0"
-
     create_git_repository "intermediate"
     create_git_release "intermediate", "0.1.0", {
       dependencies: {awesome: {git: git_url(:awesome)}},
     }
-
-    create_git_repository "forked_awesome"
-    create_git_release "forked_awesome", "0.1.0", {name: "awesome"}
 
     metadata = {dependencies: {
       intermediate: "*",

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -147,6 +147,8 @@ private def setup_repositories
   create_git_release "awesome", "0.3.0", {
     dependencies: {d: {git: git_url(:d)}},
   }
+  checkout_new_git_branch "forked_awesome", "feature/super"
+  create_git_commit "forked_awesome", "Starting super feature"
 end
 
 private def assert(value, message, file, line)

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -92,7 +92,7 @@ private def setup_repositories
   create_git_repository "transitive"
   create_file "transitive", "src/version.cr", %(require "version"; puts Version::STRING)
   create_git_release "transitive", "0.2.0", {
-    dependencies: {version: {git: git_path(:version)}},
+    dependencies: {version: {git: git_url(:version)}},
     scripts:      {
       postinstall: "crystal build src/version.cr",
     },
@@ -101,7 +101,7 @@ private def setup_repositories
   create_git_repository "transitive_2"
   create_git_release "transitive_2", "0.1.0", {
     dependencies: {
-      transitive: {git: git_path(:transitive)},
+      transitive: {git: git_url(:transitive)},
     },
     scripts: {
       postinstall: "../transitive/version",
@@ -117,8 +117,8 @@ private def setup_repositories
   create_git_release "binary", "0.2.0", {executables: ["foobar", "baz", "foo"]}
 
   create_git_repository "c"
-  create_git_release "c", "0.1.0", {dependencies: {d: {git: git_path("d"), version: "0.1.0"}}}
-  create_git_release "c", "0.2.0", {dependencies: {d: {git: git_path("d"), version: "0.2.0"}}}
+  create_git_release "c", "0.1.0", {dependencies: {d: {git: git_url(:d), version: "0.1.0"}}}
+  create_git_release "c", "0.2.0", {dependencies: {d: {git: git_url(:d), version: "0.2.0"}}}
   create_git_repository "d"
   create_git_release "d", "0.1.0"
   create_git_release "d", "0.2.0"

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -196,7 +196,7 @@ private def source_from_named_tuple(source : NamedTuple)
 end
 
 private def source_from_resolver(resolver : Shards::Resolver)
-  "#{resolver.class.key}: #{resolver.source}"
+  resolver.yaml_source_entry
 end
 
 def refute_locked(name, version = nil, file = __FILE__, line = __LINE__)

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -128,6 +128,9 @@ private def setup_repositories
   create_git_release "incompatible", "0.2.0", {crystal: "0.2.0"}
   create_git_release "incompatible", "0.3.0", {crystal: "0.4"}
   create_git_release "incompatible", "1.0.0", {crystal: "1.0.0"}
+
+  create_git_repository "awesome", "0.1.0"
+  create_fork_git_repository "forked_awesome", "awesome"
 end
 
 private def assert(value, message, file, line)

--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -321,4 +321,18 @@ describe "update" do
       assert_installed "d", "0.2.0", source: {git: git_url(:d)}
     end
   end
+
+  it "can update to forked branch after lock" do
+    metadata = {dependencies: {awesome: {git: git_url(:forked_awesome), branch: "feature/super"}}}
+    lock = {awesome: "0.1.0", d: "0.1.0"}
+
+    with_shard(metadata, lock) do
+      assert_locked "awesome", "0.1.0", source: {git: git_url(:awesome)}
+
+      run "shards update --no-color"
+
+      assert_locked "awesome", "0.2.0", git: git_commits(:forked_awesome).first
+      assert_installed "awesome", "0.2.0", git: git_commits(:forked_awesome).first
+    end
+  end
 end

--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -329,7 +329,7 @@ describe "update" do
     with_shard(metadata, lock) do
       assert_locked "awesome", "0.1.0", source: {git: git_url(:awesome)}
 
-      run "shards update --no-color"
+      run "shards update"
 
       assert_locked "awesome", "0.2.0", git: git_commits(:forked_awesome).first
       assert_installed "awesome", "0.2.0", git: git_commits(:forked_awesome).first

--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -274,4 +274,51 @@ describe "update" do
     with_shard(metadata) { run("shards update") }
     assert_locked "local_cache", "3.0"
   end
+
+  it "updates when dependency source changed" do
+    metadata = {dependencies: {web: {path: git_path(:web)}}}
+    lock = {web: "2.1.0"}
+
+    with_shard(metadata, lock) do
+      assert_locked "web", "2.1.0", source: {git: git_url(:web)}
+
+      run "shards update"
+
+      assert_locked "web", "2.1.0", source: {path: git_path(:web)}
+      assert_installed "web", "2.1.0", source: {path: git_path(:web)}
+    end
+  end
+
+  it "keeping installed version requires constraint in shard.yml" do
+    # forked_awesome has 0.2.0
+    metadata = {dependencies: {awesome: {git: git_url(:forked_awesome), version: "~> 0.1.0"}}}
+    lock = {awesome: "0.1.0"}
+
+    with_shard(metadata, lock) do
+      assert_locked "awesome", "0.1.0", source: {git: git_url(:awesome)}
+
+      run "shards update"
+
+      assert_locked "awesome", "0.1.0", source: {git: git_url(:forked_awesome)}
+      assert_installed "awesome", "0.1.0", source: {git: git_url(:forked_awesome)}
+    end
+  end
+
+  it "bumps nested dependencies locked when main dependency source changed" do
+    metadata = {dependencies: {awesome: {git: git_url(:forked_awesome)}}}
+    lock = {awesome: "0.1.0", d: "0.1.0"}
+
+    with_shard(metadata, lock) do
+      assert_locked "awesome", "0.1.0", source: {git: git_url(:awesome)}
+      assert_locked "d", "0.1.0", source: {git: git_url(:d)}
+
+      # d is not a top dependency, so it is bumped since it's required only by awesome
+      run "shards update awesome"
+
+      assert_locked "awesome", "0.2.0", source: {git: git_url(:forked_awesome)}
+      assert_locked "d", "0.2.0", source: {git: git_url(:d)}
+      assert_installed "awesome", "0.2.0", source: {git: git_url(:forked_awesome)}
+      assert_installed "d", "0.2.0", source: {git: git_url(:d)}
+    end
+  end
 end

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -41,7 +41,10 @@ def create_git_version_commit(project, version, shard : Bool | NamedTuple = true
       create_shard project, version, contents
     end
     Dir.cd(git_path(project)) do
-      run "git add src/#{project}.cr"
+      name = shard[:name]? if shard.is_a?(NamedTuple)
+      name ||= project
+      run "touch src/#{name}.cr"
+      run "git add src/#{name}.cr"
     end
     create_git_commit project, "release: v#{version}"
   end

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -28,6 +28,12 @@ def create_git_repository(project, *versions)
   versions.each { |version| create_git_release project, version }
 end
 
+def create_fork_git_repository(project, upstream)
+  Dir.cd(tmp_path) do
+    run "git clone #{git_url(upstream)} #{project}"
+  end
+end
+
 def create_git_version_commit(project, version, shard : Bool | NamedTuple = true)
   Dir.cd(git_path(project)) do
     if shard

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -37,7 +37,9 @@ module Shards
       private def validate(packages)
         packages.each do |package|
           if lock = locks.shards.find { |d| d.name == package.name }
-            if version = lock.requirement.as?(Shards::Version)
+            if lock.resolver != package.resolver
+              raise LockConflict.new("#{package.name} source changed")
+            elsif version = lock.requirement.as?(Shards::Version)
               validate_locked_version(package, version)
             else
               raise InvalidLock.new # unknown lock resolver

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -88,8 +88,8 @@ module Shards
       private def outdated_lockfile?(packages)
         return true if locks.version != Shards::Lock::CURRENT_VERSION
         return true if packages.size != locks.shards.size
-        a = packages.to_h { |x| {x.name, x.version} }
-        b = locks.shards.to_h { |x| {x.name, x.requirement.as?(Shards::Version)} }
+        a = packages.to_h { |x| {x.name, {x.resolver.class.key, x.resolver.source, x.version}} }
+        b = locks.shards.to_h { |x| {x.name, {x.resolver.class.key, x.resolver.source, x.requirement.as?(Shards::Version)}} }
         a != b
       end
     end

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -33,13 +33,14 @@ module Shards
             lock.requirement = versions.first
           end
 
+        check_single_resolver_by_name dep.resolver
         base.add_vertex(lock.name, lock, true)
+
         # Use the resolver from dependencies (not lock) if available.
         # This is to allow changing source without bumping the version when possible.
         if dep.resolver != lock.resolver
           Log.warn { "Ignoring source of \"#{dep.name}\" on shard.lock" }
         end
-        check_single_resolver_by_name dep.resolver
         spec = dep.resolver.spec(lock_version)
 
         spec.dependencies.each do |dep|
@@ -64,8 +65,6 @@ module Shards
             if version = lock.requirement.as?(Version)
               next unless dep.matches?(version)
             end
-
-            # next if dep.resolver != lock.resolver
 
             add_lock(base, lock_index, dep)
           end

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -62,6 +62,8 @@ module Shards
               next unless dep.matches?(version)
             end
 
+            next if dep.resolver != lock.resolver
+
             add_lock(base, lock_index, dep.name)
           end
         end

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -99,18 +99,15 @@ module Shards
       "git"
     end
 
-    def self.build(key : String, name : String, source : String)
-      expanded_source =
-        case key
-        when "git"
-          source
-        when "github", "bitbucket", "gitlab"
-          "https://#{key}.com/#{source}.git"
-        else
-          raise "Unknown resolver #{key}"
-        end
-
-      new(name, expanded_source)
+    def self.normalize_key_source(key : String, source : String) : {String, String}
+      case key
+      when "git"
+        {"git", source}
+      when "github", "bitbucket", "gitlab"
+        {"git", "https://#{key}.com/#{source}.git"}
+      else
+        raise "Unknown resolver #{key}"
+      end
     end
 
     protected def self.has_git_command?

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -139,8 +139,9 @@ module Shards
 
     # abstract def write_requirement(req : Requirement, yaml : YAML::Builder)
 
+    private record ResolverCacheKey, key : String, name : String, source : String
     private RESOLVER_CLASSES = {} of String => Resolver.class
-    private RESOLVER_CACHE   = {} of String => Resolver
+    private RESOLVER_CACHE   = {} of ResolverCacheKey => Resolver
 
     def self.register_resolver(key, resolver)
       RESOLVER_CLASSES[key] = resolver
@@ -163,7 +164,9 @@ module Shards
           self
         end
 
-      RESOLVER_CACHE[name] ||= begin
+      # TODO move source normalization here
+
+      RESOLVER_CACHE[ResolverCacheKey.new(key, name, source)] ||= begin
         resolver_class.build(key, name, source)
       end
     end

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -13,7 +13,12 @@ module Shards
     end
 
     def self.build(key : String, name : String, source : String)
+      _, source = self.normalize_key_source(key, source)
       self.new(name, source)
+    end
+
+    def self.normalize_key_source(key : String, source : String)
+      {key, source}
     end
 
     def ==(other : Resolver)
@@ -164,8 +169,7 @@ module Shards
           self
         end
 
-      # TODO move source normalization here
-
+      key, source = resolver_class.normalize_key_source(key, source)
       RESOLVER_CACHE[ResolverCacheKey.new(key, name, source)] ||= begin
         resolver_class.build(key, name, source)
       end

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -27,6 +27,10 @@ module Shards
       name == other.name && source == other.source
     end
 
+    def yaml_source_entry
+      "#{self.class.key}: #{source}"
+    end
+
     def installed_spec
       return unless installed?
 


### PR DESCRIPTION
Changing the source from git to path in the shard.yml, in the precense of a shard.lock file didn't trigger an update of the lockfile. The `outdated_lockfile?` logic didn't consider all the information that will be used to generate that file (resolver key and source were missing).

Now lock constraints are not added if the resolver from the shard.yml and from the shard.lock differ.

It will now handle better ambiguous sources for the same name. Before this PR one was used because the cache was accessed by name only. Now it depends on name, key and (normalized) source.

The resolver cache needed to be reset in some helper methods on integration specs to avoid misleading results. Well, now that the cache key depends not only in the name that change is not _really needed_, but I think is better to isolate that. The cache was designed for the solver and that is not used in the integration specs.