### PR TITLE
Write lockfile even when there are no dependencies

### DIFF
--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -212,11 +212,17 @@ describe "update" do
     end
   end
 
-  it "won't generate lockfile for empty dependencies" do
+  it "generates lockfile for empty dependencies" do
     metadata = {dependencies: {} of Symbol => String}
     with_shard(metadata) do
+      run "shards update"
       path = File.join(application_path, "shard.lock")
-      File.exists?(path).should be_false
+      File.exists?(path).should be_true
+      File.read(path).should eq <<-YAML
+        version: 2.0
+        shards: {}
+
+        YAML
     end
   end
 

--- a/spec/unit/lock_spec.cr
+++ b/spec/unit/lock_spec.cr
@@ -60,5 +60,13 @@ module Shards
 
       expect_raises(Error, "Invalid #{LOCK_FILENAME}.") { Lock.from_yaml("version: 1.0\nshards:\n") }
     end
+
+    it "parses empty shards" do
+      lock = Lock.from_yaml <<-YAML
+        version: 2.0
+        shards: {}
+        YAML
+      lock.shards.empty?.should be_true
+    end
   end
 end

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -17,7 +17,6 @@ module Shards
         solver.prepare(development: !Shards.production?)
 
         packages = handle_resolver_errors { solver.solve }
-        return if packages.empty?
 
         if lockfile? && Shards.production?
           validate(packages)
@@ -82,7 +81,7 @@ module Shards
       end
 
       private def generate_lockfile?(packages)
-        !Shards.production? && !packages.empty? && (!lockfile? || outdated_lockfile?(packages))
+        !Shards.production? && (!lockfile? || outdated_lockfile?(packages))
       end
 
       private def outdated_lockfile?(packages)

--- a/src/commands/update.cr
+++ b/src/commands/update.cr
@@ -54,7 +54,7 @@ module Shards
       end
 
       private def generate_lockfile?(packages)
-        !(Shards.production? || packages.empty?)
+        !Shards.production?
       end
     end
   end

--- a/src/lock.cr
+++ b/src/lock.cr
@@ -69,15 +69,20 @@ module Shards
         io << "# NOTICE: This lockfile contains some overrides from #{override_path}\n"
       end
       io << "version: #{CURRENT_VERSION}\n"
-      io << "shards:\n"
+      io << "shards:"
 
-      packages.sort_by!(&.name).each do |package|
-        key = package.resolver.class.key
+      if packages.empty?
+        io << " {}\n"
+      else
+        io.puts
+        packages.sort_by!(&.name).each do |package|
+          key = package.resolver.class.key
 
-        io << "  " << package.name << ":#{package.is_override ? " # Overridden" : nil}\n"
-        io << "    " << key << ": " << package.resolver.source << '\n'
-        io << "    version: " << package.version.value << '\n'
-        io << '\n'
+          io << "  " << package.name << ":#{package.is_override ? " # Overridden" : nil}\n"
+          io << "    " << key << ": " << package.resolver.source << '\n'
+          io << "    version: " << package.version.value << '\n'
+          io << '\n'
+        end
       end
     end
   end


### PR DESCRIPTION
With this change `shards update` and `shards install` (except with `--production` option) *always* write `shard.lock` (or touch if there are not changes) even if there are no dependencies.

Resolves #445
Unlocks #444