### PR TITLE
Fix: reinstall when resolver changes

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -300,6 +300,28 @@ describe "install" do
     end
   end
 
+  it "reinstall when resolver changes" do
+    metadata = {dependencies: {web: {git: git_url(:web)}}}
+    with_shard(metadata) do
+      run "shards install"
+      assert_locked "web", "2.1.0"
+    end
+
+    metadata = {dependencies: {web: {path: rel_path(:web)}}}
+    with_shard(metadata) do
+      run "shards install"
+      assert_locked "web", "2.1.0", source: {path: rel_path(:web)}
+      assert_installed "web", "2.1.0", source: {path: rel_path(:web)}
+    end
+
+    metadata = {dependencies: {web: {git: git_url(:web)}}}
+    with_shard(metadata) do
+      run "shards install"
+      assert_locked "web", "2.1.0", source: {git: git_url(:web)}
+      assert_installed "web", "2.1.0", source: {git: git_url(:web)}
+    end
+  end
+
   it "fails if shard.lock and shard.yml has different sources" do
     # The sources will not match, so the .lock is not valid regarding the specs
     metadata = {dependencies: {awesome: {git: git_url(:forked_awesome)}}}

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -69,6 +69,16 @@ describe "install" do
     end
   end
 
+  it "reinstall if info file is missing (path resolver)" do
+    metadata = {dependencies: {web: {path: rel_path(:web)}}}
+    with_shard(metadata) do
+      run "shards install"
+      File.delete "#{Shards::INSTALL_DIR}/.shards.info"
+      run "shards install"
+      assert_installed "web", "2.1.0"
+    end
+  end
+
   it "deletes old .sha1 files" do
     metadata = {dependencies: {web: "*"}}
     with_shard(metadata) do

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -164,6 +164,7 @@ def assert_installed(name, version = nil, file = __FILE__, line = __LINE__, *, g
   Shards::Resolver.clear_resolver_cache # Parsing Shards::Info might use cache of resolvers. Avoid it
   info = Shards::Info.new(install_path)
   dependency = info.installed[name]?
+  assert dependency, "expected #{name} to be present in the shards.info file", file, line
 
   if dependency && version
     expected_version = git ? "#{version}+git.commit.#{git}" : version

--- a/src/package.cr
+++ b/src/package.cr
@@ -19,8 +19,8 @@ module Shards
     end
 
     def installed?
-      if spec = resolver.installed_spec
-        spec.version == version
+      if installed = Shards.info.installed[name]?
+        installed.resolver == resolver && installed.requirement == version
       else
         false
       end


### PR DESCRIPTION
Currently running an `install` after changing the resolver from `path` to `git` doesn't do anything because `GitResolver` fails to detect that the current install is not what's required.

Now the `Package` uses the `.shards.info` to check that the resolver and version matches to figure out if the dependency is installed.