### PR TITLE
Mercurial command server

### DIFF
--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -82,14 +82,14 @@ end
 
 def create_hg_repository(project, *versions)
   Dir.cd(tmp_path) do
-    run "hg init #{Process.quote(project)}"
+    Shards::HgResolver.hg "init", project
   end
 
   Dir.mkdir(File.join(hg_path(project), "src"))
   File.write(File.join(hg_path(project), "src", "#{project}.cr"), "module #{project.capitalize}\nend")
 
   Dir.cd(hg_path(project)) do
-    run "hg add #{Process.quote("src/#{project}.cr")}"
+    Shards::HgResolver.hg "add", "src/#{project}.cr"
   end
 
   versions.each { |version| create_hg_release project, version }
@@ -97,7 +97,7 @@ end
 
 def create_fork_hg_repository(project, upstream)
   Dir.cd(tmp_path) do
-    run "hg clone #{Process.quote(hg_url(upstream))} #{Process.quote(project)}"
+    Shards::HgResolver.hg "clone", hg_url(upstream), project
   end
 end
 
@@ -111,7 +111,7 @@ def create_hg_version_commit(project, version, shard : Bool | NamedTuple = true)
       name = shard[:name]? if shard.is_a?(NamedTuple)
       name ||= project
       File.touch "src/#{name}.cr"
-      run "hg add #{Process.quote("src/#{name}.cr")}"
+      Shards::HgResolver.hg "add", "src/#{name}.cr"
     end
     create_hg_commit project, "release: v#{version}"
   end
@@ -124,32 +124,32 @@ end
 
 def create_hg_tag(project, version)
   Dir.cd(hg_path(project)) do
-    run "hg tag #{Process.quote(version)}"
+    Shards::HgResolver.hg "tag", version
   end
 end
 
 def create_hg_commit(project, message = "new commit")
   Dir.cd(hg_path(project)) do
     File.write("src/#{project}.cr", "# #{message}", mode: "a")
-    run "hg commit -A -m #{Process.quote(message)}"
+    Shards::HgResolver.hg "commit", "-A", "-m", message
   end
 end
 
 def checkout_new_hg_bookmark(project, branch)
   Dir.cd(hg_path(project)) do
-    run "hg bookmark #{Process.quote(branch)}"
+    Shards::HgResolver.hg "bookmark", branch
   end
 end
 
 def checkout_new_hg_branch(project, branch)
   Dir.cd(hg_path(project)) do
-    run "hg branch #{Process.quote(branch)}"
+    Shards::HgResolver.hg "branch", branch
   end
 end
 
 def checkout_hg_rev(project, rev)
   Dir.cd(hg_path(project)) do
-    run "hg update -C #{Process.quote(rev)}"
+    Shards::HgResolver.hg "update", "-C", rev
   end
 end
 
@@ -191,7 +191,7 @@ end
 
 def hg_commits(project, rev = ".")
   Dir.cd(hg_path(project)) do
-    run("hg log --template='{node}\n' -r #{Process.quote(rev)}").strip.split('\n')
+    Shards::HgResolver.hg("log", "--template", "{node}\n", "-r", rev).not_nil!.strip.split('\n')
   end
 end
 

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -130,6 +130,7 @@ end
 
 def create_hg_commit(project, message = "new commit")
   Dir.cd(hg_path(project)) do
+    File.write("src/#{project}.cr", "# #{message}", mode: "a")
     run "hg commit -A -m #{Process.quote(message)}"
   end
 end

--- a/spec/support/requirement.cr
+++ b/spec/support/requirement.cr
@@ -6,6 +6,10 @@ def commit(sha1)
   Shards::GitCommitRef.new(sha1)
 end
 
+def hg_branch(name)
+  Shards::HgBranchRef.new(name)
+end
+
 def version(version)
   Shards::Version.new(version)
 end

--- a/spec/support/requirement.cr
+++ b/spec/support/requirement.cr
@@ -6,6 +6,10 @@ def commit(sha1)
   Shards::GitCommitRef.new(sha1)
 end
 
+def hg_bookmark(name)
+  Shards::HgBookmarkRef.new(name)
+end
+
 def hg_branch(name)
   Shards::HgBranchRef.new(name)
 end

