### PR TITLE
Remove abstract def run definition

### DIFF
--- a/src/commands/command.cr
+++ b/src/commands/command.cr
@@ -21,8 +21,6 @@ module Shards
       @lockfile_path = File.join(@path, LOCK_FILENAME)
     end
 
-    abstract def run(*args, **kwargs)
-
     def self.run(path, *args, **kwargs)
       new(path).run(*args, **kwargs)
     end


### PR DESCRIPTION
Each command implements a different run. There is no generic Command reference that requires a unified API among all the subclasses.

Required change due to https://github.com/crystal-lang/crystal/pull/9585