### PR TITLE
Add `--frozen` and `--without-development` CLI flags

### DIFF
--- a/docs/shards.adoc
+++ b/docs/shards.adoc
@@ -58,7 +58,7 @@ Exit status:
 *init*::
 Initializes a default _shard.yml_ in the current folder.
 
-*install*::
+*install* [--frozen] [--without-development] [--production]::
 Resolves and installs dependencies into the _lib_ folder. If not already
 present, generates a _shard.lock_ file from resolved dependencies, locking
 version numbers or Git commits.
@@ -67,6 +67,12 @@ Reads and enforces locked versions and commits if a _shard.lock_ file is
 present. The *install* command may fail if a locked version doesn't match
 a requirement, but may succeed if a new dependency was added, as long as it
 doesn't generate a conflict, thus generating a new _shard.lock_ file.
++
+--
+--frozen:: Strictly installs locked versions from _shard.lock_. Fails if _shard.lock_ is missing.
+--without-development:: Does not install development dependencies.
+--production:: same as _--frozen_ and _--without-development_
+--
 
 *list* [--tree]::
 Lists the installed dependencies and their versions.
@@ -120,12 +126,6 @@ after a command.
 
 --ignore-crystal-version::
   Do not enforce crystal version restrictions on shards.
-
---production::
-  Runs in release mode. Development dependencies won’t
-  be installed and only locked dependencies will be installed. Commands
-  will fail if dependencies in _shard.yml_ and _shard.lock_ are out of
-  sync (used by *install*, *update*, *check* and *list* commands).
 
 -q, --quiet::
   Decreases the log verbosity, printing only warnings and errors.

--- a/man/shards.1
+++ b/man/shards.1
@@ -2,12 +2,12 @@
 .\"     Title: shards
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.12
-.\"      Date: 2021-01-30
+.\"      Date: 2021-02-02
 .\"    Manual: Shards Manual
 .\"    Source: shards 0.13.0
 .\"  Language: English
 .\"
-.TH "SHARDS" "1" "2021-01-30" "shards 0.13.0" "Shards Manual"
+.TH "SHARDS" "1" "2021-02-02" "shards 0.13.0" "Shards Manual"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -92,7 +92,7 @@ Dependencies are not satisfied.
 Initializes a default \fIshard.yml\fP in the current folder.
 .RE
 .sp
-\fBinstall\fP
+\fBinstall\fP [\-\-frozen] [\-\-without\-development] [\-\-production]
 .RS 4
 Resolves and installs dependencies into the \fIlib\fP folder. If not already
 present, generates a \fIshard.lock\fP file from resolved dependencies, locking