--- a/spec/unit/hg_resolver_spec.cr
+++ b/spec/unit/hg_resolver_spec.cr
@@ -1,0 +1,153 @@
+require "./spec_helper"
+
+private def resolver(name)
+  Shards::HgResolver.new(name, hg_url(name))
+end
+
+module Shards
+  # Allow overriding `source` for the specs
+  class HgResolver
+    def source=(@source)
+    end
+  end
+
+  describe HgResolver do
+    before_each do
+      create_hg_repository "empty"
+      create_hg_commit "empty", "initial release"
+
+      create_hg_repository "unreleased"
+      create_hg_version_commit "unreleased", "0.1.0"
+      checkout_new_hg_branch "unreleased", "branch"
+      create_hg_commit "unreleased", "testing"
+      checkout_hg_rev "unreleased", "default"
+
+      create_hg_repository "library", "0.0.1", "0.1.0", "0.1.1", "0.1.2", "0.2.0"
+
+      # Create a version tag not prefixed by 'v' which should be ignored
+      create_hg_tag "library", "99.9.9"
+    end
+
+    it "available releases" do
+      resolver("empty").available_releases.should be_empty
+      resolver("library").available_releases.should eq(versions ["0.0.1", "0.1.0", "0.1.1", "0.1.2", "0.2.0"])
+    end
+
+    it "latest version for ref" do
+      expect_raises(Shards::Error, "No shard.yml was found for shard \"empty\" at commit #{hg_commits(:empty)[0]}") do
+        resolver("empty").latest_version_for_ref(hg_branch "default")
+      end
+      expect_raises(Shards::Error, "No shard.yml was found for shard \"empty\" at commit #{hg_commits(:empty)[0]}") do
+        resolver("empty").latest_version_for_ref(nil)
+      end
+      resolver("unreleased").latest_version_for_ref(hg_branch "default").should eq(version "0.1.0+hg.commit.#{hg_commits(:unreleased)[0]}")
+      resolver("unreleased").latest_version_for_ref(hg_branch "branch").should eq(version "0.1.0+hg.commit.#{hg_commits(:unreleased, "branch")[0]}")
+      resolver("unreleased").latest_version_for_ref(nil).should eq(version "0.1.0+hg.commit.#{hg_commits(:unreleased)[0]}")
+      resolver("library").latest_version_for_ref(hg_branch "default").should eq(version "0.2.0+hg.commit.#{hg_commits(:library)[0]}")
+      resolver("library").latest_version_for_ref(nil).should eq(version "0.2.0+hg.commit.#{hg_commits(:library)[0]}")
+      expect_raises(Shards::Error, "Could not find branch foo for shard \"library\" in the repository #{hg_url(:library)}") do
+        resolver("library").latest_version_for_ref(hg_branch "foo")
+      end
+    end
+
+    it "versions for" do
+      expect_raises(Shards::Error, "No shard.yml was found for shard \"empty\" at commit #{hg_commits(:empty)[0]}") do
+        resolver("empty").versions_for(Any)
+      end
+      resolver("library").versions_for(Any).should eq(versions ["0.0.1", "0.1.0", "0.1.1", "0.1.2", "0.2.0"])
+      resolver("library").versions_for(VersionReq.new "~> 0.1.0").should eq(versions ["0.1.0", "0.1.1", "0.1.2"])
+      resolver("library").versions_for(hg_branch "default").should eq(versions ["0.2.0+hg.commit.#{hg_commits(:library)[0]}"])
+      resolver("unreleased").versions_for(hg_branch "default").should eq(versions ["0.1.0+hg.commit.#{hg_commits(:unreleased)[0]}"])
+      resolver("unreleased").versions_for(Any).should eq(versions ["0.1.0+hg.commit.#{hg_commits(:unreleased)[0]}"])
+    end
+
+    it "read spec for release" do
+      spec = resolver("library").spec(version "0.1.1")
+      spec.original_version.should eq(version "0.1.1")
+      spec.version.should eq(version "0.1.1")
+    end
+
+    it "read spec for commit" do
+      version = version("0.2.0+hg.commit.#{hg_commits(:library)[0]}")
+      spec = resolver("library").spec(version)
+      spec.original_version.should eq(version "0.2.0")
+      spec.version.should eq(version)
+    end
+
+    it "install" do
+      library = resolver("library")
+
+      library.install_sources(version("0.1.2"), install_path("library"))
+      File.exists?(install_path("library", "src/library.cr")).should be_true
+      File.exists?(install_path("library", "shard.yml")).should be_true
+      Spec.from_file(install_path("library", "shard.yml")).version.should eq(version "0.1.2")
+
+      library.install_sources(version("0.2.0"), install_path("library"))
+      Spec.from_file(install_path("library", "shard.yml")).version.should eq(version "0.2.0")
+    end
+
+    it "install commit" do
+      library = resolver("library")
+      version = version "0.2.0+hg.commit.#{hg_commits(:library)[0]}"
+      library.install_sources(version, install_path("library"))
+      Spec.from_file(install_path("library", "shard.yml")).version.should eq(version "0.2.0")
+    end
+
+    it "origin changed" do
+      library = HgResolver.new("library", hg_url("library"))
+      library.install_sources(version("0.1.2"), install_path("library"))
+
+      # Change the origin in the cache repo to https://foss.heptapod.net/foo/bar
+      hgrc_path = File.join(library.local_path, ".hg", "hgrc")
+      hgrc = File.read(hgrc_path)
+      hgrc = hgrc.gsub(/(default\s*=\s*)([^\r\n]*)/, "\\1https://foss.heptapod.net/foo/bar")
+      File.write(hgrc_path, hgrc)
+      #
+      # All of these alternatives should not trigger origin as changed
+      same_origins = [
+        "https://foss.heptapod.net/foo/bar",
+        "https://foss.heptapod.net:1234/foo/bar",
+        "http://foss.heptapod.net/foo/bar",
+        "ssh://foss.heptapod.net/foo/bar",
+        "hg://foss.heptapod.net/foo/bar",
+        "rsync://foss.heptapod.net/foo/bar",
+        "hg@foss.heptapod.net:foo/bar",
+        "bob@foss.heptapod.net:foo/bar",
+        "foss.heptapod.net:foo/bar",
+      ]
+
+      same_origins.each do |origin|
+        library.source = origin
+        library.origin_changed?.should be_false
+      end
+
+      # These alternatives should all trigger origin as changed
+      changed_origins = [
+        "https://foss.heptapod.net/foo/bar2",
+        "https://foss.heptapod.net/foos/bar",
+        "https://hghubz.com/foo/bar",
+        "file:///foss.heptapod.net/foo/bar",
+        "hg@foss.heptapod.net:foo/bar2",
+        "hg@foss.heptapod2.net.com:foo/bar",
+        "",
+      ]
+
+      changed_origins.each do |origin|
+        library.source = origin
+        library.origin_changed?.should be_true
+      end
+    end
+
+    it "renders report version" do
+      resolver("library").report_version(version "1.2.3").should eq("1.2.3")
+      resolver("library").report_version(version "1.2.3+hg.commit.654875c9dbfa8d72fba70d65fd548d51ffb85aff").should eq("1.2.3 at 654875c")
+    end
+
+    it "#matches_ref" do
+      resolver = HgResolver.new("", "")
+      resolver.matches_ref?(HgCommitRef.new("1234567890abcdef"), Shards::Version.new("0.1.0.+hg.commit.1234567")).should be_true
+      resolver.matches_ref?(HgCommitRef.new("1234567890abcdef"), Shards::Version.new("0.1.0.+hg.commit.1234567890abcdef")).should be_true
+      resolver.matches_ref?(HgCommitRef.new("1234567"), Shards::Version.new("0.1.0.+hg.commit.1234567890abcdef")).should be_true
+    end
+  end
+end

