### PR TITLE
Fix command outdated for dep with no releases

### DIFF
--- a/spec/integration/outdated_spec.cr
+++ b/spec/integration/outdated_spec.cr
@@ -20,6 +20,18 @@ describe "outdated" do
     end
   end
 
+  it "no releases" do
+    commit = git_commits("missing").first
+    with_shard({dependencies: {missing: "*"}}, {missing: "0.1.0+git.commit.#{commit}"}) do
+      run "shards install"
+
+      stdout = run "shards outdated --no-color"
+      # FIXME: This should actually report dependencies are up to date (#446)
+      stdout.should contain("W: Outdated dependencies:")
+      stdout.should contain("  * missing (installed: 0.1.0 at #{commit[0..6]})")
+    end
+  end
+
   it "available version matching pessimistic operator" do
     with_shard({dependencies: {orm: "~> 0.3.0"}}, {orm: "0.3.1"}) do
       run "shards install"

--- a/src/commands/outdated.cr
+++ b/src/commands/outdated.cr
@@ -53,7 +53,8 @@ module Shards
           else
             Versions.without_prereleases(resolver.available_releases)
           end
-        latest = Versions.sort(available_versions).first
+        latest = Versions.sort(available_versions).first?
+
         return if latest == installed
 
         @up_to_date = false
@@ -66,7 +67,7 @@ module Shards
         end
 
         # also report latest version:
-        if Versions.compare(latest, package.version) < 0
+        if latest && Versions.compare(latest, package.version) < 0
           @output << ", latest: " << resolver.report_version(latest)
         end
 


### PR DESCRIPTION
`shards outdated` would break with `Empty enumerable` error if a dependency does not have any releases. This patch fixes that.