### PR TITLE
Update manpages

### DIFF
--- a/man/shard.yml.5
+++ b/man/shard.yml.5
@@ -2,12 +2,12 @@
 .\"     Title: shard.yml
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.12
-.\"      Date: 2021-03-10
+.\"      Date: 2021-06-09
 .\"    Manual: File Formats
 .\"    Source: shards 0.14.1
 .\"  Language: English
 .\"
-.TH "SHARD.YML" "5" "2021-03-10" "shards 0.14.1" "File Formats"
+.TH "SHARD.YML" "5" "2021-06-09" "shards 0.14.1" "File Formats"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -223,11 +223,13 @@ authors:
 A restriction to indicate which are the supported crystal versions. This will
 usually express a lower and upper\-bound constraints (string, recommended)
 .sp
-When resolving dependencies, only the versions that comply with the current
-crystal will be candidates. You can pass \fI\-\-ignore\-crystal\-version\fP to disregard this
-behavior.
+When resolving dependencies, this information is not used. After dependecies
+have been determined shards checks all of them are expected to work with
+the current crystal version. If not, a warning appears for the offending
+dependencies. The resolved versions are installed and can be used at your
+own risk.
 .sp
-The valid values are the same as for \fIdependencies.version\fP:
+The valid values are mostly the same as for \fIdependencies.version\fP:
 .sp
 .RS 4
 .ie n \{\
@@ -237,7 +239,7 @@ The valid values are the same as for \fIdependencies.version\fP:
 .  sp -1
 .  IP \(bu 2.3
 .\}
-It may be a version number.
+A version number prefixed by an operator: \fI<\fP, \fI<=\fP, \fI>\fP, \fI>=\fP or \fI~>\fP.
 .RE
 .sp
 .RS 4
@@ -248,18 +250,7 @@ It may be a version number.
 .  sp -1
 .  IP \(bu 2.3
 .\}
-It may be \fI"*"\fP if any version will do.
-.RE
-.sp
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.  sp -1
-.  IP \(bu 2.3
-.\}
-The version number may be prefixed by an operator: \fI<\fP, \fI\(lA\fP, \fI>\fP, \fI>=\fP or \fI~>\fP.
+Just \fI"*"\fP if any version will do (this is the default if unspecified).
 .RE
 .sp
 .RS 4
@@ -273,29 +264,20 @@ The version number may be prefixed by an operator: \fI<\fP, \fI\(lA\fP, \fI>\fP,
 Multiple requirements can be separated by commas.
 .RE
 .sp
-When just a version number is used it has a different semantic compared to dependencies:
-\fIx.y.z\fP will be interpreted as \fI~> x.y, >= x.y.z\fP (ie: \fI>= x.y.z, < (x+1).0.0\fP) honoring semver.
-.if n .sp
-.RS 4
-.it 1 an-trap
-.nr an-no-space-flag 1
-.nr an-break-flag 1
-.br
-.ps +1
-.B Note
-.ps -1
-.br
+There is a special legacy behavior (its use is discouraged) when just a version
+number is used as the value: it works exactly the same as a \f(CR>=\fP check:
+\fIx.y.z\fP is interpreted as \fI">= x.y.z"\fP
 .sp
-If this property is not included it is treated as \fI< 1.0.0\fP.
-.sp .5v
-.RE
+You are welcome to also specify the upper bound to be lower than the next
+(future) major Crystal version, because there\(cqs no guarantee that it won\(cqt
+break your library.
 .sp
 \fBExample:\fP
 .sp
 .if n .RS 4
 .nf
 .fam C
-crystal: ">= 0.35.0"
+crystal: ">= 0.35, < 2.0"
 .fam
 .fi
 .if n .RE
@@ -434,7 +416,7 @@ It may be \fI"*"\fP if any version will do.
 .  sp -1
 .  IP \(bu 2.3
 .\}
-The version number may be prefixed by an operator: \fI<\fP, \fI\(lA\fP, \fI>\fP, \fI>=\fP or \fI~>\fP.
+The version number may be prefixed by an operator: \fI<\fP, \fI<=\fP, \fI>\fP, \fI>=\fP or \fI~>\fP.
 .RE
 .sp
 .if n .RS 4
@@ -455,6 +437,7 @@ libraries:
 .URL "http://opensource.org/" "OSI license" " "
 name or an URL to a license file
 (string, recommended).
+.RE
 .sp
 \fBrepository\fP
 .RS 4
@@ -476,7 +459,6 @@ repository: "https://github.com/crystal\-lang/shards"
 .fam
 .fi
 .if n .RE
-.RE
 .RE
 .sp
 \fBscripts\fP
@@ -635,7 +617,7 @@ version available).
 .  sp -1
 .  IP \(bu 2.3
 .\}
-The version number may be prefixed by an operator: \fI<\fP, \fI\(lA\fP, \fI>\fP, \fI>=\fP or \fI~>\fP.
+The version number may be prefixed by an operator: \fI<\fP, \fI<=\fP, \fI>\fP, \fI>=\fP or \fI~>\fP.
 .RE
 .sp
 .RS 4

--- a/man/shards.1
+++ b/man/shards.1
@@ -2,12 +2,12 @@
 .\"     Title: shards
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.12
-.\"      Date: 2021-03-10
+.\"      Date: 2021-06-09
 .\"    Manual: Shards Manual
 .\"    Source: shards 0.14.1
 .\"  Language: English
 .\"
-.TH "SHARDS" "1" "2021-03-10" "shards 0.14.1" "Shards Manual"
+.TH "SHARDS" "1" "2021-06-09" "shards 0.14.1" "Shards Manual"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -193,11 +193,6 @@ Disables colored output.
 Don\(cqt update remote repositories, use the local cache only.
 .RE
 .sp
-\-\-ignore\-crystal\-version
-.RS 4
-Do not enforce crystal version restrictions on shards.
-.RE
-.sp
 \-q, \-\-quiet
 .RS 4
 Decreases the log verbosity, printing only warnings and errors.
@@ -222,7 +217,7 @@ should be added to \fBPATH\fP.
 SHARDS_OPTS
 .RS 4
 Allows general options to be passed in as environment variable.
-\fBExample\fP: \fISHARDS_OPTS="\-\-ignore\-crystal\-version" shards update\fP
+\fBExample\fP: \fISHARDS_OPTS="\-\-no\-color" shards update\fP
 .RE
 .sp
 SHARDS_CACHE_PATH
@@ -253,7 +248,7 @@ Defaults to the output of \fIcrystal env CRYSTAL_VERSION\fP.
 .sp
 SHARDS_OVERRIDE
 .RS 4
-Defines the location of \fIshard.override.yml\fP.
+Defines an alternate location of \fIshard.override.yml\fP.
 .RE
 .SH "FILES"
 .sp
@@ -265,7 +260,16 @@ See \fBshard.yml\fP(5) for documentation.
 .sp
 shard.override.yml
 .RS 4
-Local overrides to \fIshard.yml\fP.
+Allows overriding the source and restriction of dependencies. An alternative
+location can be configured with the env var \fBSHARDS_OVERRIDE\fP.
+.sp
+The file contains a YAML document with a single \fBdependencies\fP key. It has the
+same semantics as in \fBshard.yml\fP. Dependency configuration takes precedence over
+the configuration in \fBshard.yml\fP or any dependency\(cqs \fBshard.yml\fP.
+.sp
+Use cases are local working copies, forcing a specific dependency version
+despite mismatching constraints, fixing a dependency, checking compatibility
+with unreleased dependency versions.
 .RE
 .sp
 shard.lock


### PR DESCRIPTION
The doc sources have been updated in a couple of recent PRs, but the manpages were not re-generated.

Ideally, we should have a CI check to make sure that the manpages are up to date if the sources are changed.
However, I was not yet able to implement a correct validation.
See https://github.com/straight-shoota/shards/commits/fix/manpage-changes for my current approach. It is some trouble to get appropriate SOURCE_DATE_EPOCH. It seems `git log -1 --format='%aI' -- $file` reports the date of HEAD instead of the last commit that changed `$file`. It works as expected locally, but not in CI 🤷 