--- a/spec/unit/hg_resolver_spec.cr
+++ b/spec/unit/hg_resolver_spec.cr
@@ -22,6 +22,12 @@ module Shards
       create_hg_commit "unreleased", "testing"
       checkout_hg_rev "unreleased", "default"
 
+      create_hg_repository "unreleased-bm"
+      create_hg_version_commit "unreleased-bm", "0.1.0"
+      checkout_new_hg_bookmark "unreleased-bm", "branch"
+      create_hg_commit "unreleased-bm", "testing"
+      checkout_hg_rev "unreleased-bm", "default"
+
       create_hg_repository "library", "0.0.1", "0.1.0", "0.1.1", "0.1.2", "0.2.0"
 
       # Create a version tag not prefixed by 'v' which should be ignored
@@ -43,6 +49,9 @@ module Shards
       resolver("unreleased").latest_version_for_ref(hg_branch "default").should eq(version "0.1.0+hg.commit.#{hg_commits(:unreleased)[0]}")
       resolver("unreleased").latest_version_for_ref(hg_branch "branch").should eq(version "0.1.0+hg.commit.#{hg_commits(:unreleased, "branch")[0]}")
       resolver("unreleased").latest_version_for_ref(nil).should eq(version "0.1.0+hg.commit.#{hg_commits(:unreleased)[0]}")
