### PR TITLE
Let `shards build` error if no targets defined

### DIFF
--- a/spec/integration/build_spec.cr
+++ b/spec/integration/build_spec.cr
@@ -71,4 +71,19 @@ describe "build" do
       File.exists?(bin_path("app")).should be_false
     end
   end
+
+  it "errors when no targets defined" do
+    File.write File.join(application_path, "shard.yml"), <<-YAML
+      name: build
+      version: 0.1.0
+    YAML
+
+    Dir.cd(application_path) do
+      ex = expect_raises(FailedCommand) do
+        run "shards build --no-color"
+      end
+      ex.stdout.should contain("Targets not defined in shard.yml")
+      File.exists?(bin_path("")).should be_false
+    end
+  end
 end

--- a/src/commands/build.cr
+++ b/src/commands/build.cr
@@ -4,6 +4,10 @@ module Shards
   module Commands
     class Build < Command
       def run(targets, options)
+        if spec.targets.empty?
+          raise Error.new("Targets not defined in #{SPEC_FILENAME}")
+        end
+
         unless Dir.exists?(Shards.bin_path)
           Log.debug { "mkdir #{Shards.bin_path}" }
           Dir.mkdir(Shards.bin_path)


### PR DESCRIPTION
If no `targets` are defined in `shard.yml`, the command `shards build` should fail with an error message instead of silently succeeding without actually building anything.

/cc https://forum.crystal-lang.org/t/trouble-with-building-shard/3122