### PR TITLE
Move install responsibilities from Resolver to Package

### DIFF
--- a/spec/integration/list_spec.cr
+++ b/spec/integration/list_spec.cr
@@ -49,4 +49,15 @@ describe "list" do
       stdout.should contain("    * shoulda (0.1.0)")
     end
   end
+
+  it "show error when dependencies are not installed" do
+    metadata = {
+      dependencies:             {web: "*", orm: "*"},
+      development_dependencies: {mock: "*"},
+    }
+    with_shard(metadata) do
+      ex = expect_raises(FailedCommand) { run "shards list --no-color" }
+      ex.stdout.should contain("Dependencies aren't satisfied. Install them with 'shards install'")
+    end
+  end
 end

--- a/spec/unit/git_resolver_spec.cr
+++ b/spec/unit/git_resolver_spec.cr
@@ -77,25 +77,25 @@ module Shards
     it "install" do
       library = resolver("library")
 
-      library.install(version "0.1.2")
+      library.install_sources(version("0.1.2"), install_path("library"))
       File.exists?(install_path("library", "src/library.cr")).should be_true
       File.exists?(install_path("library", "shard.yml")).should be_true
       Spec.from_file(install_path("library", "shard.yml")).version.should eq(version "0.1.2")
 
-      library.install(version "0.2.0")
+      library.install_sources(version("0.2.0"), install_path("library"))
       Spec.from_file(install_path("library", "shard.yml")).version.should eq(version "0.2.0")
     end
 
     it "install commit" do
       library = resolver("library")
       version = version "0.2.0+git.commit.#{git_commits(:library)[0]}"
-      library.install(version)
+      library.install_sources(version, install_path("library"))
       Spec.from_file(install_path("library", "shard.yml")).version.should eq(version "0.2.0")
     end
 
     it "origin changed" do
       library = GitResolver.new("library", git_url("library"))
-      library.install(version "0.1.2")
+      library.install_sources(version("0.1.2"), install_path("library"))
 
       # Change the origin in the cache repo to https://github.com/foo/bar
       Dir.cd(library.local_path) do

--- a/spec/unit/git_resolver_spec.cr
+++ b/spec/unit/git_resolver_spec.cr
@@ -80,17 +80,17 @@ module Shards
       library.install(version "0.1.2")
       File.exists?(install_path("library", "src/library.cr")).should be_true
       File.exists?(install_path("library", "shard.yml")).should be_true
-      library.installed_spec.not_nil!.version.should eq(version "0.1.2")
+      Spec.from_file(install_path("library", "shard.yml")).version.should eq(version "0.1.2")
 
       library.install(version "0.2.0")
-      library.installed_spec.not_nil!.version.should eq(version "0.2.0")
+      Spec.from_file(install_path("library", "shard.yml")).version.should eq(version "0.2.0")
     end
 
     it "install commit" do
       library = resolver("library")
       version = version "0.2.0+git.commit.#{git_commits(:library)[0]}"
       library.install(version)
-      library.installed_spec.not_nil!.version.should eq(version)
+      Spec.from_file(install_path("library", "shard.yml")).version.should eq(version "0.2.0")
     end
 
     it "origin changed" do

--- a/spec/unit/package_spec.cr
+++ b/spec/unit/package_spec.cr
@@ -1,0 +1,54 @@
+require "./spec_helper"
+require "../../src/package"
+
+private def resolver(name)
+  Shards::PathResolver.new(name, git_path(name))
+end
+
+module Shards
+  describe Package do
+    before_each do
+      create_path_repository "library", "1.2.3"
+    end
+
+    it "installs" do
+      package = Package.new("library", resolver("library"), version "1.2.3")
+      package.installed?.should be_false
+      package.install
+      package.installed?.should be_true
+    end
+
+    it "different version is not installed" do
+      package = Package.new("library", resolver("library"), version "1.2.3")
+      package.install
+
+      package2 = Package.new("library", resolver("library"), version "2.0.0")
+      package2.installed?.should be_false
+    end
+
+    it "different resolver is not installed" do
+      package = Package.new("library", resolver("library"), version "1.2.3")
+      package.install
+
+      package2 = Package.new("library", resolver("foo"), version "1.2.3")
+      package2.installed?.should be_false
+    end
+
+    it "not installed if missing target" do
+      package = Package.new("library", resolver("library"), version "1.2.3")
+      package.install
+
+      run "rm -rf #{install_path("library")}"
+      package.installed?.should be_false
+    end
+
+    it "cleanups target before installing" do
+      Dir.mkdir_p(install_path)
+      File.touch(install_path("library"))
+      package = Package.new("library", resolver("library"), version "1.2.3")
+      package.install
+
+      File.symlink?(install_path("library")).should be_true
+    end
+  end
+end

