### PR TITLE
Allow SHARDS_OPTS/--ignore-crystal-version in build & default command

### DIFF
--- a/src/cli.cr
+++ b/src/cli.cr
@@ -32,6 +32,7 @@ module Shards
       opts.on("--version", "Print the `shards` version.") { puts self.version_string; exit }
       opts.on("--production", "Run in release mode. No development dependencies and strict sync between shard.yml and shard.lock.") { self.production = true }
       opts.on("--local", "Don't update remote repositories, use the local cache only.") { self.local = true }
+      opts.on("--ignore-crystal-version", "Do not enforce crystal version restrictions on shards.") { self.ignore_crystal_version = true }
       opts.on("-v", "--verbose", "Increase the log verbosity, printing all debug statements.") { self.set_debug_log_level }
       opts.on("-q", "--quiet", "Decrease the log verbosity, printing only warnings and errors.") { self.set_warning_log_level }
       opts.on("-h", "--help", "Print usage synopsis.") { self.display_help_and_exit(opts) }
@@ -47,7 +48,7 @@ module Shards
         when "install"
           Commands::Install.run(
             path,
-            ignore_crystal_version: args.includes?("--ignore-crystal-version")
+            ignore_crystal_version: self.ignore_crystal_version?
           )
         when "list"
           Commands::List.run(path, tree: args.includes?("--tree"))
@@ -57,13 +58,13 @@ module Shards
             args[1..-1].reject(&.starts_with?("--")),
             print: args.includes?("--print"),
             update: args.includes?("--update"),
-            ignore_crystal_version: args.includes?("--ignore-crystal-version")
+            ignore_crystal_version: self.ignore_crystal_version?
           )
         when "outdated"
           Commands::Outdated.run(
             path,
             prereleases: args.includes?("--pre"),
-            ignore_crystal_version: args.includes?("--ignore-crystal-version")
+            ignore_crystal_version: self.ignore_crystal_version?
           )
         when "prune"
           Commands::Prune.run(path)
@@ -71,7 +72,7 @@ module Shards
           Commands::Update.run(
             path,
             args[1..-1].reject(&.starts_with?("--")),
-            ignore_crystal_version: args.includes?("--ignore-crystal-version")
+            ignore_crystal_version: self.ignore_crystal_version?
           )
         when "version"
           Commands::Version.run(args[1]? || path)
@@ -109,7 +110,7 @@ module Shards
     begin
       Commands::Check.run(path)
     rescue
-      Commands::Install.run(path)
+      Commands::Install.run(path, ignore_crystal_version: self.ignore_crystal_version?)
     end
 
     Commands::Build.run(path, targets, options)

--- a/src/config.cr
+++ b/src/config.cr
@@ -91,4 +91,5 @@ module Shards
 
   class_property? production = false
   class_property? local = false
+  class_property? ignore_crystal_version = false
 end


### PR DESCRIPTION
Follow up of #417.

Add --ignore-crystal-version as OptionParser option so the 

shards --ignore-crystal-version 
or
SHARDS_OPTS=--ignore-crystal-version shards

do not pick --ignore-crystal-version as the command name in args[0]?