### PR TITLE
Fix outdated command with non-release installed

### DIFF
--- a/spec/integration/outdated_spec.cr
+++ b/spec/integration/outdated_spec.cr
@@ -138,4 +138,138 @@ describe "outdated" do
       stdout.should contain("I: Dependencies are up to date!")
     end
   end
+
+  describe "non-release" do
+    describe "without relases" do
+      it "latest any" do
+        with_shard({dependencies: {missing: "*"}}, {missing: "0.1.0+git.commit.#{git_commits("missing").first}"}) do
+          run "shards install"
+
+          stdout = run "shards outdated --no-color"
+          stdout.should contain("I: Dependencies are up to date!")
+        end
+      end
+
+      it "latest branch" do
+        with_shard({dependencies: {missing: {git: git_url("missing"), branch: "master"}}}, {missing: "0.1.0+git.commit.#{git_commits("missing").first}"}) do
+          run "shards install"
+
+          stdout = run "shards outdated --no-color"
+          stdout.should contain("I: Dependencies are up to date!")
+        end
+      end
+
+      it "latest commit" do
+        with_shard({dependencies: {missing: {git: git_url("missing"), commit: git_commits("missing").first}}}, {missing: "0.1.0+git.commit.#{git_commits("missing").first}"}) do
+          run "shards install"
+
+          stdout = run "shards outdated --no-color"
+          stdout.should contain("I: Dependencies are up to date!")
+        end
+      end
+
+      it "outdated any" do
+        commits = git_commits("inprogress")
+        with_shard({dependencies: {inprogress: "*"}}, {inprogress: "0.1.0+git.commit.#{commits[1]}"}) do
+          run "shards install"
+
+          stdout = run "shards outdated --no-color"
+          stdout.should contain("W: Outdated dependencies:")
+          stdout.should contain("  * inprogress (installed: 0.1.0 at #{commits[1][0..6]}, available: 0.1.0 at #{commits.first[0..6]})")
+        end
+      end
+
+      it "outdated branch" do
+        commits = git_commits("inprogress")
+        with_shard({dependencies: {inprogress: {git: git_url("inprogress"), branch: "master"}}}, {inprogress: "0.1.0+git.commit.#{commits[1]}"}) do
+          run "shards install"
+
+          stdout = run "shards outdated --no-color"
+          stdout.should contain("W: Outdated dependencies:")
+          stdout.should contain("  * inprogress (installed: 0.1.0 at #{commits[1][0..6]}, available: 0.1.0 at #{commits.first[0..6]})")
+        end
+      end
+
+      it "outdated commit" do
+        commits = git_commits("inprogress")
+        with_shard({dependencies: {inprogress: {git: git_url("inprogress"), commit: commits[1]}}}, {inprogress: "0.1.0+git.commit.#{commits[1]}"}) do
+          run "shards install"
+
+          stdout = run "shards outdated --no-color"
+          stdout.should contain("W: Outdated dependencies:")
+          stdout.should contain("  * inprogress (installed: 0.1.0 at #{commits[1][0..6]}")
+          # TODO: commit
+          # stdout.should contain("  * inprogress (installed: 0.1.0 at #{commits[1][0..6]}, available: 0.1.0 at #{commits.first[0..6]})")
+        end
+      end
+    end
+
+    describe "with previous releases" do
+      it "outdated any" do
+        commits = git_commits("heading")
+        with_shard({dependencies: {heading: "*"}}, {heading: "0.1.0+git.commit.#{commits[1]}"}) do
+          run "shards install"
+
+          stdout = run "shards outdated --no-color"
+          stdout.should contain("W: Outdated dependencies:")
+          stdout.should contain("  * heading (installed: 0.1.0 at #{commits[1][0..6]}, available: 0.1.0)")
+          # TODO: stdout.should contain("  * heading (installed: 0.1.0 at #{commits[1][0..6]}, available: 0.1.0 at #{commits.first[0..6]})")
+        end
+      end
+
+      it "latest any" do
+        commits = git_commits("heading")
+        with_shard({dependencies: {heading: "*"}}, {heading: "0.1.0+git.commit.#{commits.first}"}) do
+          run "shards install"
+
+          stdout = run "shards outdated --no-color"
+          stdout.should contain("I: Dependencies are up to date!")
+        end
+      end
+
+      it "latest branch" do
+        commits = git_commits("heading")
+        with_shard({dependencies: {heading: {git: git_url("heading"), branch: "master"}}}, {heading: "0.1.0+git.commit.#{commits.first}"}) do
+          run "shards install"
+
+          stdout = run "shards outdated --no-color"
+          stdout.should contain("I: Dependencies are up to date!")
+        end
+      end
+    end
+
+    it "outdated any with new release" do
+      commits = git_commits("release_hist")
+      with_shard({dependencies: {release_hist: "*"}}, {release_hist: "0.1.0+git.commit.#{commits[1]}"}) do
+        run "shards install"
+
+        stdout = run "shards outdated --no-color"
+        stdout.should contain("W: Outdated dependencies:")
+        stdout.should contain("  * release_hist (installed: 0.1.0 at #{commits[1][0..6]}, available: 0.2.0)")
+      end
+    end
+
+    it "outdated branch without new release" do
+      installed_commit = git_commits("branched", "feature")[1]
+      branch_head = git_commits("branched", "feature").first
+      with_shard({dependencies: {branched: {git: git_url("branched"), branch: "feature"}}}, {branched: "0.1.0+git.commit.#{installed_commit}"}) do
+        run "shards install"
+
+        stdout = run "shards outdated --no-color"
+        stdout.should contain("W: Outdated dependencies:")
+        stdout.should contain("  * branched (installed: 0.1.0 at #{installed_commit[0..6]}, available: 0.1.0 at #{branch_head[0..6]}, latest: 0.2.0)")
+      end
+    end
+
+    it "latest branch with release on HEAD" do
+      branch_head = git_commits("branched", "feature").first
+      with_shard({dependencies: {branched: {git: git_url("branched"), branch: "feature"}}}, {branched: "0.1.0+git.commit.#{branch_head}"}) do
+        run "shards install"
+
+        stdout = run "shards outdated --no-color"
+        stdout.should contain("W: Outdated dependencies:")
+        stdout.should contain("  * branched (installed: 0.1.0 at #{branch_head[0..6]}, latest: 0.2.0)")
+      end
+    end
+  end
 end