--- a/spec/unit/package_spec.cr
+++ b/spec/unit/package_spec.cr
@@ -5,10 +5,15 @@ private def resolver(name)
   Shards::PathResolver.new(name, git_path(name))
 end
 
+private def git_resolver(name)
+  Shards::GitResolver.new(name, git_path(name))
+end
+
 module Shards
   describe Package do
     before_each do
       create_path_repository "library", "1.2.3"
+      create_git_repository "repo", "0.1.2", "0.1.3"
     end
 
     it "installs" do
@@ -16,6 +21,32 @@ module Shards
       package.installed?.should be_false
       package.install
       package.installed?.should be_true
+    end
+
+    it "reads spec from installed dir" do
+      package = Package.new("repo", git_resolver("repo"), version "0.1.2")
+      package.install
+
+      File.open(install_path("repo", "shard.yml"), "a") do |f|
+        f.puts "license: FOO"
+      end
+
+      package.spec.license.should eq("FOO")
+    end
+
+    it "fallback to resolver to read spec" do
+      package = Package.new("repo", git_resolver("repo"), version "0.1.2")
+      package.install
+      File.delete install_path("repo", "shard.yml")
+      package.spec.version.should eq(version "0.1.2")
+    end
+
+    it "reads spec from resolver if not installed" do
+      package = Package.new("repo", git_resolver("repo"), version "0.1.3")
+      package.install
+
+      package = Package.new("repo", git_resolver("repo"), version "0.1.2")
+      package.spec.original_version.should eq(version "0.1.2")
     end
 
     it "different version is not installed" do

--- a/spec/unit/path_resolver_spec.cr
+++ b/spec/unit/path_resolver_spec.cr
@@ -20,7 +20,7 @@ module Shards
 
     it "install" do
       resolver("library").tap do |library|
-        library.install(version "1.2.3")
+        library.install_sources(version("1.2.3"), install_path("library"))
         File.exists?(install_path("library", "src/library.cr")).should be_true
         File.exists?(install_path("library", "shard.yml")).should be_true
         Spec.from_file(install_path("library", "shard.yml")).version.should eq(version "1.2.3")
@@ -28,53 +28,8 @@ module Shards
     end
 
     it "install fails when path doesnt exist" do
-      expect_raises(Error) { resolver("unknown").install(version "1.0.0") }
-    end
-
-    it "installed reports library is installed" do
-      resolver("library").tap do |resolver|
-        resolver.installed?.should be_false
-
-        resolver.install(version "1.2.3")
-        resolver.installed?.should be_true
-      end
-    end
-
-    it "installed when target is incorrect link" do
-      resolver("library").tap do |resolver|
-        resolver.install(version "1.2.3")
-        resolver.installed?.should be_true
-      end
-    end
-
-    it "installed when target is incorrect broken link" do
-      resolver("library").tap do |resolver|
-        File.symlink("/does-not-exist", resolver.install_path)
-        resolver.installed?.should be_false
-
-        resolver.install(version "1.2.3")
-        resolver.installed?.should be_true
-      end
-    end
-
-    it "installed when target is dir" do
-      resolver("library").tap do |resolver|
-        Dir.mkdir_p(resolver.install_path)
-        File.touch(File.join(resolver.install_path, "foo"))
-        resolver.installed?.should be_false
-
-        resolver.install(version "1.2.3")
-        resolver.installed?.should be_true
-      end
-    end
-
-    it "installed when target is file" do
-      resolver("library").tap do |resolver|
-        File.touch(resolver.install_path)
-        resolver.installed?.should be_false
-
-        resolver.install(version "1.2.3")
-        resolver.installed?.should be_true
+      expect_raises(Error) do
+        resolver("unknown").install_sources(version("1.0.0"), install_path("unknown"))
       end
     end
 

