### PR TITLE
Fix nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ commands:
             git config --global column.ui always
       - crystal/version
       - checkout
-      - run: make lib SHARDS=none # do not use shards to install lib
+      - run: shards install --ignore-crystal-version
       - run: make
       - run: make test
       - run: crystal tool format --check src spec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ commands:
             git config --global column.ui always
       - crystal/version
       - checkout
-      - crystal/shards-install
+      - run: make lib SHARDS=none # do not use shards to install lib
       - run: make
       - run: make test
       - run: crystal tool format --check src spec


### PR DESCRIPTION
Grab version from lock and install using curl

This will fix shards nightly builds. ~~This is the analogous to https://github.com/crystal-lang/distribution-scripts/pull/71~~ , curl is not available in crystal docker image. This PR uses --ignore-crystal-version