### PR TITLE
Don't use compile-time shell commands to determine build timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ MOLINILLO_SOURCES = $(shell find lib/molinillo -name '*.cr' 2> /dev/null)
 SOURCES = $(SHARDS_SOURCES) $(MOLINILLO_SOURCES)
 TEMPLATES = src/templates/*.ecr
 
+SHARDS_CONFIG_BUILD_COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null)
+SOURCE_DATE_EPOCH := $(shell (git show -s --format=%ct HEAD || stat -c "%Y" Makefile || stat -f "%m" Makefile) 2> /dev/null)
+EXPORTS := SHARDS_CONFIG_BUILD_COMMIT="$(SHARDS_CONFIG_BUILD_COMMIT)" SOURCE_DATE_EPOCH="$(SOURCE_DATE_EPOCH)"
 DESTDIR ?=
 PREFIX ?= /usr/local
 BINDIR ?= $(DESTDIR)$(PREFIX)/bin
@@ -29,7 +32,7 @@ clean: phony
 
 bin/shards: $(SOURCES) $(TEMPLATES) lib
 	@mkdir -p bin
-	$(CRYSTAL) build $(FLAGS) src/shards.cr -o bin/shards
+	$(EXPORTS) $(CRYSTAL) build $(FLAGS) src/shards.cr -o bin/shards
 
 install: bin/shards phony
 	$(INSTALL) -m 0755 -d "$(BINDIR)" "$(MANDIR)/man1" "$(MANDIR)/man5"

--- a/src/version.cr
+++ b/src/version.cr
@@ -1,7 +1,11 @@
 module Shards
   VERSION    = {{ read_file("#{__DIR__}/../VERSION").chomp }}
-  BUILD_SHA1 = {{ `git log --format=%h -n 1 2>/dev/null || echo ""`.stringify.chomp }}
-  BUILD_DATE = Time.unix({{ (env("SOURCE_DATE_EPOCH") || `date +%s`).to_i }}).to_s("%Y-%m-%d")
+  BUILD_SHA1 = {{ env("SHARDS_CONFIG_BUILD_COMMIT") || "" }}
+  {% if (t = env("SOURCE_DATE_EPOCH")) && !t.empty? %}
+    BUILD_DATE = Time.unix({{t.to_i}}).to_s("%Y-%m-%d")
+  {% else %}
+    BUILD_DATE = ""
+  {% end %}
 
   def self.version_string
     if BUILD_SHA1.empty?


### PR DESCRIPTION
This closely follows https://github.com/crystal-lang/crystal/pull/9088 and moves non-essential shell commands to Makefile, passing the values through environment variables.

This is part of work to bring 'shards' to Windows.
