### PR TITLE
Fix README referencing CRFLAGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Shards is usually distributed with Crystal itself (e.g. Homebrew and Debian
 packages). Alternatively, a `shards` package may be available for your system.
 
 You can download a source tarball from the same page (or clone the repository)
-then run `make CRFLAGS=--release`and copy `bin/shards` into your `PATH`. For
+then run `CRYSTAL_OPTS=--release make`and copy `bin/shards` into your `PATH`. For
 example `/usr/local/bin`.
 
 You are now ready to create a `shard.yml` for your projects (see details in

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Shards is usually distributed with Crystal itself (e.g. Homebrew and Debian
 packages). Alternatively, a `shards` package may be available for your system.
 
 You can download a source tarball from the same page (or clone the repository)
-then run `CRYSTAL_OPTS=--release make`and copy `bin/shards` into your `PATH`. For
+then run `make release=1`and copy `bin/shards` into your `PATH`. For
 example `/usr/local/bin`.
 
 You are now ready to create a `shard.yml` for your projects (see details in


### PR DESCRIPTION
`CRFLAGS` was dropped in favour of generic `CRYSTAL_OPTS` in #344

/cf https://github.com/crystal-lang/shards/pull/414#issuecomment-758347018

Maybe we should add a `release=1` flag to the makefile for this use case to add some abstraction?
