### PR TITLE
Don't default the Crystal version to "<1.0.0", use only the lower bound

### DIFF
--- a/docs/shard.yml.adoc
+++ b/docs/shard.yml.adoc
@@ -83,16 +83,15 @@ When resolving dependencies, only the versions that comply with the current
 crystal will be candidates. You can pass _--ignore-crystal-version_ to disregard this
 behavior.
 +
-The valid values are the same as for _dependencies.version_:
+The valid values are mostly the same as for _dependencies.version_:
 +
 --
-* It may be a version number.
-* It may be _"*"_ if any version will do (this is the default if unspecified).
-* The version number may be prefixed by an operator: _<_, _<=_, _>_, _>=_ or _~>_.
+* A version number prefixed by an operator: _<_, _<=_, _>_, _>=_ or _~>_.
+* Just _"*"_ if any version will do (this is the default if unspecified).
 * Multiple requirements can be separated by commas.
 --
-+
-When just a version number is used, it works exactly the same as a `>=` check:
+There is a special legacy behavior (its use is discouraged) when just a version
+number is used as the value: it works exactly the same as a `>=` check:
 _x.y.z_ will be interpreted as _">= x.y.z"_
 +
 You are welcome to also specify the upper bound to be lower than the next

--- a/docs/shard.yml.adoc
+++ b/docs/shard.yml.adoc
@@ -87,21 +87,23 @@ The valid values are the same as for _dependencies.version_:
 +
 --
 * It may be a version number.
-* It may be _"*"_ if any version will do.
+* It may be _"*"_ if any version will do (this is the default if unspecified).
 * The version number may be prefixed by an operator: _<_, _<=_, _>_, _>=_ or _~>_.
 * Multiple requirements can be separated by commas.
 --
 +
-When just a version number is used it has a different semantic compared to dependencies:
-_x.y.z_ will be interpreted as _~> x.y, >= x.y.z_ (ie: _>= x.y.z, < (x+1).0.0_) honoring semver.
+When just a version number is used, it works exactly the same as a `>=` check:
+_x.y.z_ will be interpreted as _">= x.y.z"_
 +
-NOTE: If this property is not included it is treated as _< 1.0.0_.
+You are welcome to also specify the upper bound to be lower than the next
+(future) major Crystal version, because there's no guarantee that it won't
+break your library.
 +
 *Example:*
 +
 [source,yaml]
 ----
-crystal: ">= 0.35.0"
+crystal: ">= 0.35, < 2.0"
 ----
 
 *dependencies*::

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -133,10 +133,10 @@ private def setup_repositories
   create_git_release "d", "0.2.0"
 
   create_git_repository "incompatible"
-  create_git_release "incompatible", "0.1.0", {crystal: "0.1.0"}
-  create_git_release "incompatible", "0.2.0", {crystal: "0.2.0"}
-  create_git_release "incompatible", "0.3.0", {crystal: "0.4"}
-  create_git_release "incompatible", "1.0.0", {crystal: "1.0.0"}
+  create_git_release "incompatible", "0.1.0", {crystal: "~>0.1, >=0.1.0"}
+  create_git_release "incompatible", "0.2.0", {crystal: "~>0.2, >=0.2.0"}
+  create_git_release "incompatible", "0.3.0", {crystal: "~>0.4, >=0.4"}
+  create_git_release "incompatible", "1.0.0", {crystal: "~>1.0, >=1.0.0"}
 
   create_git_repository "awesome"
   create_git_release "awesome", "0.1.0", {

--- a/src/molinillo_solver.cr
+++ b/src/molinillo_solver.cr
@@ -184,13 +184,13 @@ module Shards
     def self.crystal_version_req(specification : Shards::Spec)
       crystal_pattern =
         if crystal_version = specification.crystal
-          if crystal_version =~ /^(\d+)\.(\d+)(\.(\d+))?$/
-            "~> #{$1}.#{$2}, >= #{crystal_version}"
+          if crystal_version =~ /^\d+\.\d+(\.\d+)?$/
+            ">= #{crystal_version}"
           else
             crystal_version
           end
         else
-          "< 1.0.0"
+          "*"
         end
 
       VersionReq.new(crystal_pattern)


### PR DESCRIPTION
Fixes #413

As I said in https://github.com/crystal-lang/shards/issues/413#issuecomment-727671407, when discussing this breaking check, there was no motivation specified in terms of how this makes developers' lives better at all. And seems that the majority does not want this check.

Behavior before #395:
`crystal: ` field does nothing

Behavior now:
`crystal` unspecified means `< 1.0.0`
`crystal: x.y.z` means `>= x.y.z, <(x+1).0`

Behavior with this PR:
`crystal` unspecified means `*` / does mostly nothing
`crystal: x.y.z` means `>= x.y.z`

It is still possible to explicitly write `crystal: ">=0.35, <2.0"` and the check *will* trigger.