### PR TITLE
Add --skip-postinstall cli option to install and update

### DIFF
--- a/docs/shards.adoc
+++ b/docs/shards.adoc
@@ -58,7 +58,7 @@ Exit status:
 *init*::
 Initializes a default _shard.yml_ in the current folder.
 
-*install* [--frozen] [--without-development] [--production]::
+*install* [--frozen] [--without-development] [--production] [--skip-postinstall]::
 Resolves and installs dependencies into the _lib_ folder. If not already
 present, generates a _shard.lock_ file from resolved dependencies, locking
 version numbers or Git commits.
@@ -72,6 +72,7 @@ doesn't generate a conflict, thus generating a new _shard.lock_ file.
 --frozen:: Strictly installs locked versions from _shard.lock_. Fails if _shard.lock_ is missing.
 --without-development:: Does not install development dependencies.
 --production:: same as _--frozen_ and _--without-development_
+--skip-postinstall:: Does not run postinstall of dependencies.
 --
 
 *list* [--tree]::

--- a/man/shard.yml.5
+++ b/man/shard.yml.5
@@ -2,12 +2,12 @@
 .\"     Title: shard.yml
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.12
-.\"      Date: 2021-01-30
+.\"      Date: 2021-02-19
 .\"    Manual: File Formats
 .\"    Source: shards 0.13.0
 .\"  Language: English
 .\"
-.TH "SHARD.YML" "5" "2021-01-30" "shards 0.13.0" "File Formats"
+.TH "SHARD.YML" "5" "2021-02-19" "shards 0.13.0" "File Formats"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/man/shards.1
+++ b/man/shards.1
@@ -2,12 +2,12 @@
 .\"     Title: shards
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.12
-.\"      Date: 2021-02-02
+.\"      Date: 2021-02-19
 .\"    Manual: Shards Manual
 .\"    Source: shards 0.13.0
 .\"  Language: English
 .\"
-.TH "SHARDS" "1" "2021-02-02" "shards 0.13.0" "Shards Manual"
+.TH "SHARDS" "1" "2021-02-19" "shards 0.13.0" "Shards Manual"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -92,7 +92,7 @@ Dependencies are not satisfied.
 Initializes a default \fIshard.yml\fP in the current folder.
 .RE
 .sp
-\fBinstall\fP [\-\-frozen] [\-\-without\-development] [\-\-production]
+\fBinstall\fP [\-\-frozen] [\-\-without\-development] [\-\-production] [\-\-skip\-postinstall]
 .RS 4
 Resolves and installs dependencies into the \fIlib\fP folder. If not already
 present, generates a \fIshard.lock\fP file from resolved dependencies, locking
@@ -116,6 +116,11 @@ Does not install development dependencies.
 \-\-production
 .RS 4
 same as \fI\-\-frozen\fP and \fI\-\-without\-development\fP
+.RE
+.sp
+\-\-skip\-postinstall
+.RS 4
+Does not run postinstall of dependencies.
 .RE
 .RE
 .sp

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -652,7 +652,15 @@ describe "install" do
     with_shard({dependencies: {post: "*"}}) do
       output = run "shards install --no-color"
       File.exists?(install_path("post", "made.txt")).should be_true
-      output.should contain("Postinstall of post: make")
+      output.should contain("Postinstall of post: make\n")
+    end
+  end
+
+  it "can skip postinstall script" do
+    with_shard({dependencies: {post: "*"}}) do
+      output = run "shards install --no-color --skip-postinstall"
+      File.exists?(install_path("post", "made.txt")).should be_false
+      output.should contain("Postinstall of post: make (skipped)")
     end
   end
 

--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -235,6 +235,15 @@ describe "update" do
     end
   end
 
+  it "can skipe postinstall with transitive dependencies" do
+    with_shard({dependencies: {transitive: "*"}}, {transitive: "0.1.0"}) do
+      output = run "shards update --no-color --skip-postinstall"
+      binary = install_path("transitive", Shards::Helpers.exe("version"))
+      File.exists?(binary).should be_false
+      output.should contain("Postinstall of transitive: crystal build src/version.cr (skipped)")
+    end
+  end
+
   it "installs new executables" do
     metadata = {dependencies: {binary: "0.2.0"}}
     lock = {binary: "0.1.0"}

--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -235,7 +235,7 @@ describe "update" do
     end
   end
 
-  it "can skipe postinstall with transitive dependencies" do
+  it "skips postinstall with transitive dependencies" do
     with_shard({dependencies: {transitive: "*"}}, {transitive: "0.1.0"}) do
       output = run "shards update --no-color --skip-postinstall"
       binary = install_path("transitive", Shards::Helpers.exe("version"))

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -40,6 +40,9 @@ module Shards
         self.frozen = true
         self.with_development = false
       end
+      opts.on("--skip-postinstall", "Does not run postinstall of dependencies") do
+        self.skip_postinstall = true
+      end
       opts.on("--local", "Don't update remote repositories, use the local cache only.") { self.local = true }
       opts.on("--ignore-crystal-version", "Do not enforce crystal version restrictions on shards.") { self.ignore_crystal_version = true }
       opts.on("-v", "--verbose", "Increase the log verbosity, printing all debug statements.") { self.set_debug_log_level }

--- a/src/config.cr
+++ b/src/config.cr
@@ -98,4 +98,5 @@ module Shards
   class_property? with_development = true
   class_property? local = false
   class_property? ignore_crystal_version = false
+  class_property? skip_postinstall = false
 end

--- a/src/package.cr
+++ b/src/package.cr
@@ -83,16 +83,20 @@ module Shards
     end
 
     def postinstall
-      run_script("postinstall")
+      run_script("postinstall", Shards.skip_postinstall?)
     rescue ex : Script::Error
       cleanup_install_directory
       raise ex
     end
 
-    def run_script(name)
+    def run_script(name, skip)
       if installed? && (command = spec.scripts[name]?)
-        Log.info { "#{name.capitalize} of #{self.name}: #{command}" }
-        Script.run(install_path, command, name, self.name)
+        if !skip
+          Log.info { "#{name.capitalize} of #{self.name}: #{command}" }
+          Script.run(install_path, command, name, self.name)
+        else
+          Log.info { "#{name.capitalize} of #{self.name}: #{command} (skipped)" }
+        end
       end
     end
 


### PR DESCRIPTION
Partially implements the suggestions of https://github.com/crystal-lang/shards/issues/468#issuecomment-767064550

The postinstall instructions will be logged with a trailing `(skipped)`.

Usually the postinstall will generate target binaries that are then linked/copied by `Package#install_executables`.

With this PR the target binaries will not exist and wont be linked/copied, which is fine.

To complete the idea https://github.com/crystal-lang/shards/issues/468#issuecomment-767064550 and decouple the commands for Windows environments in a comfortable way I am not sure if it's better to a) make the `shards postinstall --dry-run [shard names]` perform postinstall and install_executables or if b) postinstall and install-executables should be different commands. 

Either way that can be handled in a separate PR. This should be enough to download dependencies with postinstall in Windows.