### PR TITLE
Spec: Allow empty scalar for mappings/sequences

### DIFF
--- a/spec/unit/spec_spec.cr
+++ b/spec/unit/spec_spec.cr
@@ -82,6 +82,21 @@ module Shards
       spec.dependencies[2].requirement.should eq(Any)
     end
 
+    it "parses empty mappings/sequences" do
+      spec = Spec.from_yaml <<-YAML
+        name: orm
+        version: 1.0.0
+        authors:
+        dependencies:
+        development_dependencies:
+        targets:
+        executables:
+        libraries:
+        scripts:
+        YAML
+      spec.dependencies.empty?.should be_true
+    end
+
     it "fails dependency with duplicate resolver" do
       expect_raises Shards::ParseError, %(Duplicate resolver mapping for dependency "foo" at line 6, column 5) do
         Spec.from_yaml <<-YAML

--- a/src/ext/yaml.cr
+++ b/src/ext/yaml.cr
@@ -21,5 +21,18 @@ module YAML
       end
       read_mapping_end
     end
+
+    def read_empty_or(&)
+      if kind.scalar?
+        case value
+        when "", "~"
+          # allow empty dependencies
+          read_next
+          return
+        end
+      end
+
+      yield
+    end
   end
 end

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -109,38 +109,52 @@ module Shards
           @crystal = pull.read_scalar
         when "authors"
           check_duplicate(@authors, "authors", line, column)
-          pull.each_in_sequence do
-            authors << Author.new(pull.read_scalar)
+          pull.read_empty_or do
+            pull.each_in_sequence do
+              authors << Author.new(pull.read_scalar)
+            end
           end
         when "dependencies"
           check_duplicate(@dependencies, "dependencies", line, column)
-          pull.each_in_mapping do
-            dependencies << Dependency.from_yaml(pull)
+          pull.read_empty_or do
+            pull.each_in_mapping do
+              dependencies << Dependency.from_yaml(pull)
+            end
           end
         when "development_dependencies"
           check_duplicate(@development_dependencies, "development_dependencies", line, column)
-          pull.each_in_mapping do
-            development_dependencies << Dependency.from_yaml(pull)
+          pull.read_empty_or do
+            pull.each_in_mapping do
+              development_dependencies << Dependency.from_yaml(pull)
+            end
           end
         when "targets"
           check_duplicate(@targets, "targets", line, column)
-          pull.each_in_mapping do
-            targets << Target.new(pull)
+          pull.read_empty_or do
+            pull.each_in_mapping do
+              targets << Target.new(pull)
+            end
           end
         when "executables"
           check_duplicate(@executables, "executables", line, column)
-          pull.each_in_sequence do
-            executables << pull.read_scalar
+          pull.read_empty_or do
+            pull.each_in_sequence do
+              executables << pull.read_scalar
+            end
           end
         when "libraries"
           check_duplicate(@libraries, "libraries", line, column)
-          pull.each_in_mapping do
-            libraries << Library.new(pull)
+          pull.read_empty_or do
+            pull.each_in_mapping do
+              libraries << Library.new(pull)
+            end
           end
         when "scripts"
           check_duplicate(@scripts, "scripts", line, column)
-          pull.each_in_mapping do
-            scripts[pull.read_scalar] = pull.read_scalar
+          pull.read_empty_or do
+            pull.each_in_mapping do
+              scripts[pull.read_scalar] = pull.read_scalar
+            end
           end
         else
           if validate


### PR DESCRIPTION
This patch allows empty scalars as values for mappings or sequences in `shard.yml`.

So this is considered a valid specification:
```yaml
name: foo
version: 0.1.0
dependencies:
```
Previously, this caused a YAML parser error: `Expected MAPPING_START but was SCALAR at line 3, column 15`

There's no change to internal behaviour because empty mappings and sequences were already allowed (`dependencies: {}`).
So this is just a simple UX feature that avoids errors when for example all dependencies are removed but the `dependencies:` key isn't.
Both empty string and YAML null value (`~`) are accepted.