+      resolver("unreleased-bm").latest_version_for_ref(hg_branch "default").should eq(version "0.1.0+hg.commit.#{hg_commits("unreleased-bm")[0]}")
+      resolver("unreleased-bm").latest_version_for_ref(hg_bookmark "branch").should eq(version "0.1.0+hg.commit.#{hg_commits("unreleased-bm", "branch")[0]}")
+      resolver("unreleased-bm").latest_version_for_ref(nil).should eq(version "0.1.0+hg.commit.#{hg_commits("unreleased-bm")[0]}")
       resolver("library").latest_version_for_ref(hg_branch "default").should eq(version "0.2.0+hg.commit.#{hg_commits(:library)[0]}")
       resolver("library").latest_version_for_ref(nil).should eq(version "0.2.0+hg.commit.#{hg_commits(:library)[0]}")
       expect_raises(Shards::Error, "Could not find branch foo for shard \"library\" in the repository #{hg_url(:library)}") do
@@ -59,6 +68,8 @@ module Shards
       resolver("library").versions_for(hg_branch "default").should eq(versions ["0.2.0+hg.commit.#{hg_commits(:library)[0]}"])
       resolver("unreleased").versions_for(hg_branch "default").should eq(versions ["0.1.0+hg.commit.#{hg_commits(:unreleased)[0]}"])
       resolver("unreleased").versions_for(Any).should eq(versions ["0.1.0+hg.commit.#{hg_commits(:unreleased)[0]}"])
+      resolver("unreleased-bm").versions_for(hg_branch "default").should eq(versions ["0.1.0+hg.commit.#{hg_commits("unreleased-bm")[0]}"])
+      resolver("unreleased-bm").versions_for(Any).should eq(versions ["0.1.0+hg.commit.#{hg_commits("unreleased-bm")[0]}"])
     end
 
     it "read spec for release" do

--- a/src/config.cr
+++ b/src/config.cr
@@ -12,6 +12,7 @@ module Shards
   VERSION_REFERENCE     = /^v?\d+[-.][-.a-zA-Z\d]+$/
   VERSION_TAG           = /^v(\d+[-.][-.a-zA-Z\d]+)$/
   VERSION_AT_GIT_COMMIT = /^(\d+[-.][-.a-zA-Z\d]+)\+git\.commit\.([0-9a-f]+)$/
+  VERSION_AT_HG_COMMIT  = /^(\d+[-.][-.a-zA-Z\d]+)\+hg\.commit\.([0-9a-f]+)$/
 
   def self.cache_path
     @@cache_path ||= find_or_create_cache_path

