### PR TITLE
Improve error message when locked version is missing in source

### DIFF
--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -31,6 +31,10 @@ module Shards
       "#{self.class.key}: #{source}"
     end
 
+    def to_s(io : IO)
+      io << yaml_source_entry
+    end
+
     def versions_for(req : Requirement) : Array(Version)
       case req
       when Version then [req]


### PR DESCRIPTION
When running `shards install` and the locked version is not available in the source, it's an error. This error is now more explicit in describing this situation and recommends to run `shards update`.

This patch does not change any behaviour (as proposed in https://github.com/crystal-lang/shards/issues/465#issuecomment-763253847), it just improves the error reporting.

Related to #465