--- a/spec/unit/path_resolver_spec.cr
+++ b/spec/unit/path_resolver_spec.cr
@@ -23,7 +23,7 @@ module Shards
         library.install(version "1.2.3")
         File.exists?(install_path("library", "src/library.cr")).should be_true
         File.exists?(install_path("library", "shard.yml")).should be_true
-        library.installed_spec.not_nil!.version.should eq(version "1.2.3")
+        Spec.from_file(install_path("library", "shard.yml")).version.should eq(version "1.2.3")
       end
     end
 

--- a/spec/unit/resolver_spec.cr
+++ b/spec/unit/resolver_spec.cr
@@ -17,21 +17,6 @@ module Shards
       resolver.should_not eq(GitResolver.new("name", "/path"))
     end
 
-    describe "#installed_spec" do
-      it "reports parse error location" do
-        create_path_repository "foo", "1.2.3"
-        create_file "foo", "shard.yml", "name: foo\nname: foo\n"
-
-        resolver = Shards::PathResolver.new("foo", git_path("foo"))
-        resolver.install Shards::Version.new("1.2.3")
-
-        error = expect_raises(ParseError, %(Error in foo:spec/unit/.lib/foo/shard.yml: duplicate attribute "name" at line 2, column 1)) do
-          resolver.installed_spec
-        end
-        error.resolver.should eq resolver
-      end
-    end
-
     describe "#spec" do
       it "reports parse error location" do
         create_path_repository "foo", "1.2.3"

--- a/spec/unit/spec_helper.cr
+++ b/spec/unit/spec_helper.cr
@@ -16,12 +16,13 @@ end
 Spec.before_each do
   clear_repositories
   Shards::Resolver.clear_resolver_cache
+  Shards.info.reload
 end
 
 private def clear_repositories
   run "rm -rf #{tmp_path}/*"
-  run "rm -rf #{Shards.cache_path}/*"
-  run "rm -rf #{Shards.install_path}/*"
+  run "rm -rf #{Shards.cache_path}"
+  run "rm -rf #{Shards.install_path}"
 end
 
 def install_path(project, *path_names)

--- a/src/commands/list.cr
+++ b/src/commands/list.cr
@@ -14,19 +14,21 @@ module Shards
 
       private def list(dependencies, level = 1)
         dependencies.each do |dependency|
-          resolver = dependency.resolver
-
-          # FIXME: duplicated from Check#verify
-          unless _spec = resolver.installed_spec
+          installed = Shards.info.installed[dependency.name]
+          unless installed
             Log.debug { "#{dependency.name}: not installed" }
             raise Error.new("Dependencies aren't satisfied. Install them with 'shards install'")
           end
 
+          version = installed.requirement.as(Shards::Version)
+          package = Package.new(installed.name, installed.resolver, version)
+          resolver = installed.resolver
+
           indent = "  " * level
-          puts "#{indent}* #{_spec.name} (#{resolver.report_version _spec.version})"
+          puts "#{indent}* #{dependency.name} (#{resolver.report_version version})"
 
           indent_level = @tree ? level + 1 : level
-          list(_spec.dependencies, indent_level)
+          list(package.spec.dependencies, indent_level)
         end
       end
 

--- a/src/commands/list.cr
+++ b/src/commands/list.cr
@@ -14,7 +14,7 @@ module Shards
 
       private def list(dependencies, level = 1)
         dependencies.each do |dependency|
-          installed = Shards.info.installed[dependency.name]
+          installed = Shards.info.installed[dependency.name]?
           unless installed
             Log.debug { "#{dependency.name}: not installed" }
             raise Error.new("Dependencies aren't satisfied. Install them with 'shards install'")

