### PR TITLE
Fix touch install_path to not accidentally create file

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -648,6 +648,24 @@ describe "install" do
     end
   end
 
+  it "updates lockfile when there are no dependencies" do
+    with_shard({name: "empty"}) do
+      run "shards install"
+      mtime = File.info("shard.lock").modification_time
+      run "shards install"
+      File.info("shard.lock").modification_time.should be >= mtime
+      Shards::Lock.from_file("shard.lock").version.should eq(Shards::Lock::CURRENT_VERSION)
+    end
+  end
+
+  it "creates ./lib/ when there are no dependencies" do
+    with_shard({name: "empty"}) do
+      File.exists?("./lib/").should be_false
+      run "shards install"
+      File.directory?("./lib/").should be_true
+    end
+  end
+
   it "runs postinstall script" do
     with_shard({dependencies: {post: "*"}}) do
       output = run "shards install --no-color"

--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -483,4 +483,22 @@ describe "update" do
       end
     end
   end
+
+  it "updates lockfile when there are no dependencies" do
+    with_shard({name: "empty"}) do
+      run "shards update"
+      mtime = File.info("shard.lock").modification_time
+      run "shards update"
+      File.info("shard.lock").modification_time.should be >= mtime
+      Shards::Lock.from_file("shard.lock").version.should eq(Shards::Lock::CURRENT_VERSION)
+    end
+  end
+
+  it "creates ./lib/ when there are no dependencies" do
+    with_shard({name: "empty"}) do
+      File.exists?("./lib/").should be_false
+      run "shards update"
+      File.directory?("./lib/").should be_true
+    end
+  end
 end

--- a/src/commands/command.cr
+++ b/src/commands/command.cr
@@ -101,5 +101,10 @@ module Shards
         Log.warn { "Using --ignore-crystal-version was not needed. All shards are already compatible with Crystal #{Shards.crystal_version}" }
       end
     end
+
+    def touch_install_path
+      Dir.mkdir_p(Shards.install_path)
+      File.touch(Shards.install_path)
+    end
   end
 end

--- a/src/commands/install.cr
+++ b/src/commands/install.cr
@@ -36,7 +36,7 @@ module Shards
         end
 
         # Touch install path so its mtime is bigger than that of the lockfile
-        File.touch(Shards.install_path)
+        touch_install_path
 
         if ignore_crystal_version
           check_ignored_crystal_version(packages)

--- a/src/commands/update.cr
+++ b/src/commands/update.cr
@@ -28,7 +28,7 @@ module Shards
         end
 
         # Touch install path so its mtime is bigger than that of the lockfile
-        File.touch(Shards.install_path)
+        touch_install_path
 
         if ignore_crystal_version
           check_ignored_crystal_version(packages)


### PR DESCRIPTION
Fix-up for #444. There's an unconditional `touch` on `./lib`. But that folder might not exist when no dependencies are installed. This ends up creating a file at this path, which is obviously not ideal because later you might want to install dependencies and shards expects a directory.

This patch makes sure to always create the folder.

Ref. https://github.com/crystal-lang/shards/pull/477#issuecomment-783651180

The newly added spec for `shard.lock` modification time was not broken, but added it for coverage.