--- a/spec/integration/outdated_spec.cr
+++ b/spec/integration/outdated_spec.cr
@@ -26,9 +26,7 @@ describe "outdated" do
       run "shards install"
 
       stdout = run "shards outdated --no-color"
-      # FIXME: This should actually report dependencies are up to date (#446)
-      stdout.should contain("W: Outdated dependencies:")
-      stdout.should contain("  * missing (installed: 0.1.0 at #{commit[0..6]})")
+      stdout.should contain("I: Dependencies are up to date!")
     end
   end
 

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -165,6 +165,26 @@ private def setup_repositories
   create_git_release "intermediate", "0.1.0", {
     dependencies: {awesome: {git: git_url(:awesome)}},
   }
+
+  # repo with release and unreleased commits
+  create_git_repository "heading"
+  create_git_release "heading", "0.1.0"
+  create_git_version_commit "heading", "0.1.0"
+  create_git_version_commit "heading", "0.1.0"
+
+  # repo with release and preceding commit
+  create_git_repository "release_hist"
+  create_git_release "release_hist", "0.1.0"
+  create_git_version_commit "release_hist", "0.1.0"
+  create_git_release "release_hist", "0.2.0"
+
+  # repo with branch and new release outside branch
+  create_git_repository "branched"
+  create_git_release "branched", "0.1.0"
+  checkout_new_git_branch "branched", "feature"
+  create_git_version_commit "branched", "0.1.0"
+  checkout_git_branch "branched", "master"
+  create_git_release "branched", "0.2.0"
 end
 
 private def assert(value, message, file, line)


### PR DESCRIPTION
This fixes `shards outdated` to work correctly with non-release versions. Currently it reports every version as outdated which is not the latest release, even if the installed commit is ahead of the latest release.

Resolves #446

In the example from #446, it's pretty obvious: The installed version is head on `master`, so it's really the latest and should not be listed as outdated.

When the requirement is a branch, the intention is to track that path. So the highest available version is head of that branch.

If there is a tagged releases with a higher version number (independent of the requirement restriction), that should always be treated as latest.

Commit and tag requirements are complicated because they provide no context to depict intention. A typical use case would be to pin an unreleased commit in master.
For now `shards outdated` assumes available versions for a tag or commit requirement to be on master branch.
Further enhancements could look whether the commit is actually an ancestor of master. That could help identify a pinned commit not merged to master. But there's not really a point forward from there, anyways. So it's probably fine to leave it that way.

There is currently a limitation that the requirements can only be accessed for first level dependencies. `shards outdated` just grabs that from `shard.yml`. For transitive dependencies I couldn't find an easy way to access the dependency requirement because there can be multiple ones and the solver just merges them together.
This only makes a difference when a dependency has a dependency with a branch restriction. Then the special handling for reporing branch head as available version does not work.
This can probably be improved later, but for now the fix is good enough and doesn't need to cover all edge cases.

This has already proven very valuable in practice, because it removes a lot of noise from `shards outdated`.