--- a/src/commands/outdated.cr
+++ b/src/commands/outdated.cr
@@ -29,13 +29,13 @@ module Shards
       end
 
       private def analyze(package)
-        resolver = package.resolver
-        installed = resolver.installed_spec.try(&.version)
-
-        unless installed
+        unless installed_dep = Shards.info.installed[package.name]?
           Log.warn { "#{package.name}: not installed" }
           return
         end
+
+        resolver = package.resolver
+        installed = installed_dep.requirement.as(Shards::Version)
 
         # already the latest version?
         available_versions =

--- a/src/info.cr
+++ b/src/info.cr
@@ -12,6 +12,8 @@ class Shards::Info
     path = info_path
     if File.exists?(path)
       @installed = Lock.from_file(path).shards.index_by &.name
+    else
+      @installed.clear
     end
   end
 

--- a/src/resolvers/crystal.cr
+++ b/src/resolvers/crystal.cr
@@ -14,7 +14,7 @@ module Shards
       nil
     end
 
-    def install_sources(version : Version)
+    def install_sources(version : Version, install_path : String)
       raise NotImplementedError.new("CrystalResolver#install_sources")
     end
 

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -209,7 +209,7 @@ module Shards
       end
     end
 
-    def install_sources(version : Version)
+    def install_sources(version : Version, install_path : String)
       update_local_cache
       ref = git_ref(version)
 

--- a/src/resolvers/path.cr
+++ b/src/resolvers/path.cr
@@ -20,19 +20,6 @@ module Shards
       load_spec(version) || raise Error.new("Can't read spec for #{name.inspect}")
     end
 
-    def installed?
-      File.symlink?(install_path) && check_install_path_target
-    end
-
-    private def check_install_path_target
-      begin
-        real_install_path = File.real_path(install_path)
-      rescue File::NotFoundError
-        return false
-      end
-      real_install_path == expanded_local_path
-    end
-
     def available_releases : Array(Version)
       [spec(nil).version]
     end
@@ -47,7 +34,7 @@ module Shards
       end
     end
 
-    def install_sources(version)
+    def install_sources(version, install_path)
       path = expanded_local_path
 
       Dir.mkdir_p(File.dirname(install_path))

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -81,25 +81,8 @@ module Shards
     end
 
     abstract def read_spec(version : Version) : String?
-    abstract def install_sources(version : Version)
+    abstract def install_sources(version : Version, install_dir : String)
     abstract def report_version(version : Version) : String
-
-    def install(version : Version)
-      cleanup_install_directory
-
-      install_sources(version)
-      Shards.info.installed[name] = Dependency.new(name, self, version)
-      Shards.info.save
-    end
-
-    def install_path
-      File.join(Shards.install_path, name)
-    end
-
-    protected def cleanup_install_directory
-      Log.debug { "rm -rf '#{Helpers::Path.escape(install_path)}'" }
-      FileUtils.rm_rf(install_path)
-    end
 
     def parse_requirement(params : Hash(String, String)) : Requirement
       if version = params["version"]?


### PR DESCRIPTION
This is the first part of a refactor I'm working on to better separate responsibilities between internal entities in Shards. I split these changes in two so it can be reviewed more easily. With this PR the `Resolver` still represents a source to obtain different versions of a shard, but the installation is delegated completely to the `Package` class.

This will make more sense with the second part, where locks and installed packages (`Shards.info.installed`) will return instances of `Package` instead of `Dependency`. In other words, finally the `Dependency` will represent just the intention with some more or less precise definition of which version is desired, while a `Package` represents a specific version that must be or is already installed.

There is a small change in behaviour after this refactor, but I think in the good direction. Now the only source of truth to determine if a shard is already installed is the `.shard.info` file. So the contents of the shard could be manually changed, or the symlink created for a `path` resolver modified but Shards still would assume the dependency is already there and nothing must be done to fix it. Only in the case of a complete removal of the directory or symlink it will reinstall the dependency ignoring what was recorded in the info file.