### PR TITLE
Use git's `checkout` feature directly to write out repo files

### DIFF
--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -215,7 +215,7 @@ module Shards
       ref = git_ref(version)
 
       Dir.mkdir_p(install_path)
-      run "git archive --format=tar --prefix= #{ref.to_git_ref} | tar -x -f - -C #{Helpers::Path.escape(install_path)}"
+      run "git --work-tree=#{Helpers::Path.escape(install_path)} checkout #{ref.to_git_ref} -- ."
     end
 
     def commit_sha1_at(ref : GitRef)


### PR DESCRIPTION
to avoid relying on a shell to pipe into `tar`.

Caveat: `git checkout` also updates the index in the repository, but that shouldn't be a problem here (is there even any index in a bare repo to start with?)

This is part of work to bring 'shards' to Windows.
