### PR TITLE
Remove dysfunctional `GitResolver#matches?`

### DIFF
--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -195,21 +195,6 @@ module Shards
         .compact_map { |tag| Version.new($1) if tag =~ VERSION_TAG }
     end
 
-    def matches?(commit)
-      if branch = dependency["branch"]?
-        capture("git branch --list #{GitResolver.git_column_never} --contains #{commit}")
-          .split('\n')
-          .compact_map { |line| $1? if line =~ /^[* ] (.+)$/ }
-          .includes?(branch)
-      elsif tag = dependency["tag"]?
-        capture("git tag --list #{GitResolver.git_column_never} --contains #{commit}")
-          .split('\n')
-          .includes?(tag)
-      else
-        !capture("git log -n 1 #{commit}").strip.empty?
-      end
-    end
-
     def install_sources(version : Version, install_path : String)
       update_local_cache
       ref = git_ref(version)


### PR DESCRIPTION
The method does not work anymore because there is not variable or
method `dependency`.