### PR TITLE
Fix working directory in `capture`

### DIFF
--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -404,7 +404,7 @@ module Shards
     end
 
     private def capture(command, path = local_path)
-      run(command, capture: true, path: local_path).not_nil!
+      run(command, capture: true, path: path).not_nil!
     end
 
     private def run(command, path = local_path, capture = false)


### PR DESCRIPTION
The working directory passed to `run` should be the parameter `path`,
not `local_path`.