### PR TITLE
Touch install_path and lockfile to express dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,6 @@ test_integration: bin/shards phony
 lib: shard.lock
 	mkdir -p lib/molinillo
 	$(SHARDS) install || (curl -L $(MOLINILLO_URL) | tar -xzf - -C lib/molinillo --strip-components=1)
-	touch lib
 
 shard.lock: shard.yml
 	$(SHARDS) update

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -1161,6 +1161,9 @@ describe "install" do
         run "shards install"
         File.info("shard.lock").modification_time.should be <= File.info("lib").modification_time
         File.info("shard.yml").modification_time.should be <= File.info("shard.lock").modification_time
+        run "shards install"
+        File.info("shard.lock").modification_time.should be <= File.info("lib").modification_time
+        File.info("shard.yml").modification_time.should be <= File.info("shard.lock").modification_time
       end
     end
 
@@ -1172,6 +1175,7 @@ describe "install" do
         run "shards install"
         File.touch("shard.yml")
         run "shards install"
+        File.info("shard.lock").modification_time.should be <= File.info("lib").modification_time
         File.info("shard.yml").modification_time.should be <= File.info("shard.lock").modification_time
       end
     end

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -1127,4 +1127,29 @@ describe "install" do
       stdout.should contain(%(Using --ignore-crystal-version was not needed. All shards are already compatible with Crystal 1.1.0))
     end
   end
+
+  describe "mtime" do
+    it "mtime lib > shard.lock > shard.yml" do
+      metadata = {dependencies: {
+        web: "*",
+      }}
+      with_shard(metadata) do
+        run "shards install"
+        File.info("shard.lock").modification_time.should be <= File.info("lib").modification_time
+        File.info("shard.yml").modification_time.should be <= File.info("shard.lock").modification_time
+      end
+    end
+
+    it "mtime shard.lock > shard.yml even when unmodified" do
+      metadata = {dependencies: {
+        web: "*",
+      }}
+      with_shard(metadata) do
+        run "shards install"
+        File.touch("shard.yml")
+        run "shards install"
+        File.info("shard.yml").modification_time.should be <= File.info("shard.lock").modification_time
+      end
+    end
+  end
 end

--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -455,6 +455,9 @@ describe "update" do
         run "shards update"
         File.info("shard.lock").modification_time.should be <= File.info("lib").modification_time
         File.info("shard.yml").modification_time.should be <= File.info("shard.lock").modification_time
+        run "shards update"
+        File.info("shard.lock").modification_time.should be <= File.info("lib").modification_time
+        File.info("shard.yml").modification_time.should be <= File.info("shard.lock").modification_time
       end
     end
 
@@ -466,6 +469,7 @@ describe "update" do
         run "shards update"
         File.touch("shard.yml")
         run "shards update"
+        File.info("shard.lock").modification_time.should be <= File.info("lib").modification_time
         File.info("shard.yml").modification_time.should be <= File.info("shard.lock").modification_time
       end
     end

--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -439,4 +439,29 @@ describe "update" do
       assert_locked "d", "0.2.0"
     end
   end
+
+  describe "mtime" do
+    it "mtime lib > shard.lock > shard.yml" do
+      metadata = {dependencies: {
+        web: "*",
+      }}
+      with_shard(metadata) do
+        run "shards update"
+        File.info("shard.lock").modification_time.should be <= File.info("lib").modification_time
+        File.info("shard.yml").modification_time.should be <= File.info("shard.lock").modification_time
+      end
+    end
+
+    it "mtime shard.lock > shard.yml even when unmodified" do
+      metadata = {dependencies: {
+        web: "*",
+      }}
+      with_shard(metadata) do
+        run "shards update"
+        File.touch("shard.yml")
+        run "shards update"
+        File.info("shard.yml").modification_time.should be <= File.info("shard.lock").modification_time
+      end
+    end
+  end
 end

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -27,6 +27,12 @@ module Shards
 
         if generate_lockfile?(packages)
           write_lockfile(packages)
+
+          # Touch install path so its mtime is bigger than that of the lockfile
+          File.touch(Shards.install_path)
+        else
+          # Touch lockfile so its mtime is bigger than that of shard.yml
+          File.touch(lockfile_path)
         end
 
         if ignore_crystal_version

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -26,13 +26,13 @@ module Shards
 
         if generate_lockfile?(packages)
           write_lockfile(packages)
-
-          # Touch install path so its mtime is bigger than that of the lockfile
-          File.touch(Shards.install_path)
-        else
+        elsif !Shards.production?
           # Touch lockfile so its mtime is bigger than that of shard.yml
           File.touch(lockfile_path)
         end
+
+        # Touch install path so its mtime is bigger than that of the lockfile
+        File.touch(Shards.install_path)
 
         if ignore_crystal_version
           check_ignored_crystal_version(packages)

--- a/src/commands/update.cr
+++ b/src/commands/update.cr
@@ -22,6 +22,12 @@ module Shards
 
         if generate_lockfile?(packages)
           write_lockfile(packages)
+
+          # Touch install path so its mtime is bigger than that of the lockfile
+          File.touch(Shards.install_path)
+        else
+          # Touch lockfile so its mtime is bigger than that of shard.yml
+          File.touch(lockfile_path)
         end
 
         if ignore_crystal_version

--- a/src/commands/update.cr
+++ b/src/commands/update.cr
@@ -22,13 +22,13 @@ module Shards
 
         if generate_lockfile?(packages)
           write_lockfile(packages)
-
-          # Touch install path so its mtime is bigger than that of the lockfile
-          File.touch(Shards.install_path)
         else
           # Touch lockfile so its mtime is bigger than that of shard.yml
           File.touch(lockfile_path)
         end
+
+        # Touch install path so its mtime is bigger than that of the lockfile
+        File.touch(Shards.install_path)
 
         if ignore_crystal_version
           check_ignored_crystal_version(packages)

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -214,7 +214,7 @@ module Shards
       ref = git_ref(version)
 
       Dir.mkdir_p(install_path)
-      run "git archive --format=tar --prefix= #{ref.to_git_ref} | tar -x -f - -C #{Process.quote(install_path)}"
+      run "git --work-tree=#{Process.quote(install_path)} checkout #{ref.to_git_ref} -- ."
     end
 
     def commit_sha1_at(ref : GitRef)


### PR DESCRIPTION
This patch makes sure that modification times are always in order `lib > shard.lock > shard.yml`. This is necessary for mtime-based dependency resolution for example with make.

Resolves #390