--- a/src/resolvers/hg.cr
+++ b/src/resolvers/hg.cr
@@ -1,0 +1,463 @@
+require "uri"
+require "./resolver"
+require "../versions"
+require "../logger"
+require "../helpers"
+
+module Shards
+  abstract struct HgRef < Ref
+    def full_info
+      to_s
+    end
+  end
+
+  struct HgBranchRef < HgRef
+    def initialize(@branch : String)
+    end
+
+    def to_hg_ref(simple = false)
+      simple ? @branch : "branch(\"#{@branch}\") and head()"
+    end
+
+    def to_s(io)
+      io << "branch " << @branch
+    end
+
+    def to_yaml(yaml)
+      yaml.scalar "branch"
+      yaml.scalar @branch
+    end
+  end
+
+  struct HgBookmarkRef < HgRef
+    def initialize(@bookmark : String)
+    end
+
+    def to_hg_ref(simple = false)
+      simple ? @bookmark : "bookmark(\"#{@bookmark}\")"
+    end
+
+    def to_s(io)
+      io << "bookmark " << @bookmark
+    end
+
+    def to_yaml(yaml)
+      yaml.scalar "bookmark"
+      yaml.scalar @bookmark
+    end
+  end
+
+  struct HgTagRef < HgRef
+    def initialize(@tag : String)
+    end
+
+    def to_hg_ref(simple = false)
+      simple ? @tag : "tag(\"#{@tag}\")"
+    end
+
+    def to_s(io)
+      io << "tag " << @tag
+    end
+
+    def to_yaml(yaml)
+      yaml.scalar "tag"
+      yaml.scalar @tag
+    end
+  end
+
+  struct HgCommitRef < HgRef
+    getter commit : String
+
+    def initialize(@commit : String)
+    end
+
+    def =~(other : HgCommitRef)
+      commit.starts_with?(other.commit) || other.commit.starts_with?(commit)
+    end
+
+    def to_hg_ref(simple = false)
+      @commit
+    end
+
+    def to_s(io)
+      io << "commit " << @commit[0...7]
+    end
+
+    def full_info
+      "commit #{@commit}"
+    end
+
+    def to_yaml(yaml)
+      yaml.scalar "commit"
+      yaml.scalar @commit
+    end
+  end
+
+  struct HgCurrentRef < HgRef
+    def to_hg_ref(simple = false)
+      "."
+    end
+
+    def to_s(io)
+      io << "current"
+    end
+
+    def to_yaml(yaml)
+      raise NotImplementedError.new("HgCurrentRef is for internal use only")
+    end
+  end
+
+  class HgResolver < Resolver
+    @@has_hg_command : Bool?
+    @@hg_version : String?
+
+    @origin_url : String?
+
+    def self.key
+      "hg"
+    end
+
+    def self.normalize_key_source(key : String, source : String) : {String, String}
+      case key
+      when "hg"
+        {"hg", source}
+      else
+        raise "Unknown resolver #{key}"
+      end
+    end
+
+    protected def self.has_hg_command?
+      if @@has_hg_command.nil?
+        @@has_hg_command = (Process.run("hg", ["--version"]).success? rescue false)
+      end
+      @@has_hg_command
+    end
+
+    protected def self.hg_version
+      @@hg_version ||= `hg --version`[/\(version\s+([^)]*)\)/, 1]
+    end
+
+    def read_spec(version : Version) : String?
+      update_local_cache
+      ref = hg_ref(version)
+
+      if file_exists?(ref, SPEC_FILENAME)
+        capture("hg cat -r #{Process.quote(ref.to_hg_ref)} #{Process.quote(SPEC_FILENAME)}")
+      else
+        Log.debug { "Missing \"#{SPEC_FILENAME}\" for #{name.inspect} at #{ref}" }
+        nil
+      end
+    end
+
+    private def spec_at_ref(ref : HgRef) : Spec?
+      update_local_cache
+      begin
+        if file_exists?(ref, SPEC_FILENAME)
+          spec_yaml = capture("hg cat -r #{Process.quote(ref.to_hg_ref)} #{Process.quote(SPEC_FILENAME)}")
+          Spec.from_yaml(spec_yaml)
+        end
+      rescue Error
+        nil
+      end
+    end
+
+    private def spec?(version)
+      spec(version)
+    rescue Error
+    end
+
+    def available_releases : Array(Version)
+      update_local_cache
+      versions_from_tags
+    end
+
+    def latest_version_for_ref(ref : HgRef?) : Version
+      update_local_cache
+      ref ||= HgCurrentRef.new
+      begin
+        commit = commit_sha1_at(ref)
+      rescue Error
+        raise Error.new "Could not find #{ref.full_info} for shard #{name.inspect} in the repository #{source}"
+      end
+
+      if spec = spec_at_ref(ref)
+        Version.new "#{spec.version.value}+hg.commit.#{commit}"
+      else
+        raise Error.new "No #{SPEC_FILENAME} was found for shard #{name.inspect} at commit #{commit}"
+      end
+    end
+
+    def matches_ref?(ref : HgRef, version : Version)
+      case ref
+      when HgCommitRef
+        ref =~ hg_ref(version)
+      when HgBranchRef, HgBookmarkRef, HgCurrentRef
+        # TODO: check if version is the branch
+        version.has_metadata?
+      else
+        # TODO: check branch and tags
+        true
+      end
+    end
+
+    protected def versions_from_tags
+      capture("hg tags --template '{tag}\\n'")
+        .split('\n')
+        .sort!
+        .compact_map { |tag| Version.new($1) if tag =~ VERSION_TAG }
+    end
+
+    def matches?(commit)
+      if branch = dependency["branch"]?
+        !capture("hg log -r 'branch(#{tag}) and descendants(#{commit})' --template '{branch}\\n'").strip.empty?
+      elsif bookmark = dependency["bookmark"]?
+        !capture("hg log -r 'bookmark(#{bookmark}) and descendants(#{commit})' --template '{bookmarks}\\n'").strip.empty?
+      elsif tag = dependency["tag"]?
+        !capture("hg log -r 'tag(#{tag}) and descendants(#{commit})' --template '{tags}\n'").strip.empty?
+      else
+        !capture("hg log -r #{commit}").strip.empty?
+      end
+    end
+
+    def install_sources(version : Version, install_path : String)
+      update_local_cache
+      ref = hg_ref(version)
+
+      FileUtils.rm_r(install_path) if File.exists?(install_path)
+      Dir.mkdir_p(install_path)
+      run "hg clone --quiet -u #{Process.quote(ref.to_hg_ref(true))} -- #{Process.quote(local_path)} #{Process.quote(install_path)}"
+    end
+
+    def commit_sha1_at(ref : HgRef)
+      capture("hg log -r #{Process.quote(ref.to_hg_ref)} --template '{node}'").strip
+    end
+
+    def local_path
+      @local_path ||= begin
+        uri = parse_uri(hg_url)
+
+        path = uri.path
+        path = Path[path]
+        # E.g. turns "c:\local\path" into "c\local\path". Or just drops the leading slash.
+        if (anchor = path.anchor)
+          path = Path[path.drive.to_s.rchop(":"), path.relative_to(anchor)]
+        end
+
+        if host = uri.host
+          File.join(Shards.cache_path, host, path)
+        else
+          File.join(Shards.cache_path, path)
+        end
+      end
+    end
+
+    def hg_url
+      source.strip
+    end
+
+    def parse_requirement(params : Hash(String, String)) : Requirement
+      params.each do |key, value|
+        case key
+        when "branch"
+          return HgBranchRef.new value
+        when "bookmark"
+          return HgBookmarkRef.new value
+        when "tag"
+          return HgTagRef.new value
+        when "commit"
+          return HgCommitRef.new value
+        else
+        end
+      end
+
+      super
+    end
+
+    record HgVersion, value : String, commit : String? = nil
+
+    private def parse_hg_version(version : Version) : HgVersion
+      case version.value
+      when VERSION_REFERENCE
+        HgVersion.new version.value
+      when VERSION_AT_HG_COMMIT
+        HgVersion.new $1, $2
+      else
+        raise Error.new("Invalid version for hg resolver: #{version}")
+      end
+    end
+
+    private def hg_ref(version : Version) : HgRef
+      hg_version = parse_hg_version(version)
+      if commit = hg_version.commit
+        HgCommitRef.new commit
+      else
+        HgTagRef.new "v#{hg_version.value}"
+      end
+    end
+
+    private def update_local_cache
+      if cloned_repository? && origin_changed?
+        delete_repository
+        @updated_cache = false
+      end
+
+      return if Shards.local? || @updated_cache
+      Log.info { "Fetching #{hg_url}" }
+
+      if cloned_repository?
+        # repositories cloned with shards v0.8.0 won't fetch any new remote
+        # refs; we must delete them and clone again!
+        if valid_repository?
+          fetch_repository
+        else
+          delete_repository
+          mirror_repository
+        end
+      else
+        mirror_repository
+      end
+
+      @updated_cache = true
+    end
+
+    private def mirror_repository
+      hg_retry(err: "Failed to clone #{hg_url}") do
+        # We checkout the working directory so that "." is meaningful.
+        #
+        # An alternative would be to use the `@` bookmark, but only as long
+        # as nothing new is committed.
+        run_in_current_folder "hg clone --quiet -- #{Process.quote(hg_url)} #{Process.quote(local_path)}"
+      end
+    end
+
+    private def fetch_repository
+      hg_retry(err: "Failed to update #{hg_url}") do
+        run "hg pull"
+      end
+    end
+
+    private def hg_retry(err = "Failed to update repository")
+      retries = 0
+      loop do
+        yield
+        break
+      rescue Error
+        retries += 1
+        next if retries < 3
+        raise Error.new(err)
+      end
+    end
+
+    private def delete_repository
+      Log.debug { "rm -rf #{Process.quote(local_path)}'" }
+      Shards::Helpers.rm_rf(local_path)
+      @origin_url = nil
+    end
+
+    private def cloned_repository?
+      Dir.exists?(local_path)
+    end
+
+    private def valid_repository?
+      File.each_line(File.join(local_path, ".hg", "dirstate")) do |line|
+        return true if line =~ /mirror\s*=\s*true/
+      end
+      false
+    end
+
+    private def origin_url
+      @origin_url ||= capture("hg paths default").strip
+    end
+
+    # Returns whether origin URLs have differing hosts and/or paths.
+    protected def origin_changed?
+      return false if origin_url == hg_url
+      return true if origin_url.nil? || hg_url.nil?
+
+      origin_parsed = parse_uri(origin_url)
+      hg_parsed = parse_uri(hg_url)
+
+      (origin_parsed.host != hg_parsed.host) || (origin_parsed.path != hg_parsed.path)
+    end
+
+    # Parses a URI string, with additional support for ssh+git URI schemes.
+    private def parse_uri(raw_uri)
+      # Need to check for file URIs early, otherwise generic parsing will fail on a colon.
+      if (path = raw_uri.lchop?("file://"))
+        return URI.new(scheme: "file", path: path)
+      end
+
+      # Try normal URI parsing first
+      uri = URI.parse(raw_uri)
+      return uri if uri.absolute? && !uri.opaque?
+
+      # Otherwise, assume and attempt to parse the scp-style ssh URIs
+      host, _, path = raw_uri.partition(':')
+
+      if host.includes?('@')
+        user, _, host = host.partition('@')
+      end
+
+      # Normalize leading slash, matching URI parsing
+      unless path.starts_with?('/')
+        path = '/' + path
+      end
+
+      URI.new(scheme: "ssh", host: host, path: path, user: user)
+    end
+
+    private def file_exists?(ref : HgRef, path)
+      files = capture("hg files -r #{Process.quote(ref.to_hg_ref)} -- #{Process.quote(path)}")
+      !files.strip.empty?
+    end
+
+    private def capture(command, path = local_path)
+      run(command, capture: true, path: path).not_nil!
+    end
+
+    private def run(command, path = local_path, capture = false)
+      if Shards.local? && !Dir.exists?(path)
+        dependency_name = File.basename(path)
+        raise Error.new("Missing repository cache for #{dependency_name.inspect}. Please run without --local to fetch it.")
+      end
+      Dir.cd(path) do
+        run_in_current_folder(command, capture)
+      end
+    end
+
+    private def run_in_current_folder(command, capture = false)
+      unless HgResolver.has_hg_command?
+        raise Error.new("Error missing hg command line tool. Please install Mercurial first!")
+      end
+
+      Log.debug { command }
+
+      output = capture ? IO::Memory.new : Process::Redirect::Close
+      error = IO::Memory.new
+      status = Process.run(command, shell: true, output: output, error: error)
+
+      if status.success?
+        output.to_s if capture
+      else
+        str = error.to_s
+        if str.starts_with?("abort: ") && (idx = str.index('\n'))
+          message = str[7...idx]
+        else
+          message = str
+        end
+        raise Error.new("Failed #{command} (#{message}). Maybe a commit, branch, bookmark or file doesn't exist?")
+      end
+    end
+
+    def report_version(version : Version) : String
+      hg_version = parse_hg_version(version)
+      if commit = hg_version.commit
+        "#{hg_version.value} at #{commit[0...7]}"
+      else
+        version.value
+      end
+    end
+
+    register_resolver "hg", HgResolver
+  end
+end


### PR DESCRIPTION
This is a modification of the HgResolver from some other pull request to make use of the hg command server to speed up hg commands.

The mercurial command server is feature of hg to overcome the (relatively long) startup time of the Python interpreter. Instead of starting a new interpreter for each single hg command only a single process is started. All subsequent hg commands are then passed to this running process.

The command server is started by `HgResolver` the first time a command is run. The same command server is also used for all test cases.

This overall reduces the running time of all hg tests to a few seconds.