### PR TITLE
Use Process.quote instead of the old platform-specific helper

### DIFF
--- a/src/commands/prune.cr
+++ b/src/commands/prune.cr
@@ -1,6 +1,5 @@
 require "file_utils"
 require "./command"
-require "../helpers/path"
 
 module Shards
   module Commands
@@ -13,7 +12,7 @@ module Shards
           name = File.basename(path)
 
           if locks.shards.none? { |d| d.name == name }
-            Log.debug { "rm -rf '#{Helpers::Path.escape(path)}'" }
+            Log.debug { "rm -rf '#{Process.quote(path)}'" }
             FileUtils.rm_rf(path)
 
             Shards.info.installed.delete(name)

--- a/src/helpers/path.cr
+++ b/src/helpers/path.cr
@@ -1,9 +1,0 @@
-module Shards
-  module Helpers
-    module Path
-      def self.escape(path)
-        "'#{path.gsub(/'/, "\\'")}'"
-      end
-    end
-  end
-end

--- a/src/package.cr
+++ b/src/package.cr
@@ -77,7 +77,7 @@ module Shards
     end
 
     protected def cleanup_install_directory
-      Log.debug { "rm -rf '#{Helpers::Path.escape(install_path)}'" }
+      Log.debug { "rm -rf #{Process.quote(install_path)}" }
       FileUtils.rm_rf(install_path)
     end
 

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -2,7 +2,6 @@ require "uri"
 require "./resolver"
 require "../versions"
 require "../logger"
-require "../helpers/path"
 
 module Shards
   abstract struct GitRef < Ref
@@ -215,7 +214,7 @@ module Shards
       ref = git_ref(version)
 
       Dir.mkdir_p(install_path)
-      run "git archive --format=tar --prefix= #{ref.to_git_ref} | tar -x -f - -C #{Helpers::Path.escape(install_path)}"
+      run "git archive --format=tar --prefix= #{ref.to_git_ref} | tar -x -f - -C #{Process.quote(install_path)}"
     end
 
     def commit_sha1_at(ref : GitRef)
@@ -313,7 +312,7 @@ module Shards
       # be used interactively.
       # This configuration can be overriden by defining the environment
       # variable `GIT_ASKPASS`.
-      run_in_current_folder "git clone -c core.askPass=true --mirror --quiet -- #{Helpers::Path.escape(git_url)} #{local_path}"
+      run_in_current_folder "git clone -c core.askPass=true --mirror --quiet -- #{Process.quote(git_url)} #{local_path}"
     rescue Error
       raise Error.new("Failed to clone #{git_url}")
     end


### PR DESCRIPTION
This is part of work to bring 'shards' to Windows.
