### PR TITLE
Use Package for locks and installed shards

### DIFF
--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -175,7 +175,7 @@ def assert_installed(name, version = nil, file = __FILE__, line = __LINE__, *, g
 
   if dependency && version
     expected_version = git ? "#{version}+git.commit.#{git}" : version
-    dependency.requirement.should eq(version expected_version), file, line
+    dependency.version.should eq(version expected_version), file, line
   end
 
   if dependency && source
@@ -210,7 +210,7 @@ def assert_locked(name, version = nil, file = __FILE__, line = __LINE__, *, git 
 
   if lock && version
     expected_version = git ? "#{version}+git.commit.#{git}" : version
-    actual_value = lock.requirement.as(Shards::Version).value
+    actual_value = lock.version.value
     assert expected_version == actual_value, "expected #{name} dependency to have been locked at version #{version} instead of #{actual_value}", file, line
   end
 

--- a/spec/unit/info_spec.cr
+++ b/spec/unit/info_spec.cr
@@ -17,13 +17,13 @@ module Shards
       File.write File.join(install_path, ".shards.info"), SAMPLE_INFO
       info = Info.new
       info.installed.should eq({
-        "foo" => Dependency.new("foo", GitResolver.new("foo", "https://example.com/foo.git"), version "1.2.3"),
+        "foo" => Package.new("foo", GitResolver.new("foo", "https://example.com/foo.git"), version "1.2.3"),
       })
     end
 
     it "save changes" do
       info = Info.new
-      dep = Dependency.new("foo", GitResolver.new("foo", "https://example.com/foo.git"), version "1.2.3")
+      dep = Package.new("foo", GitResolver.new("foo", "https://example.com/foo.git"), version "1.2.3")
       info.installed["foo"] = dep
       info.save
 

--- a/spec/unit/lock_spec.cr
+++ b/spec/unit/lock_spec.cr
@@ -4,6 +4,8 @@ require "../../src/lock"
 module Shards
   describe Lock do
     it "parses" do
+      create_git_repository "library", "0.1.0"
+
       lock = Lock.from_yaml <<-YAML
       version: 1.0
       shards:
@@ -11,8 +13,8 @@ module Shards
           github: user/repo
           version: 1.2.3
         example:
-          git: https://example.com/example-crystal.git
-          commit: 0d246ee6c52d4e758651b8669a303f04be9a2a96
+          git: #{git_url(:library)}
+          commit: #{git_commits(:library)[0]}
         new_git:
           git: https://example.com/new.git
           version: 1.2.3+git.commit.0d246ee6c52d4e758651b8669a303f04be9a2a96
@@ -28,22 +30,22 @@ module Shards
 
       shards[0].name.should eq("repo")
       shards[0].resolver.should eq(GitResolver.new("repo", "https://github.com/user/repo.git"))
-      shards[0].requirement.should eq(version "1.2.3")
+      shards[0].version.should eq(version "1.2.3")
       shards[0].to_s.should eq("repo (1.2.3)")
 
       shards[1].name.should eq("example")
-      shards[1].resolver.should eq(GitResolver.new("example", "https://example.com/example-crystal.git"))
-      shards[1].requirement.should eq(commit "0d246ee6c52d4e758651b8669a303f04be9a2a96")
-      shards[1].to_s.should eq("example (commit 0d246ee)")
+      shards[1].resolver.should eq(GitResolver.new("example", git_url(:library)))
+      shards[1].version.should eq(version "0.1.0+git.commit.#{git_commits(:library)[0]}")
+      shards[1].to_s.should eq("example (0.1.0 at #{git_commits(:library)[0][0...7]})")
 
       shards[2].name.should eq("new_git")
       shards[2].resolver.should eq(GitResolver.new("new_git", "https://example.com/new.git"))
-      shards[2].requirement.should eq(version "1.2.3+git.commit.0d246ee6c52d4e758651b8669a303f04be9a2a96")
+      shards[2].version.should eq(version "1.2.3+git.commit.0d246ee6c52d4e758651b8669a303f04be9a2a96")
       shards[2].to_s.should eq("new_git (1.2.3 at 0d246ee)")
 
       shards[3].name.should eq("new_path")
       shards[3].resolver.should eq(PathResolver.new("new_path", "../path"))
-      shards[3].requirement.should eq(version "0.1.2")
+      shards[3].version.should eq(version "0.1.2")
       shards[3].to_s.should eq("new_path (0.1.2 at ../path)")
     end
 

--- a/src/commands/check.cr
+++ b/src/commands/check.cr
@@ -34,18 +34,13 @@ module Shards
           return false
         end
 
-        if version = lock.requirement.as?(Shards::Version)
-          if !dependency.matches?(version)
-            Log.debug { "#{dependency.name}: lock conflict" }
-            return false
-          else
-            package = Package.new(lock.name, lock.resolver, version)
-            return false unless package.installed?
-            verify(package.spec.dependencies)
-            return true
-          end
+        if !dependency.matches?(lock.version)
+          Log.debug { "#{dependency.name}: lock conflict" }
+          return false
         else
-          raise Error.new("Invalid #{LOCK_FILENAME}. Please run `shards install` to fix it.")
+          return false unless lock.installed?
+          verify(lock.spec.dependencies)
+          return true
         end
       end
     end

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -39,10 +39,8 @@ module Shards
           if lock = locks.shards.find { |d| d.name == package.name }
             if lock.resolver != package.resolver
               raise LockConflict.new("#{package.name} source changed")
-            elsif version = lock.requirement.as?(Shards::Version)
-              validate_locked_version(package, version)
             else
-              raise InvalidLock.new # unknown lock resolver
+              validate_locked_version(package, lock.version)
             end
           else
             raise LockConflict.new("can't install new dependency #{package.name} in production")
@@ -91,7 +89,7 @@ module Shards
         return true if locks.version != Shards::Lock::CURRENT_VERSION
         return true if packages.size != locks.shards.size
         a = packages.to_h { |x| {x.name, {x.resolver.class.key, x.resolver.source, x.version}} }
-        b = locks.shards.to_h { |x| {x.name, {x.resolver.class.key, x.resolver.source, x.requirement.as?(Shards::Version)}} }
+        b = locks.shards.to_h { |x| {x.name, {x.resolver.class.key, x.resolver.source, x.version}} }
         a != b
       end
     end

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -88,9 +88,8 @@ module Shards
       private def outdated_lockfile?(packages)
         return true if locks.version != Shards::Lock::CURRENT_VERSION
         return true if packages.size != locks.shards.size
-        a = packages.to_h { |x| {x.name, {x.resolver.class.key, x.resolver.source, x.version}} }
-        b = locks.shards.to_h { |x| {x.name, {x.resolver.class.key, x.resolver.source, x.version}} }
-        a != b
+
+        packages.index_by(&.name) != locks.shards.index_by(&.name)
       end
     end
   end

--- a/src/commands/list.cr
+++ b/src/commands/list.cr
@@ -14,18 +14,14 @@ module Shards
 
       private def list(dependencies, level = 1)
         dependencies.each do |dependency|
-          installed = Shards.info.installed[dependency.name]?
-          unless installed
+          package = Shards.info.installed[dependency.name]?
+          unless package
             Log.debug { "#{dependency.name}: not installed" }
             raise Error.new("Dependencies aren't satisfied. Install them with 'shards install'")
           end
 
-          version = installed.requirement.as(Shards::Version)
-          package = Package.new(installed.name, installed.resolver, version)
-          resolver = installed.resolver
-
           indent = "  " * level
-          puts "#{indent}* #{dependency.name} (#{resolver.report_version version})"
+          puts "#{indent}* #{package}"
 
           indent_level = @tree ? level + 1 : level
           list(package.spec.dependencies, indent_level)

--- a/src/commands/outdated.cr
+++ b/src/commands/outdated.cr
@@ -35,7 +35,7 @@ module Shards
         end
 
         resolver = package.resolver
-        installed = installed_dep.requirement.as(Shards::Version)
+        installed = installed_dep.version
 
         # already the latest version?
         available_versions =

--- a/src/dependency.cr
+++ b/src/dependency.cr
@@ -53,7 +53,7 @@ module Shards
       end
     end
 
-    def as_package
+    def as_package?
       version =
         case req = @requirement
         when VersionReq then Version.new(req.to_s)

--- a/src/dependency.cr
+++ b/src/dependency.cr
@@ -58,6 +58,8 @@ module Shards
         case req = @requirement
         when VersionReq then Version.new(req.to_s)
         else
+          # This conversion is used to keep compatibility
+          # with old versions (1.0) of lock files.
           versions = @resolver.versions_for(req)
           unless versions.size == 1
             return

--- a/src/dependency.cr
+++ b/src/dependency.cr
@@ -11,7 +11,7 @@ module Shards
     def initialize(@name : String, @resolver : Resolver, @requirement : Requirement = Any)
     end
 
-    def self.from_yaml(pull : YAML::PullParser, *, is_lock = false)
+    def self.from_yaml(pull : YAML::PullParser)
       mapping_start = pull.location
       name = pull.read_scalar
       pull.read_mapping do
@@ -40,10 +40,6 @@ module Shards
         resolver = resolver_data[:type].find_resolver(resolver_data[:key], name, resolver_data[:source])
 
         requirement = resolver.parse_requirement(params)
-        if is_lock && requirement.is_a?(VersionReq)
-          requirement = Version.new(requirement.to_s)
-        end
-
         Dependency.new(name, resolver, requirement)
       end
     end
@@ -55,6 +51,21 @@ module Shards
         yaml.scalar resolver.source
         requirement.to_yaml(yaml)
       end
+    end
+
+    def as_package
+      version =
+        case req = @requirement
+        when VersionReq then Version.new(req.to_s)
+        else
+          versions = @resolver.versions_for(req)
+          unless versions.size == 1
+            return
+          end
+          versions.first
+        end
+
+      Package.new(@name, @resolver, version)
     end
 
     def_equals @name, @resolver, @requirement

--- a/src/info.cr
+++ b/src/info.cr
@@ -2,7 +2,7 @@ require "./lock"
 
 class Shards::Info
   getter install_path : String
-  getter installed = Hash(String, Dependency).new
+  getter installed = Hash(String, Package).new
 
   def initialize(@install_path = Shards.install_path)
     reload

--- a/src/lock.cr
+++ b/src/lock.cr
@@ -34,7 +34,7 @@ module Shards
             when "shards"
               pull.each_in_mapping do
                 dep = Dependency.from_yaml(pull)
-                if package = dep.as_package
+                if package = dep.as_package?
                   shards << package
                 else
                   Log.warn { "Lock for shard \"#{dep.name}\" is invalid" }

--- a/src/lock.cr
+++ b/src/lock.cr
@@ -1,14 +1,15 @@
 require "./ext/yaml"
 require "./dependency"
+require "./package"
 
 module Shards
   class Lock
     property version : String
-    property shards : Array(Dependency)
+    property shards : Array(Package)
 
     CURRENT_VERSION = "2.0"
 
-    def initialize(@version : String, @shards : Array(Dependency))
+    def initialize(@version : String, @shards : Array(Package))
     end
 
     def self.from_file(path)
@@ -17,7 +18,7 @@ module Shards
     end
 
     def self.from_yaml(str)
-      dependencies = [] of Dependency
+      shards = [] of Package
 
       pull = YAML::PullParser.new(str)
       pull.read_stream do
@@ -32,13 +33,18 @@ module Shards
             case key = pull.read_scalar
             when "shards"
               pull.each_in_mapping do
-                dependencies << Dependency.from_yaml(pull, is_lock: true)
+                dep = Dependency.from_yaml(pull)
+                if package = dep.as_package
+                  shards << package
+                else
+                  Log.warn { "Lock for shard \"#{dep.name}\" is invalid" }
+                end
               end
             else
               pull.raise "No such attribute #{key} in lock version #{version}"
             end
 
-            Lock.new(version, dependencies)
+            Lock.new(version, shards)
           end
         end
       end

--- a/src/lock.cr
+++ b/src/lock.cr
@@ -33,6 +33,10 @@ module Shards
             case key = pull.read_scalar
             when "shards"
               pull.each_in_mapping do
+                # Shards are parsed as dependencies to keep
+                # compatiblity with version 1.0. Calls to `as_package?`
+                # will use the resolver to convert potential references
+                # to explicit versions used in 2.0 format.
                 dep = Dependency.from_yaml(pull)
                 if package = dep.as_package?
                   shards << package

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -22,7 +22,7 @@ module Shards
     private def add_lock(base, lock_index, dep : Dependency)
       if lock = lock_index.delete(dep.name)
         check_single_resolver_by_name dep.resolver
-        base.add_vertex(lock.name, Dependency.new(lock.name, lock.resolver, lock.version), true)
+        base.add_vertex(lock.name, Dependency.new(lock.name, dep.resolver, lock.version), true)
 
         # Use the resolver from dependencies (not lock) if available.
         # This is to allow changing source without bumping the version when possible.

--- a/src/package.cr
+++ b/src/package.cr
@@ -11,6 +11,8 @@ module Shards
     def initialize(@name, @resolver, @version, @is_override = false)
     end
 
+    def_equals @name, @resolver, @version
+
     def report_version
       resolver.report_version(version)
     end
@@ -44,7 +46,7 @@ module Shards
     def installed?
       return false unless File.exists?(install_path)
       if installed = Shards.info.installed[name]?
-        installed.resolver == resolver && installed.requirement == version
+        installed.resolver == resolver && installed.version == version
       else
         false
       end
@@ -70,7 +72,7 @@ module Shards
         File.symlink(target, lib_path)
       end
 
-      Shards.info.installed[name] = Dependency.new(name, resolver, version)
+      Shards.info.installed[name] = self
       Shards.info.save
     end
 
@@ -114,6 +116,14 @@ module Shards
           FileUtils.cp(source, destination)
         end
       end
+    end
+
+    def to_yaml(builder)
+      Dependency.new(name, resolver, version).to_yaml(builder)
+    end
+
+    def to_s(io)
+      io << name << " (" << report_version << ")"
     end
   end
 end

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -1,6 +1,7 @@
 require "uri"
 require "./resolver"
 require "../versions"
+require "../logger"
 require "../helpers/path"
 
 module Shards


### PR DESCRIPTION
This is the followup from #426. Previously, locks and installed shards were represented as `Dependency` with a `Version` requirement. But that forces to do castings and checks on many places. With this change the code is simplified, and the check for invalid dependency is only done while parsing.