### PR TITLE
Shards overrides

### DIFF
--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -148,7 +148,13 @@ private def setup_repositories
     dependencies: {d: {git: git_url(:d)}},
   }
   checkout_new_git_branch "forked_awesome", "feature/super"
+  create_file "forked_awesome", File.join("src", "super_feature.cr"), ""
   create_git_commit "forked_awesome", "Starting super feature"
+
+  create_git_repository "intermediate"
+  create_git_release "intermediate", "0.1.0", {
+    dependencies: {awesome: {git: git_url(:awesome)}},
+  }
 end
 
 private def assert(value, message, file, line)

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -150,6 +150,7 @@ private def setup_repositories
   checkout_new_git_branch "forked_awesome", "feature/super"
   create_file "forked_awesome", File.join("src", "super_feature.cr"), ""
   create_git_commit "forked_awesome", "Starting super feature"
+  create_git_commit "forked_awesome", "More on super feature"
 
   create_git_repository "intermediate"
   create_git_release "intermediate", "0.1.0", {

--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -439,22 +439,4 @@ describe "update" do
       assert_locked "d", "0.2.0"
     end
   end
-
-  # conflicts with "unlocks subdependency"
-  pending "can update override (without unlocking nested)" do
-    metadata = {dependencies: {
-      intermediate: "*",
-    }}
-    lock = {intermediate: "0.1.0", awesome: "0.1.0", d: "0.1.0"}
-    override = {dependencies: {
-      awesome: {git: git_url(:forked_awesome)}, # latest version of forked_awesome is 0.2.0
-    }}
-
-    with_shard(metadata, lock, override) do
-      run "shards update override"
-
-      assert_installed "d", "0.1.0"
-      assert_locked "d", "0.1.0"
-    end
-  end
 end

--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -335,4 +335,126 @@ describe "update" do
       assert_installed "awesome", "0.2.0", git: git_commits(:forked_awesome).first
     end
   end
+
+  it "can update top dependency with override branch" do
+    metadata = {dependencies: {
+      awesome: "*",
+    }}
+    lock = {awesome: "0.1.0"}
+    override = {dependencies: {
+      awesome: {git: git_url(:forked_awesome), branch: "feature/super"},
+    }}
+    expected_commit = git_commits(:forked_awesome).first
+
+    with_shard(metadata, lock, override) do
+      run "shards update"
+
+      assert_installed "awesome", "0.2.0+git.commit.#{expected_commit}", source: {git: git_url(:forked_awesome)}
+      assert_locked "awesome", "0.2.0+git.commit.#{expected_commit}", source: {git: git_url(:forked_awesome)}
+    end
+  end
+
+  it "can update top dependency override version" do
+    metadata = {dependencies: {
+      awesome: "*",
+    }}
+    lock = {awesome: "0.1.0"}
+    override = {dependencies: {
+      awesome: {git: git_url(:forked_awesome), version: "0.1.0"},
+    }}
+
+    with_shard(metadata, lock, override) do
+      run "shards update"
+
+      assert_installed "awesome", "0.1.0", source: {git: git_url(:forked_awesome)}
+      assert_locked "awesome", "0.1.0", source: {git: git_url(:forked_awesome)}
+    end
+  end
+
+  it "can update to nested override branch" do
+    metadata = {dependencies: {
+      intermediate: "*",
+    }}
+    lock = {intermediate: "0.1.0", awesome: "0.1.0"}
+    override = {dependencies: {
+      awesome: {git: git_url(:forked_awesome), branch: "feature/super"},
+    }}
+    expected_commit = git_commits(:forked_awesome).first
+
+    with_shard(metadata, lock, override) do
+      run "shards update"
+
+      assert_installed "awesome", "0.2.0+git.commit.#{expected_commit}", source: {git: git_url(:forked_awesome)}
+      assert_locked "awesome", "0.2.0+git.commit.#{expected_commit}", source: {git: git_url(:forked_awesome)}
+    end
+  end
+
+  it "can update to nested override version" do
+    metadata = {dependencies: {
+      intermediate: "*",
+    }}
+    lock = {intermediate: "0.1.0", awesome: "0.1.0"}
+    override = {dependencies: {
+      awesome: {git: git_url(:forked_awesome), version: "0.1.0"},
+    }}
+
+    with_shard(metadata, lock, override) do
+      run "shards update"
+
+      assert_installed "awesome", "0.1.0", source: {git: git_url(:forked_awesome)}
+      assert_locked "awesome", "0.1.0", source: {git: git_url(:forked_awesome)}
+    end
+  end
+
+  it "update to nested latest override if no version" do
+    metadata = {dependencies: {
+      intermediate: "*",
+    }}
+    lock = {intermediate: "0.1.0", awesome: "0.1.0"}
+    override = {dependencies: {
+      awesome: {git: git_url(:forked_awesome)}, # latest version of forked_awesome is 0.2.0
+    }}
+
+    with_shard(metadata, lock, override) do
+      run "shards update"
+
+      assert_installed "awesome", "0.2.0", source: {git: git_url(:forked_awesome)}
+      assert_locked "awesome", "0.2.0", source: {git: git_url(:forked_awesome)}
+    end
+  end
+
+  it "updating all with override does unlock nested" do
+    metadata = {dependencies: {
+      intermediate: "*",
+    }}
+    lock = {intermediate: "0.1.0", awesome: "0.1.0", d: "0.1.0"}
+    override = {dependencies: {
+      awesome: {git: git_url(:forked_awesome)}, # latest version of forked_awesome is 0.2.0
+    }}
+
+    with_shard(metadata, lock, override) do
+      run "shards update"
+
+      assert_installed "d", "0.2.0"
+      assert_locked "d", "0.2.0"
+    end
+  end
+
+  # conflicts with "unlocks subdependency"
+  pending "can update override (without unlocking nested)" do
+    metadata = {dependencies: {
+      intermediate: "*",
+    }}
+    lock = {intermediate: "0.1.0", awesome: "0.1.0", d: "0.1.0"}
+    override = {dependencies: {
+      awesome: {git: git_url(:forked_awesome)}, # latest version of forked_awesome is 0.2.0
+    }}
+
+    with_shard(metadata, lock, override) do
+      run "shards update override"
+
+      assert_installed "d", "0.1.0"
+      assert_locked "d", "0.1.0"
+    end
+  end
 end

--- a/spec/support/cli.cr
+++ b/spec/support/cli.cr
@@ -88,8 +88,15 @@ def to_lock_yaml(lock)
 
   YAML.dump({
     version: Shards::Lock::CURRENT_VERSION,
-    shards:  lock.to_a.to_h do |name, version|
-      {name, {git: git_url(name), version: version}}
+    shards:  lock.to_a.to_h do |name, data|
+      if data.is_a?(NamedTuple)
+        git = data[:git]
+        version = data[:version]
+      else
+        git = git_url(name)
+        version = data
+      end
+      {name, {git: git, version: version}}
     end,
   })
 end

--- a/spec/unit/override_spec.cr
+++ b/spec/unit/override_spec.cr
@@ -20,17 +20,14 @@ module Shards
 
       override.dependencies[0].name.should eq("repo")
       override.dependencies[0].resolver.should eq(GitResolver.new("repo", "https://github.com/user/repo.git"))
-      override.dependencies[0].resolver.is_override.should eq(true)
       override.dependencies[0].requirement.should eq(version_req "1.2.3")
 
       override.dependencies[1].name.should eq("example")
       override.dependencies[1].resolver.should eq(GitResolver.new("example", "https://example.com/example-crystal.git"))
-      override.dependencies[1].resolver.is_override.should eq(true)
       override.dependencies[1].requirement.should eq(branch "master")
 
       override.dependencies[2].name.should eq("local")
       override.dependencies[2].resolver.should eq(PathResolver.new("local", "/var/clones/local"))
-      override.dependencies[2].resolver.is_override.should eq(true)
       override.dependencies[2].requirement.should eq(Any)
     end
 

--- a/spec/unit/override_spec.cr
+++ b/spec/unit/override_spec.cr
@@ -1,0 +1,105 @@
+require "./spec_helper"
+require "../../src/override"
+
+module Shards
+  describe Override do
+    it "parses" do
+      override = Override.from_yaml <<-YAML
+      dependencies:
+        repo:
+          github: user/repo
+          version: 1.2.3
+        example:
+          git: https://example.com/example-crystal.git
+          branch: master
+        local:
+          path: /var/clones/local
+      YAML
+
+      override.dependencies.size.should eq(3)
+
+      override.dependencies[0].name.should eq("repo")
+      override.dependencies[0].resolver.should eq(GitResolver.new("repo", "https://github.com/user/repo.git"))
+      override.dependencies[0].resolver.is_override.should eq(true)
+      override.dependencies[0].requirement.should eq(version_req "1.2.3")
+
+      override.dependencies[1].name.should eq("example")
+      override.dependencies[1].resolver.should eq(GitResolver.new("example", "https://example.com/example-crystal.git"))
+      override.dependencies[1].resolver.is_override.should eq(true)
+      override.dependencies[1].requirement.should eq(branch "master")
+
+      override.dependencies[2].name.should eq("local")
+      override.dependencies[2].resolver.should eq(PathResolver.new("local", "/var/clones/local"))
+      override.dependencies[2].resolver.is_override.should eq(true)
+      override.dependencies[2].requirement.should eq(Any)
+    end
+
+    it "fails dependency with duplicate resolver" do
+      expect_raises Shards::ParseError, %(Duplicate resolver mapping for dependency "foo" at line 4, column 5) do
+        Override.from_yaml <<-YAML
+          dependencies:
+            foo:
+              github: user/repo
+              gitlab: user/repo
+          YAML
+      end
+    end
+
+    it "fails dependency with missing resolver" do
+      expect_raises Shards::ParseError, %(Missing resolver for dependency "foo" at line 2, column 3) do
+        Override.from_yaml <<-YAML
+          dependencies:
+            foo:
+              branch: master
+          YAML
+      end
+    end
+
+    it "accepts dependency with extra attributes" do
+      override = Override.from_yaml <<-YAML
+        dependencies:
+          foo:
+            github: user/repo
+            extra: foobar
+        YAML
+      dep = Dependency.new("foo", GitResolver.new("foo", "https://github.com/user/repo.git"), Any)
+      override.dependencies[0].should eq dep
+    end
+
+    it "skips unknown attributes" do
+      override = Override.from_yaml("\nanme: test\ncustom:\n  test: more\nname: test\nversion: 1\n")
+      override.dependencies.should be_empty
+    end
+
+    it "raises on unknown attributes if validating" do
+      expect_raises(ParseError, "unknown attribute: deps") { Override.from_yaml("deps:", validate: true) }
+    end
+
+    it "fails to parse dependencies" do
+      str = <<-YAML
+      dependencies:
+        github: spalger/crystal-mime
+        branch: master
+      YAML
+      expect_raises(ParseError) { Override.from_yaml(str) }
+    end
+
+    it "errors on duplicate attributes" do
+      expect_raises(ParseError, %(duplicate attribute "dependencies")) do
+        Override.from_yaml <<-YAML
+          dependencies:
+            bar:
+              github: foo/bar
+          dependencies:
+            baz:
+              github: foo/baz
+        YAML
+      end
+    end
+
+    it "parses empty dependencies" do
+      override = Override.from_yaml("dependencies: {}\n")
+      override.dependencies.should be_empty
+    end
+  end
+end

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -7,7 +7,7 @@ module Shards
       def run(*, ignore_crystal_version = false)
         Log.info { "Resolving dependencies" }
 
-        solver = MolinilloSolver.new(spec, ignore_crystal_version: ignore_crystal_version)
+        solver = MolinilloSolver.new(spec, override, ignore_crystal_version: ignore_crystal_version)
 
         if lockfile?
           # install must be as conservative as possible:

--- a/src/commands/lock.cr
+++ b/src/commands/lock.cr
@@ -7,7 +7,7 @@ module Shards
       def run(shards : Array(String), print = false, update = false, *, ignore_crystal_version = false)
         Log.info { "Resolving dependencies" }
 
-        solver = MolinilloSolver.new(spec, ignore_crystal_version: ignore_crystal_version)
+        solver = MolinilloSolver.new(spec, override, ignore_crystal_version: ignore_crystal_version)
 
         if lockfile?
           if update

--- a/src/commands/lock.cr
+++ b/src/commands/lock.cr
@@ -28,7 +28,7 @@ module Shards
         return if packages.empty?
 
         if print
-          Shards::Lock.write(packages, STDOUT)
+          Shards::Lock.write(packages, @override_path, STDOUT)
         else
           write_lockfile(packages)
         end

--- a/src/commands/outdated.cr
+++ b/src/commands/outdated.cr
@@ -13,7 +13,7 @@ module Shards
 
         Log.info { "Resolving dependencies" }
 
-        solver = MolinilloSolver.new(spec, prereleases: @prereleases, ignore_crystal_version: ignore_crystal_version)
+        solver = MolinilloSolver.new(spec, override, prereleases: @prereleases, ignore_crystal_version: ignore_crystal_version)
         solver.prepare(development: !Shards.production?)
 
         packages = handle_resolver_errors { solver.solve }

--- a/src/commands/update.cr
+++ b/src/commands/update.cr
@@ -7,7 +7,7 @@ module Shards
       def run(shards : Array(String), *, ignore_crystal_version = false)
         Log.info { "Resolving dependencies" }
 
-        solver = MolinilloSolver.new(spec, ignore_crystal_version: ignore_crystal_version)
+        solver = MolinilloSolver.new(spec, override, ignore_crystal_version: ignore_crystal_version)
 
         if lockfile? && !shards.empty?
           # update selected dependencies to latest possible versions, but

--- a/src/config.cr
+++ b/src/config.cr
@@ -1,9 +1,10 @@
 require "./info"
 
 module Shards
-  SPEC_FILENAME = "shard.yml"
-  LOCK_FILENAME = "shard.lock"
-  INSTALL_DIR   = "lib"
+  SPEC_FILENAME     = "shard.yml"
+  LOCK_FILENAME     = "shard.lock"
+  OVERRIDE_FILENAME = "shard.override.yml"
+  INSTALL_DIR       = "lib"
 
   DEFAULT_COMMAND = "install"
   DEFAULT_VERSION = "0"

--- a/src/config.cr
+++ b/src/config.cr
@@ -65,6 +65,10 @@ module Shards
   def self.bin_path=(@@bin_path : String)
   end
 
+  def self.global_override_filename
+    ENV["SHARDS_OVERRIDE"]?.try { |p| File.expand_path(p) }
+  end
+
   def self.crystal_version
     @@crystal_version ||= without_prerelease(ENV["CRYSTAL_VERSION"]? || begin
       output = IO::Memory.new

--- a/src/dependency.cr
+++ b/src/dependency.cr
@@ -11,7 +11,7 @@ module Shards
     def initialize(@name : String, @resolver : Resolver, @requirement : Requirement = Any)
     end
 
-    def self.from_yaml(pull : YAML::PullParser, *, is_lock = false)
+    def self.from_yaml(pull : YAML::PullParser, *, is_lock = false, is_override = false)
       mapping_start = pull.location
       name = pull.read_scalar
       pull.read_mapping do
@@ -37,7 +37,12 @@ module Shards
           raise YAML::ParseException.new("Missing resolver for dependency #{name.inspect}", *mapping_start)
         end
 
-        resolver = resolver_data[:type].find_resolver(resolver_data[:key], name, resolver_data[:source])
+        unless is_override
+          resolver = resolver_data[:type].find_resolver(resolver_data[:key], name, resolver_data[:source])
+        else
+          resolver = resolver_data[:type].build_override_resolver(resolver_data[:key], name, resolver_data[:source])
+        end
+
         requirement = resolver.parse_requirement(params)
         if is_lock && requirement.is_a?(VersionReq)
           requirement = Version.new(requirement.to_s)

--- a/src/dependency.cr
+++ b/src/dependency.cr
@@ -11,7 +11,7 @@ module Shards
     def initialize(@name : String, @resolver : Resolver, @requirement : Requirement = Any)
     end
 
-    def self.from_yaml(pull : YAML::PullParser, *, is_lock = false, is_override = false)
+    def self.from_yaml(pull : YAML::PullParser, *, is_lock = false)
       mapping_start = pull.location
       name = pull.read_scalar
       pull.read_mapping do
@@ -37,11 +37,7 @@ module Shards
           raise YAML::ParseException.new("Missing resolver for dependency #{name.inspect}", *mapping_start)
         end
 
-        unless is_override
-          resolver = resolver_data[:type].find_resolver(resolver_data[:key], name, resolver_data[:source])
-        else
-          resolver = resolver_data[:type].build_override_resolver(resolver_data[:key], name, resolver_data[:source])
-        end
+        resolver = resolver_data[:type].find_resolver(resolver_data[:key], name, resolver_data[:source])
 
         requirement = resolver.parse_requirement(params)
         if is_lock && requirement.is_a?(VersionReq)

--- a/src/lock.cr
+++ b/src/lock.cr
@@ -55,7 +55,7 @@ module Shards
     end
 
     def self.write(packages : Array(Package), override_path : String?, io : IO)
-      if packages.any?(&.resolver.is_override)
+      if packages.any?(&.is_override)
         io << "# WARNING: This lockfile was generated using also #{override_path}\n"
       end
       io << "version: #{CURRENT_VERSION}\n"
@@ -64,7 +64,7 @@ module Shards
       packages.sort_by!(&.name).each do |package|
         key = package.resolver.class.key
 
-        io << "  " << package.name << ":#{package.resolver.is_override ? " # Overridden" : nil}\n"
+        io << "  " << package.name << ":#{package.is_override ? " # Overridden" : nil}\n"
         io << "    " << key << ": " << package.resolver.source << '\n'
         io << "    version: " << package.version.value << '\n'
         io << '\n'

--- a/src/lock.cr
+++ b/src/lock.cr
@@ -56,7 +56,7 @@ module Shards
 
     def self.write(packages : Array(Package), override_path : String?, io : IO)
       if packages.any?(&.is_override)
-        io << "# WARNING: This lockfile was generated using also #{override_path}\n"
+        io << "# NOTICE: This lockfile contains some overrides from #{override_path}\n"
       end
       io << "version: #{CURRENT_VERSION}\n"
       io << "shards:\n"

--- a/src/lock.cr
+++ b/src/lock.cr
@@ -48,15 +48,15 @@ module Shards
       pull.close if pull
     end
 
-    def self.write(packages : Array(Package), path : String)
+    def self.write(packages : Array(Package), override_path : String?, path : String)
       File.open(path, "w") do |file|
-        write(packages, file)
+        write(packages, override_path, file)
       end
     end
 
-    def self.write(packages : Array(Package), io : IO)
+    def self.write(packages : Array(Package), override_path : String?, io : IO)
       if packages.any?(&.resolver.is_override)
-        io << "# WARNING: This lockfile was generated using also a shard.override.yml file\n"
+        io << "# WARNING: This lockfile was generated using also #{override_path}\n"
       end
       io << "version: #{CURRENT_VERSION}\n"
       io << "shards:\n"

--- a/src/lock.cr
+++ b/src/lock.cr
@@ -55,13 +55,16 @@ module Shards
     end
 
     def self.write(packages : Array(Package), io : IO)
+      if packages.any?(&.resolver.is_override)
+        io << "# WARNING: This lockfile was generated using also a shard.override.yml file\n"
+      end
       io << "version: #{CURRENT_VERSION}\n"
       io << "shards:\n"
 
       packages.sort_by!(&.name).each do |package|
         key = package.resolver.class.key
 
-        io << "  " << package.name << ":\n"
+        io << "  " << package.name << ":#{package.resolver.is_override ? " # Overridden" : nil}\n"
         io << "    " << key << ": " << package.resolver.source << '\n'
         io << "    version: " << package.version.value << '\n'
         io << '\n'

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -156,7 +156,7 @@ module Shards
     end
 
     def on_override(dependency : Dependency | Shards::Spec) : Dependency?
-      @override.try(&.dependencies.find { |o| name_for(o) == name_for(dependency) })
+      @override.try(&.dependencies.find { |o| o.name == dependency.name })
     end
 
     def apply_overrides(deps : Array(Dependency))

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -44,6 +44,7 @@ module Shards
         spec = dep.resolver.spec(lock_version)
 
         spec.dependencies.each do |dep|
+          dep = on_override(dep) || dep
           add_lock(base, lock_index, dep)
         end
       end
@@ -55,6 +56,7 @@ module Shards
              else
                @spec.dependencies
              end
+      deps = deps.map { |dep| on_override(dep) || dep }
 
       base = Molinillo::DependencyGraph(Dependency, Dependency).new
       if locks = @locks

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -172,11 +172,13 @@ module Shards
     end
 
     def dependencies_for(specification : S) : Array(R)
-      return apply_overrides(specification.dependencies) if specification.name == "crystal"
-      return apply_overrides(specification.dependencies) if @ignore_crystal_version
+      spec_dependencies = apply_overrides(specification.dependencies)
+
+      return spec_dependencies if specification.name == "crystal"
+      return spec_dependencies if @ignore_crystal_version
 
       crystal_dependency = Dependency.new("crystal", CrystalResolver::INSTANCE, MolinilloSolver.crystal_version_req(specification))
-      apply_overrides(specification.dependencies) + [crystal_dependency]
+      spec_dependencies + [crystal_dependency]
     end
 
     def self.crystal_version_req(specification : Shards::Spec)

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -208,6 +208,8 @@ module Shards
     private def versions_for(dependency, resolver) : Array(Version)
       check_single_resolver_by_name resolver
 
+      return resolver.versions_for(Any) if resolver.is_override
+
       matching = resolver.versions_for(dependency.requirement)
 
       if (locks = @locks) &&

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -98,7 +98,7 @@ module Shards
         resolver = spec.resolver || raise "BUG: returned Spec has no resolver"
         version = spec.version
 
-        packages << Package.new(spec.name, resolver, version)
+        packages << Package.new(spec.name, resolver, version, !on_override(spec).nil?)
       end
 
       packages
@@ -156,7 +156,7 @@ module Shards
       end
     end
 
-    def on_override(dependency : Dependency) : Dependency?
+    def on_override(dependency : Dependency | Shards::Spec) : Dependency?
       @override.try(&.dependencies.find { |o| name_for(o) == name_for(dependency) })
     end
 
@@ -209,7 +209,7 @@ module Shards
 
       matching = resolver.versions_for(dependency.requirement)
 
-      if !resolver.is_override &&
+      if on_override(dependency).nil? &&
          (locks = @locks) &&
          (locked = locks.find { |dep| dep.name == dependency.name }) &&
          (locked_version = locked.requirement.as?(Version)) &&

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -212,8 +212,7 @@ module Shards
 
       matching = resolver.versions_for(dependency.requirement)
 
-      if on_override(dependency).nil? &&
-         (locks = @locks) &&
+      if (locks = @locks) &&
          (locked = locks.find { |dep| dep.name == dependency.name }) &&
          (locked_version = locked.requirement.as?(Version)) &&
          dependency.matches?(locked_version)

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -138,10 +138,10 @@ module Shards
     @specs = Hash({String, Version}, Spec).new
 
     def search_for(dependency : R) : Array(S)
-      resolver = dependency.resolver
-      check_single_resolver_by_name resolver
+      check_single_resolver_by_name dependency.resolver
 
       @search_results[{dependency.name, dependency.requirement}] ||= begin
+        resolver = dependency.resolver
         versions = Versions.sort(versions_for(dependency, resolver)).reverse
         result = versions.map do |version|
           @specs[{dependency.name, version}] ||= begin

--- a/src/override.cr
+++ b/src/override.cr
@@ -1,0 +1,69 @@
+require "colorize"
+require "./ext/yaml"
+require "./config"
+require "./dependency"
+require "./errors"
+require "./target"
+
+module Shards
+  class Override
+    def self.from_file(path, validate = false)
+      path = File.join(path, OVERRIDE_FILENAME) if File.directory?(path)
+      raise Error.new("Missing #{File.basename(path)}") unless File.exists?(path)
+      from_yaml(File.read(path), path, validate)
+    end
+
+    def self.from_yaml(input, filename = OVERRIDE_FILENAME, validate = false)
+      parser = YAML::PullParser.new(input)
+      parser.read_stream do
+        parser.read_document do
+          new(parser, validate)
+        end
+      end
+    rescue ex : YAML::ParseException
+      raise ParseError.new(ex.message, input, filename, ex.line_number, ex.column_number)
+    ensure
+      parser.close if parser
+    end
+
+    def initialize(@resolver : Resolver? = nil)
+      @read_from_yaml = false
+    end
+
+    property resolver : Resolver?
+    getter? read_from_yaml : Bool
+
+    # :nodoc:
+    def initialize(pull : YAML::PullParser, validate = false)
+      pull.each_in_mapping do
+        line, column = pull.location
+
+        case key = pull.read_scalar
+        when "dependencies"
+          check_duplicate(@dependencies, "dependencies", line, column)
+          pull.each_in_mapping do
+            dependencies << Dependency.from_yaml(pull, is_override: true)
+          end
+        else
+          if validate
+            pull.raise "unknown attribute: #{key}", line, column
+          else
+            pull.skip
+          end
+        end
+      end
+
+      @read_from_yaml = true
+    end
+
+    private def check_duplicate(argument, name, line, column)
+      unless argument.nil?
+        raise YAML::ParseException.new("duplicate attribute #{name.inspect}", line, column)
+      end
+    end
+
+    def dependencies
+      @dependencies ||= [] of Dependency
+    end
+  end
+end

--- a/src/override.cr
+++ b/src/override.cr
@@ -27,11 +27,9 @@ module Shards
     end
 
     def initialize(@resolver : Resolver? = nil)
-      @read_from_yaml = false
     end
 
     property resolver : Resolver?
-    getter? read_from_yaml : Bool
 
     # :nodoc:
     def initialize(pull : YAML::PullParser, validate = false)
@@ -52,8 +50,6 @@ module Shards
           end
         end
       end
-
-      @read_from_yaml = true
     end
 
     private def check_duplicate(argument, name, line, column)

--- a/src/override.cr
+++ b/src/override.cr
@@ -42,7 +42,7 @@ module Shards
         when "dependencies"
           check_duplicate(@dependencies, "dependencies", line, column)
           pull.each_in_mapping do
-            dependencies << Dependency.from_yaml(pull, is_override: true)
+            dependencies << Dependency.from_yaml(pull)
           end
         else
           if validate

--- a/src/package.cr
+++ b/src/package.cr
@@ -5,9 +5,10 @@ module Shards
     getter name : String
     getter resolver : Resolver
     getter version : Version
+    getter is_override : Bool
     @spec : Spec?
 
-    def initialize(@name, @resolver, @version)
+    def initialize(@name, @resolver, @version, @is_override)
     end
 
     def report_version

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -179,6 +179,9 @@ module Shards
       case ref
       when GitCommitRef
         ref =~ git_ref(version)
+      when GitBranchRef, GitHeadRef
+        # TODO: check if version is the branch
+        version.has_metadata?
       else
         # TODO: check branch and tags
         true

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -8,7 +8,6 @@ module Shards
   abstract class Resolver
     getter name : String
     getter source : String
-    property is_override : Bool = false
 
     def initialize(@name : String, @source : String)
     end
@@ -171,13 +170,6 @@ module Shards
       RESOLVER_CACHE[ResolverCacheKey.new(key, name, source)] ||= begin
         resolver_class.build(key, name, source)
       end
-    end
-
-    def self.build_override_resolver(key : String, name : String, source : String)
-      resolver_class, key, source = prepare_build_args(key, name, source)
-      resolver = resolver_class.build(key, name, source)
-      resolver.is_override = true
-      resolver
     end
 
     private def self.prepare_build_args(key, name, source)

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -165,14 +165,6 @@ module Shards
     end
 
     def self.find_resolver(key : String, name : String, source : String)
-      resolver_class, key, source = prepare_build_args(key, name, source)
-
-      RESOLVER_CACHE[ResolverCacheKey.new(key, name, source)] ||= begin
-        resolver_class.build(key, name, source)
-      end
-    end
-
-    private def self.prepare_build_args(key, name, source)
       resolver_class =
         if self == Resolver
           RESOLVER_CLASSES[key]? ||
@@ -183,7 +175,9 @@ module Shards
 
       key, source = resolver_class.normalize_key_source(key, source)
 
-      {resolver_class, key, source}
+      RESOLVER_CACHE[ResolverCacheKey.new(key, name, source)] ||= begin
+        resolver_class.build(key, name, source)
+      end
     end
   end
 end

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -8,6 +8,7 @@ module Shards
   abstract class Resolver
     getter name : String
     getter source : String
+    property is_override : Bool = false
 
     def initialize(@name : String, @source : String)
     end
@@ -165,6 +166,21 @@ module Shards
     end
 
     def self.find_resolver(key : String, name : String, source : String)
+      resolver_class, key, source = prepare_build_args(key, name, source)
+
+      RESOLVER_CACHE[ResolverCacheKey.new(key, name, source)] ||= begin
+        resolver_class.build(key, name, source)
+      end
+    end
+
+    def self.build_override_resolver(key : String, name : String, source : String)
+      resolver_class, key, source = prepare_build_args(key, name, source)
+      resolver = resolver_class.build(key, name, source)
+      resolver.is_override = true
+      resolver
+    end
+
+    private def self.prepare_build_args(key, name, source)
       resolver_class =
         if self == Resolver
           RESOLVER_CLASSES[key]? ||
@@ -174,9 +190,8 @@ module Shards
         end
 
       key, source = resolver_class.normalize_key_source(key, source)
-      RESOLVER_CACHE[ResolverCacheKey.new(key, name, source)] ||= begin
-        resolver_class.build(key, name, source)
-      end
+
+      {resolver_class, key, source}
     end
   end
 end


### PR DESCRIPTION
Implements most of #412 .

Reads a `shard.override.yml` (or the file specified by `SHARDS_OVERRIDE`) to override the source and restriction of a dependency. There are no changes regarding CLI options of shards.

This allows the cases described in the motivation of #412

* Use local working copies
* Use a shard version despite published constraints
* Fixing a dependency
* Checking app against development version of a dependency

---

### Usage sample

On a project that uses `github:crystal-lang/crystal-sqlite3` it will current use `crysta-db 0.8.0`.

```yaml
# file: shard.yml
name: sample
version: 0.1.0

dependencies:
  sqlite3:
    github: crystal-lang/crystal-sqlite3
    version: ~> 0.15.0

crystal: 0.35.1
```

```yaml
# file: shard.lock
version: 2.0
shards:
  db:
    git: https://github.com/crystal-lang/crystal-db.git
    version: 0.8.0

  sqlite3:
    git: https://github.com/crystal-lang/crystal-sqlite3.git
    version: 0.15.0
```

Let's suppose I need to work on a fix for `crystal-db`. I can create a `shard.override.yml` file pointing to my working copy of `crystal-db`

```yaml
# file: shard.override.yml
dependencies:
  db:
    path: /my/path/to/crystal-db
```

Execute `$ shards update` to change the installed and locked version of `crystal-db`.
(Note: if `$ shards install` is used instead of update, the use will get an error regarding 
that db has ambiguous sources due to the existing shard.lock and the shard.override.yml)

```terminal-session
$ shards update
Resolving dependencies
Fetching https://github.com/crystal-lang/crystal-sqlite3.git
Installing db (0.9.0 at /my/path/to/crystal-db)
Using sqlite3 (0.15.0)
Writing shard.lock
```

After this update you will have a symlink to the /my/path/to/crystal-db

```terminal-session
$ ls -la lib/
total 8
drwxr-xr-x   5 bcardiff  staff  160 Jul 22 11:15 .
drwxr-xr-x  15 bcardiff  staff  480 Jul 22 11:14 ..
-rw-r--r--   1 bcardiff  staff  196 Jul 22 11:15 .shards.info
lrwxr-xr-x   1 bcardiff  staff   43 Jul 22 11:15 db -> /my/path/to/crystal-db
drwxr-xr-x  12 bcardiff  staff  384 Jul 22 11:14 sqlite3
```

And the `shard.lock` has some comments to clarify if the lock was computed with overrides and will not be safe to commit.

```yaml
# file: shard.lock
# WARNING: This lockfile was generated using also shard.override.yml
version: 2.0
shards:
  db: # Overridden
    path: /my/path/to/crystal-db
    version: 0.9.0

  sqlite3:
    git: https://github.com/crystal-lang/crystal-sqlite3.git
    version: 0.15.0
```

Note that in this example we also bump `crystal-db` from 0.8 to 0.9 despite the fact that `crystal-sqlite3` requires `~> 0.8.0`. So we are overriding the requirements along the dependency graph.

You can override to a specific version, branch, fork, local path and solve ambiguos reference in case the ecosystem do not agree what is the main fork for a shard name.

Having a `shard.master.yml` will all dependencies to the master/develop branch will simplify how to check if you the project is up to date with non-released changes of dependencies.

---

Closes #412
Closes #105
Closes #299