### PR TITLE
Versioning examples consider crystal 2.x changes in `shard.yml.adoc`

### DIFF
--- a/docs/shard.yml.adoc
+++ b/docs/shard.yml.adoc
@@ -101,7 +101,7 @@ NOTE: If this property is not included it is treated as _< 1.0.0_.
 +
 [source,yaml]
 ----
-crystal: ">= 0.35.0"
+crystal: ">= 0.35.0, < 2.0.0"
 ----
 
 *dependencies*::
@@ -355,7 +355,7 @@ with some dependencies:
 ----
 name: shards
 version: 1.2.3
-crystal: '>= 0.35.0'
+crystal: '>= 0.35.0, < 2.0.0'
 
 authors:
 - Julien Portalier <julien@example.com>

--- a/man/shard.yml.5
+++ b/man/shard.yml.5
@@ -2,12 +2,12 @@
 .\"     Title: shard.yml
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.12
-.\"      Date: 2021-03-10
+.\"      Date: 2021-03-23
 .\"    Manual: File Formats
 .\"    Source: shards 0.14.1
 .\"  Language: English
 .\"
-.TH "SHARD.YML" "5" "2021-03-10" "shards 0.14.1" "File Formats"
+.TH "SHARD.YML" "5" "2021-03-23" "shards 0.14.1" "File Formats"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -295,7 +295,7 @@ If this property is not included it is treated as \fI< 1.0.0\fP.
 .if n .RS 4
 .nf
 .fam C
-crystal: ">= 0.35.0"
+crystal: ">= 0.35.0, < 2.0.0"
 .fam
 .fi
 .if n .RE
@@ -701,7 +701,7 @@ with some dependencies:
 .fam C
 name: shards
 version: 1.2.3
-crystal: \(aq>= 0.35.0\(aq
+crystal: \(aq>= 0.35.0, < 2.0.0\(aq
 
 authors:
 \- Julien Portalier <julien@example.com>


### PR DESCRIPTION
I'm a newbie in crystal-lang and the tools around them. 😅 
So this PR might be just a question...

As far as I know, Crystal made many changes the specs so far.
So planning `2.0.0` will contain other many changes?
Then the versioning including `< 2.0.0` might be robust?
I saw `shards` specifying as it in own shard.yml https://github.com/crystal-lang/shards/blob/addc26a3f22fee9fccb01cbb3e8878bef02d4295/shard.yml#L15 👀 

I know `examples` does not mean `recommended`. But it often spread into wide, I think.
How about to write this in example?