### PR TITLE
Fix broken SOURCE_DATE_EPOCH in docs.mk

### DIFF
--- a/docs.mk
+++ b/docs.mk
@@ -6,7 +6,7 @@ MAN_FILES := man/shards.1 man/shard.yml.5
 HTML_FILES := docs/shards.html docs/shard.yml.html
 
 SHARDS_VERSION := $(shell cat VERSION)
-source_date_epoch := $(shell (git show -s --format=%ct HEAD || stat -c "%Y" $(1) || stat -f "%m" $(1)) 2> /dev/null)
+SOURCE_DATE_EPOCH := $(shell (git show -s --format=%ct HEAD || stat -c "%Y" Makefile || stat -f "%m" Makefile) 2> /dev/null)
 
 docs: manpages
 
@@ -15,10 +15,10 @@ manpages: $(MAN_FILES)
 htmlpages: $(HTML_FILES)
 
 man/%.1 man/%.5: docs/%.adoc
-	SOURCE_DATE_EPOCH=$(call source_date_epoch,$<) $(ASCIIDOC) $(ASCIIDOC_OPTIONS) $< -b manpage -o $@
+	SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(ASCIIDOC) $(ASCIIDOC_OPTIONS) $< -b manpage -o $@
 
 docs/%.html: docs/%.adoc
-	SOURCE_DATE_EPOCH=$(call source_date_epoch,$<) $(ASCIIDOC) $(ASCIIDOC_OPTIONS) $< -b html5 -o $@
+	SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) $(ASCIIDOC) $(ASCIIDOC_OPTIONS) $< -b html5 -o $@
 
 clean_docs: phony
 	rm -f $(MAN_FILES)


### PR DESCRIPTION
The call is totally broken and doesn't actually work (would need to define the function using `define`). It just happend to still succeed inside a git repository.

I don't think we really need file-specific SOURCE_DATE_EPOCH, so we can spare the call entirely and just use a global variable.

This change also allows to specify `SOURCE_DATE_EPOCH` as an external variable when building docs.

Ref https://github.com/crystal-lang/shards/issues/253#issuecomment-785079152