@@ -102,6 +102,21 @@ Reads and enforces locked versions and commits if a \fIshard.lock\fP file is
 present. The \fBinstall\fP command may fail if a locked version doesn\(cqt match
 a requirement, but may succeed if a new dependency was added, as long as it
 doesn\(cqt generate a conflict, thus generating a new \fIshard.lock\fP file.
+.sp
+\-\-frozen
+.RS 4
+Strictly installs locked versions from \fIshard.lock\fP. Fails if \fIshard.lock\fP is missing.
+.RE
+.sp
+\-\-without\-development
+.RS 4
+Does not install development dependencies.
+.RE
+.sp
+\-\-production
+.RS 4
+same as \fI\-\-frozen\fP and \fI\-\-without\-development\fP
+.RE
 .RE
 .sp
 \fBlist\fP [\-\-tree]
@@ -176,14 +191,6 @@ Don\(cqt update remote repositories, use the local cache only.
 \-\-ignore\-crystal\-version
 .RS 4
 Do not enforce crystal version restrictions on shards.
-.RE
-.sp
-\-\-production
-.RS 4
-Runs in release mode. Development dependencies won’t
-be installed and only locked dependencies will be installed. Commands
-will fail if dependencies in \fIshard.yml\fP and \fIshard.lock\fP are out of
-sync (used by \fBinstall\fP, \fBupdate\fP, \fBcheck\fP and \fBlist\fP commands).
 .RE
 .sp
 \-q, \-\-quiet

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -398,143 +398,181 @@ describe "install" do
     end
   end
 
-  describe "with --production" do
-    it "fails if shard.lock and shard.yml has different sources" do
-      # The sources will not match, so the .lock is not valid regarding the specs
-      metadata = {dependencies: {awesome: {git: git_url(:forked_awesome)}}}
-      lock = {awesome: "0.1.0", d: "0.1.0"}
+  ["frozen", "production"].each do |flag|
+    describe "with --#{flag}" do
+      it "fails if shard.lock and shard.yml has different sources" do
+        # The sources will not match, so the .lock is not valid regarding the specs
+        metadata = {dependencies: {awesome: {git: git_url(:forked_awesome)}}}
+        lock = {awesome: "0.1.0", d: "0.1.0"}
 
-      with_shard(metadata, lock) do
-        assert_locked "awesome", "0.1.0", source: {git: git_url(:awesome)}
+        with_shard(metadata, lock) do
+          assert_locked "awesome", "0.1.0", source: {git: git_url(:awesome)}
 
-        ex = expect_raises(FailedCommand) { run "shards install --production --no-color" }
-        ex.stdout.should contain("Outdated shard.lock (awesome source changed)")
-        ex.stderr.should be_empty
+          ex = expect_raises(FailedCommand) { run "shards install --#{flag} --no-color" }
+          ex.stdout.should contain("Outdated shard.lock (awesome source changed)")
+          ex.stderr.should be_empty
+        end
+      end
+
+      it "fails if shard.lock is missing" do
+        metadata = {dependencies: {web: "*"}}
+
+        with_shard(metadata) do
+          ex = expect_raises(FailedCommand) { run "shards install --#{flag} --no-color" }
+          ex.stdout.should contain("Missing shard.lock")
+          ex.stderr.should be_empty
+        end
+      end
+
+      it "fails if shard.lock and shard.yml has different sources with incompatible versions." do
+        # User should use update command in this scenario
+        # forked_awesome does not have a 0.3.0
+        # awesome has 0.3.0
+        metadata = {dependencies: {awesome: {git: git_url(:forked_awesome)}}}
+        lock = {awesome: "0.3.0"}
+
+        with_shard(metadata, lock) do
+          assert_locked "awesome", "0.3.0", source: {git: git_url(:awesome)}
+
+          ex = expect_raises(FailedCommand) { run "shards install --#{flag} --no-color" }
+          ex.stdout.should contain("Maybe a commit, branch or file doesn't exist?")
+          ex.stderr.should be_empty
+        end
+      end
+
+      it "fails to install when dependency requirement changed" do
+        metadata = {dependencies: {web: "2.0.0"}}
+        lock = {web: "1.0.0"}
+
+        with_shard(metadata, lock) do
+          ex = expect_raises(FailedCommand) { run "shards install --no-color --#{flag}" }
+          ex.stdout.should contain("Outdated shard.lock")
+          ex.stderr.should be_empty
+          refute_installed "web"
+        end
+      end
+
+      it "fails to install when dependency requirement (commit) changed" do
+        metadata = {dependencies: {inprogress: {git: git_url(:inprogress), commit: git_commits(:inprogress)[1]}}}
+        lock = {inprogress: "0.1.0+git.commit.#{git_commits(:inprogress).first}"}
+
+        with_shard(metadata, lock) do
+          ex = expect_raises(FailedCommand) { run "shards install --no-color --#{flag}" }
+          ex.stdout.should contain("Outdated shard.lock")
+          refute_installed "inprogress"
+        end
+      end
+
+      it "doesn't install new dependencies" do
+        metadata = {
+          dependencies: {
+            web: "~> 1.0.0",
+            orm: "*",
+          },
+        }
+        lock = {web: "1.0.0"}
+
+        with_shard(metadata, lock) do
+          ex = expect_raises(FailedCommand) { run "shards install --#{flag} --no-color" }
+          ex.stdout.should contain("Outdated shard.lock")
+          ex.stderr.should be_empty
+        end
+      end
+
+      it "install" do
+        metadata = {dependencies: {web: "*"}}
+        lock = {web: "1.0.0"}
+
+        with_shard(metadata, lock) do
+          run "shards install --#{flag}"
+          assert_installed "web", "1.0.0"
+        end
+      end
+
+      it "install with locked commit" do
+        metadata = {dependencies: {web: "*"}}
+        web_version = "2.1.0+git.commit.#{git_commits(:web).first}"
+        lock = {web: web_version}
+
+        with_shard(metadata, lock) do
+          run "shards install --#{flag}"
+          assert_installed "web", "2.1.0", git: git_commits(:web).first
+        end
+      end
+
+      it "install with locked commit by a previous shards version" do
+        metadata = {dependencies: {web: "*"}}
+
+        with_shard(metadata) do
+          File.write "shard.lock", {version: "1.0", shards: {web: {git: git_url(:web), commit: git_commits(:web).first}}}
+          run "shards install --#{flag}"
+          assert_installed "web", "2.1.0", git: git_commits(:web).first
+        end
+      end
+
+      it "fails if lock is not up to date with override in main dependency" do
+        metadata = {dependencies: {
+          awesome: "*",
+        }}
+        lock = {awesome: "0.1.0", d: "0.1.0"}
+        override = {dependencies: {
+          awesome: {git: git_url(:forked_awesome), branch: "feature/super"},
+        }}
+        expected_commit = git_commits(:forked_awesome).first
+
+        with_shard(metadata, lock, override) do
+          ex = expect_raises(FailedCommand) { run "shards install --no-color --#{flag}" }
+          ex.stdout.should contain("Outdated shard.lock")
+          ex.stderr.should be_empty
+          refute_installed "awesome"
+        end
+      end
+
+      it "fails if lock is not up to date with override in nested dependency" do
+        metadata = {dependencies: {
+          intermediate: "*",
+        }}
+        lock = {intermediate: "0.1.0", awesome: "0.1.0", d: "0.1.0"}
+        override = {dependencies: {
+          awesome: {git: git_url(:forked_awesome), branch: "feature/super"},
+        }}
+        expected_commit = git_commits(:forked_awesome).first
+
+        with_shard(metadata, lock, override) do
+          ex = expect_raises(FailedCommand) { run "shards install --no-color --#{flag}" }
+          ex.stdout.should contain("Outdated shard.lock")
+          ex.stderr.should be_empty
+          refute_installed "awesome"
+        end
       end
     end
+  end
 
-    it "fails if shard.lock and shard.yml has different sources with incompatible versions." do
-      # User should use update command in this scenario
-      # forked_awesome does not have a 0.3.0
-      # awesome has 0.3.0
-      metadata = {dependencies: {awesome: {git: git_url(:forked_awesome)}}}
-      lock = {awesome: "0.3.0"}
-
-      with_shard(metadata, lock) do
-        assert_locked "awesome", "0.3.0", source: {git: git_url(:awesome)}
-
-        ex = expect_raises(FailedCommand) { run "shards install --production --no-color" }
-        ex.stdout.should contain("Maybe a commit, branch or file doesn't exist?")
-        ex.stderr.should be_empty
-      end
-    end
-
-    it "fails to install when dependency requirement changed" do
-      metadata = {dependencies: {web: "2.0.0"}}
-      lock = {web: "1.0.0"}
-
-      with_shard(metadata, lock) do
-        ex = expect_raises(FailedCommand) { run "shards install --no-color --production" }
-        ex.stdout.should contain("Outdated shard.lock")
-        ex.stderr.should be_empty
-        refute_installed "web"
-      end
-    end
-
-    it "fails to install when dependency requirement (commit) changed" do
-      metadata = {dependencies: {inprogress: {git: git_url(:inprogress), commit: git_commits(:inprogress)[1]}}}
-      lock = {inprogress: "0.1.0+git.commit.#{git_commits(:inprogress).first}"}
-
-      with_shard(metadata, lock) do
-        ex = expect_raises(FailedCommand) { run "shards install --no-color --production" }
-        ex.stdout.should contain("Outdated shard.lock")
-        refute_installed "inprogress"
-      end
-    end
-
-    it "doesn't install new dependencies" do
+  describe "with --without-development" do
+    it "doesn't install development dependencies" do
       metadata = {
-        dependencies: {
-          web: "~> 1.0.0",
-          orm: "*",
-        },
+        dependencies:             {web: "*", orm: "*"},
+        development_dependencies: {mock: "*"},
       }
-      lock = {web: "1.0.0"}
-
-      with_shard(metadata, lock) do
-        ex = expect_raises(FailedCommand) { run "shards install --production --no-color" }
-        ex.stdout.should contain("Outdated shard.lock")
-        ex.stderr.should be_empty
-      end
-    end
-
-    it "install" do
-      metadata = {dependencies: {web: "*"}}
-      lock = {web: "1.0.0"}
-
-      with_shard(metadata, lock) do
-        run "shards install --production"
-        assert_installed "web", "1.0.0"
-      end
-    end
-
-    it "install with locked commit" do
-      metadata = {dependencies: {web: "*"}}
-      web_version = "2.1.0+git.commit.#{git_commits(:web).first}"
-      lock = {web: web_version}
-
-      with_shard(metadata, lock) do
-        run "shards install --production"
-        assert_installed "web", "2.1.0", git: git_commits(:web).first
-      end
-    end
-
-    it "install with locked commit by a previous shards version" do
-      metadata = {dependencies: {web: "*"}}
 
       with_shard(metadata) do
-        File.write "shard.lock", {version: "1.0", shards: {web: {git: git_url(:web), commit: git_commits(:web).first}}}
-        run "shards install --production"
-        assert_installed "web", "2.1.0", git: git_commits(:web).first
+        File.exists?(File.join(application_path, "shard.lock")).should be_false
+        run "shards install --without-development"
+
+        # it installed dependencies (recursively)
+        assert_installed "web"
+        assert_installed "orm"
+
+        # it didn't install development dependencies
+        refute_installed "mock"
+        refute_installed "minitest"
+
+        File.exists?(File.join(application_path, "shard.lock")).should be_true
       end
     end
+  end
 
-    it "fails if lock is not up to date with override in main dependency" do
-      metadata = {dependencies: {
-        awesome: "*",
-      }}
-      lock = {awesome: "0.1.0", d: "0.1.0"}
-      override = {dependencies: {
-        awesome: {git: git_url(:forked_awesome), branch: "feature/super"},
-      }}
-      expected_commit = git_commits(:forked_awesome).first
-
-      with_shard(metadata, lock, override) do
-        ex = expect_raises(FailedCommand) { run "shards install --no-color --production" }
-        ex.stdout.should contain("Outdated shard.lock")
-        ex.stderr.should be_empty
-        refute_installed "awesome"
-      end
-    end
-
-    it "fails if lock is not up to date with override in nested dependency" do
-      metadata = {dependencies: {
-        intermediate: "*",
-      }}
-      lock = {intermediate: "0.1.0", awesome: "0.1.0", d: "0.1.0"}
-      override = {dependencies: {
-        awesome: {git: git_url(:forked_awesome), branch: "feature/super"},
-      }}
-      expected_commit = git_commits(:forked_awesome).first
-
-      with_shard(metadata, lock, override) do
-        ex = expect_raises(FailedCommand) { run "shards install --no-color --production" }
-        ex.stdout.should contain("Outdated shard.lock")
-        ex.stderr.should be_empty
-        refute_installed "awesome"
-      end
-    end
-
+  describe "with --production" do
     it "doesn't install development dependencies" do
       metadata = {
         dependencies:             {web: "*", orm: "*"},

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -540,22 +540,19 @@ describe "install" do
         dependencies:             {web: "*", orm: "*"},
         development_dependencies: {mock: "*"},
       }
+      # --production requires a lock file because it implies --frozen
+      lock = {web: "1.0.0", orm: "0.3.0"}
 
-      with_shard(metadata) do
-        File.exists?(File.join(application_path, "shard.lock")).should be_false
+      with_shard(metadata, lock) do
         run "shards install --production"
 
         # it installed dependencies (recursively)
         assert_installed "web"
         assert_installed "orm"
-        assert_installed "pg"
 
         # it didn't install development dependencies
         refute_installed "mock"
         refute_installed "minitest"
-
-        # it didn't generate lock file
-        File.exists?(File.join(application_path, "shard.lock")).should be_false
       end
     end
   end

--- a/spec/integration/list_spec.cr
+++ b/spec/integration/list_spec.cr
@@ -18,7 +18,24 @@ describe "list" do
     end
   end
 
-  it "production doesn't list development dependencies" do
+  it "--without-development doesn't list development dependencies" do
+    metadata = {
+      dependencies:             {web: "*", orm: "*"},
+      development_dependencies: {mock: "*"},
+    }
+
+    with_shard(metadata) do
+      run "shards install --without-development"
+      stdout = run "shards list --without-development"
+      stdout.should contain("web (2.1.0)")
+      stdout.should contain("orm (0.5.0)")
+      stdout.should contain("pg (0.2.1)")
+      stdout.should_not contain("mock")
+      stdout.should_not contain("shoulda")
+    end
+  end
+
+  it "--production doesn't list development dependencies" do
     metadata = {
       dependencies:             {web: "*", orm: "*"},
       development_dependencies: {mock: "*"},

--- a/spec/integration/list_spec.cr
+++ b/spec/integration/list_spec.cr
@@ -23,14 +23,16 @@ describe "list" do
       dependencies:             {web: "*", orm: "*"},
       development_dependencies: {mock: "*"},
     }
-    with_shard(metadata) do
+    # --production requires a lock file because it implies --frozen
+    lock = {web: "1.0.0", orm: "0.3.0"}
+
+    with_shard(metadata, lock) do
       run "shards install --production"
       stdout = run "shards list --production"
-      stdout.should contain("web (2.1.0)")
-      stdout.should contain("orm (0.5.0)")
-      stdout.should contain("pg (0.2.1)")
-      stdout.should_not contain("mock (0.1.0)")
-      stdout.should_not contain("shoulda (0.1.0)")
+      stdout.should contain("web (1.0.0)")
+      stdout.should contain("orm (0.3.0)")
+      stdout.should_not contain("mock")
+      stdout.should_not contain("shoulda")
     end
   end
 

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -30,7 +30,13 @@ module Shards
 
       opts.on("--no-color", "Disable colored output.") { self.colors = false }
       opts.on("--version", "Print the `shards` version.") { puts self.version_string; exit }
-      opts.on("--production", "Run in release mode. No development dependencies and strict sync between shard.yml and shard.lock.") do
+      opts.on("--frozen", "Strictly installs locked versions from shard.lock.") do
+        self.frozen = true
+      end
+      opts.on("--without-development", "Does not install development dependencies.") do
+        self.with_development = false
+      end
+      opts.on("--production", "same as `--frozen --without-development`") do
         self.frozen = true
         self.with_development = false
       end

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -30,7 +30,10 @@ module Shards
 
       opts.on("--no-color", "Disable colored output.") { self.colors = false }
       opts.on("--version", "Print the `shards` version.") { puts self.version_string; exit }
-      opts.on("--production", "Run in release mode. No development dependencies and strict sync between shard.yml and shard.lock.") { self.production = true }
+      opts.on("--production", "Run in release mode. No development dependencies and strict sync between shard.yml and shard.lock.") do
+        self.frozen = true
+        self.with_development = false
+      end
       opts.on("--local", "Don't update remote repositories, use the local cache only.") { self.local = true }
       opts.on("--ignore-crystal-version", "Do not enforce crystal version restrictions on shards.") { self.ignore_crystal_version = true }
       opts.on("-v", "--verbose", "Increase the log verbosity, printing all debug statements.") { self.set_debug_log_level }

--- a/src/commands/check.cr
+++ b/src/commands/check.cr
@@ -8,14 +8,14 @@ module Shards
         if has_dependencies?
           locks # ensures that lockfile exists
           verify(spec.dependencies)
-          verify(spec.development_dependencies) unless Shards.production?
+          verify(spec.development_dependencies) if Shards.with_development?
         end
 
         Log.info { "Dependencies are satisfied" }
       end
 
       private def has_dependencies?
-        spec.dependencies.any? || (!Shards.production? && spec.development_dependencies.any?)
+        spec.dependencies.any? || (Shards.with_development? && spec.development_dependencies.any?)
       end
 
       private def verify(dependencies)

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -14,11 +14,11 @@ module Shards
           solver.locks = locks.shards
         end
 
-        solver.prepare(development: !Shards.production?)
+        solver.prepare(development: Shards.with_development?)
 
         packages = handle_resolver_errors { solver.solve }
 
-        if lockfile? && Shards.production?
+        if lockfile? && Shards.frozen?
           validate(packages)
         end
 
@@ -26,7 +26,7 @@ module Shards
 
         if generate_lockfile?(packages)
           write_lockfile(packages)
-        elsif !Shards.production?
+        elsif !Shards.frozen?
           # Touch lockfile so its mtime is bigger than that of shard.yml
           File.touch(lockfile_path)
         end
@@ -87,7 +87,7 @@ module Shards
       end
 
       private def generate_lockfile?(packages)
-        !Shards.production? && (!lockfile? || outdated_lockfile?(packages))
+        !Shards.frozen? && (!lockfile? || outdated_lockfile?(packages))
       end
 
       private def outdated_lockfile?(packages)

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -5,6 +5,10 @@ module Shards
   module Commands
     class Install < Command
       def run(*, ignore_crystal_version = false)
+        if Shards.frozen? && !lockfile?
+          raise Error.new("Missing shard.lock")
+        end
+
         Log.info { "Resolving dependencies" }
 
         solver = MolinilloSolver.new(spec, override, ignore_crystal_version: ignore_crystal_version)
@@ -18,7 +22,7 @@ module Shards
 
         packages = handle_resolver_errors { solver.solve }
 
-        if lockfile? && Shards.frozen?
+        if Shards.frozen?
           validate(packages)
         end
 

--- a/src/commands/list.cr
+++ b/src/commands/list.cr
@@ -9,7 +9,7 @@ module Shards
         return unless has_dependencies?
         puts "Shards installed:"
         list(spec.dependencies)
-        list(spec.development_dependencies) unless Shards.production?
+        list(spec.development_dependencies) if Shards.with_development?
       end
 
       private def list(dependencies, level = 1)
@@ -30,7 +30,7 @@ module Shards
 
       # FIXME: duplicates Check#has_dependencies?
       private def has_dependencies?
-        spec.dependencies.any? || (!Shards.production? && spec.development_dependencies.any?)
+        spec.dependencies.any? || (Shards.with_development? && spec.development_dependencies.any?)
       end
     end
   end

--- a/src/commands/lock.cr
+++ b/src/commands/lock.cr
@@ -22,7 +22,7 @@ module Shards
           end
         end
 
-        solver.prepare(development: !Shards.production?)
+        solver.prepare(development: Shards.with_development?)
 
         packages = handle_resolver_errors { solver.solve }
         return if packages.empty?

--- a/src/commands/outdated.cr
+++ b/src/commands/outdated.cr
@@ -14,7 +14,7 @@ module Shards
         Log.info { "Resolving dependencies" }
 
         solver = MolinilloSolver.new(spec, override, prereleases: @prereleases, ignore_crystal_version: ignore_crystal_version)
-        solver.prepare(development: !Shards.production?)
+        solver.prepare(development: Shards.with_development?)
 
         packages = handle_resolver_errors { solver.solve }
         packages.each { |package| analyze(package) }
@@ -110,7 +110,7 @@ module Shards
 
       # FIXME: duplicates Check#has_dependencies?
       private def has_dependencies?
-        spec.dependencies.any? || (!Shards.production? && spec.development_dependencies.any?)
+        spec.dependencies.any? || (Shards.with_development? && spec.development_dependencies.any?)
       end
 
       private def dependency_by_name(name : String)

--- a/src/commands/update.cr
+++ b/src/commands/update.cr
@@ -15,7 +15,7 @@ module Shards
           solver.locks = locks.shards.reject { |d| shards.includes?(d.name) }
         end
 
-        solver.prepare(development: !Shards.production?)
+        solver.prepare(development: Shards.with_development?)
 
         packages = handle_resolver_errors { solver.solve }
         install(packages)
@@ -60,7 +60,7 @@ module Shards
       end
 
       private def generate_lockfile?(packages)
-        !Shards.production?
+        !Shards.frozen?
       end
     end
   end

--- a/src/config.cr
+++ b/src/config.cr
@@ -94,7 +94,8 @@ module Shards
     end
   end
 
-  class_property? production = false
+  class_property? frozen = false
+  class_property? with_development = true
   class_property? local = false
   class_property? ignore_crystal_version = false
 end


### PR DESCRIPTION
This patch adds flags `--frozen` and `--without-development` which allow to use the two functions of `--production` individually.

There's also a behavioural change included in ff457ff which lets `--frozen` fail when `shard.lock` is missing. This should actually be the expected behaviour, also for `--production`.

Resolves most of #452