### PR TITLE
Add `--skip-executables`

### DIFF
--- a/docs/shard.yml.adoc
+++ b/docs/shard.yml.adoc
@@ -82,7 +82,7 @@ usually express a lower and upper-bound constraints (string, recommended)
 When resolving dependencies, this information is not used. After dependecies
 have been determined shards checks all of them are expected to work with
 the current crystal version. If not, a warning appears for the offending
-dependencies. The resolved versions are installed and can be used at your 
+dependencies. The resolved versions are installed and can be used at your
 own risk.
 +
 The valid values are mostly the same as for _dependencies.version_:
@@ -158,7 +158,8 @@ POSIX platforms). When installed as a dependency for another project the
 executables will be copied to the _bin_ folder of that project.
 +
 Executables are always installed last, after the _postinstall_ script is run, so
-libraries can build the executables when they are installed by Shards.
+libraries can build the executables when they are installed by Shards. Installation
+can be disabled by passing the flag _--skip-executables_.
 +
 *Example:*
 +

--- a/docs/shards.adoc
+++ b/docs/shards.adoc
@@ -58,7 +58,7 @@ Exit status:
 *init*::
 Initializes a default _shard.yml_ in the current folder.
 
-*install* [--frozen] [--without-development] [--production] [--skip-postinstall]::
+*install* [--frozen] [--without-development] [--production] [--skip-postinstall] [--skip-executables]::
 Resolves and installs dependencies into the _lib_ folder. If not already
 present, generates a _shard.lock_ file from resolved dependencies, locking
 version numbers or Git commits.
@@ -73,6 +73,7 @@ doesn't generate a conflict, thus generating a new _shard.lock_ file.
 --without-development:: Does not install development dependencies.
 --production:: same as _--frozen_ and _--without-development_
 --skip-postinstall:: Does not run postinstall of dependencies.
+--skip-executables:: Does not install executables.
 --
 
 *list* [--tree]::

--- a/man/shard.yml.5
+++ b/man/shard.yml.5
@@ -2,12 +2,12 @@
 .\"     Title: shard.yml
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.12
-.\"      Date: 2021-03-10
+.\"      Date: 2021-06-09
 .\"    Manual: File Formats
 .\"    Source: shards 0.14.1
 .\"  Language: English
 .\"
-.TH "SHARD.YML" "5" "2021-03-10" "shards 0.14.1" "File Formats"
+.TH "SHARD.YML" "5" "2021-06-09" "shards 0.14.1" "File Formats"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -223,11 +223,13 @@ authors:
 A restriction to indicate which are the supported crystal versions. This will
 usually express a lower and upper\-bound constraints (string, recommended)
 .sp
-When resolving dependencies, only the versions that comply with the current
-crystal will be candidates. You can pass \fI\-\-ignore\-crystal\-version\fP to disregard this
-behavior.
+When resolving dependencies, this information is not used. After dependecies
+have been determined shards checks all of them are expected to work with
+the current crystal version. If not, a warning appears for the offending
+dependencies. The resolved versions are installed and can be used at your
+own risk.
 .sp
-The valid values are the same as for \fIdependencies.version\fP:
+The valid values are mostly the same as for \fIdependencies.version\fP:
 .sp
 .RS 4
 .ie n \{\
@@ -237,7 +239,7 @@ The valid values are the same as for \fIdependencies.version\fP:
 .  sp -1
 .  IP \(bu 2.3
 .\}
-It may be a version number.
+A version number prefixed by an operator: \fI<\fP, \fI<=\fP, \fI>\fP, \fI>=\fP or \fI~>\fP.
 .RE
 .sp
 .RS 4
@@ -248,18 +250,7 @@ It may be a version number.
 .  sp -1
 .  IP \(bu 2.3
 .\}
-It may be \fI"*"\fP if any version will do.
-.RE
-.sp
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.  sp -1
-.  IP \(bu 2.3
-.\}
-The version number may be prefixed by an operator: \fI<\fP, \fI\(lA\fP, \fI>\fP, \fI>=\fP or \fI~>\fP.
+Just \fI"*"\fP if any version will do (this is the default if unspecified).
 .RE
 .sp
 .RS 4
@@ -273,29 +264,20 @@ The version number may be prefixed by an operator: \fI<\fP, \fI\(lA\fP, \fI>\fP,
 Multiple requirements can be separated by commas.
 .RE
 .sp
-When just a version number is used it has a different semantic compared to dependencies:
-\fIx.y.z\fP will be interpreted as \fI~> x.y, >= x.y.z\fP (ie: \fI>= x.y.z, < (x+1).0.0\fP) honoring semver.
-.if n .sp
-.RS 4
-.it 1 an-trap
-.nr an-no-space-flag 1
-.nr an-break-flag 1
-.br
-.ps +1
-.B Note
-.ps -1
-.br
+There is a special legacy behavior (its use is discouraged) when just a version
+number is used as the value: it works exactly the same as a \f(CR>=\fP check:
+\fIx.y.z\fP is interpreted as \fI">= x.y.z"\fP
 .sp
-If this property is not included it is treated as \fI< 1.0.0\fP.
-.sp .5v
-.RE
+You are welcome to also specify the upper bound to be lower than the next
+(future) major Crystal version, because there\(cqs no guarantee that it won\(cqt
+break your library.
 .sp
 \fBExample:\fP
 .sp
 .if n .RS 4
 .nf
 .fam C
-crystal: ">= 0.35.0"
+crystal: ">= 0.35, < 2.0"
 .fam
 .fi
 .if n .RE
@@ -434,7 +416,7 @@ It may be \fI"*"\fP if any version will do.
 .  sp -1
 .  IP \(bu 2.3
 .\}
-The version number may be prefixed by an operator: \fI<\fP, \fI\(lA\fP, \fI>\fP, \fI>=\fP or \fI~>\fP.
+The version number may be prefixed by an operator: \fI<\fP, \fI<=\fP, \fI>\fP, \fI>=\fP or \fI~>\fP.
 .RE
 .sp
 .if n .RS 4
@@ -455,6 +437,7 @@ libraries:
 .URL "http://opensource.org/" "OSI license" " "
 name or an URL to a license file
 (string, recommended).
+.RE
 .sp
 \fBrepository\fP
 .RS 4
@@ -476,7 +459,6 @@ repository: "https://github.com/crystal\-lang/shards"
 .fam
 .fi
 .if n .RE
-.RE
 .RE
 .sp
 \fBscripts\fP
@@ -635,7 +617,7 @@ version available).
 .  sp -1
 .  IP \(bu 2.3
 .\}
-The version number may be prefixed by an operator: \fI<\fP, \fI\(lA\fP, \fI>\fP, \fI>=\fP or \fI~>\fP.
+The version number may be prefixed by an operator: \fI<\fP, \fI<=\fP, \fI>\fP, \fI>=\fP or \fI~>\fP.
 .RE
 .sp
 .RS 4

--- a/man/shard.yml.5
+++ b/man/shard.yml.5
@@ -2,12 +2,12 @@
 .\"     Title: shard.yml
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.12
-.\"      Date: 2021-06-09
+.\"      Date: 2021-06-10
 .\"    Manual: File Formats
 .\"    Source: shards 0.14.1
 .\"  Language: English
 .\"
-.TH "SHARD.YML" "5" "2021-06-09" "shards 0.14.1" "File Formats"
+.TH "SHARD.YML" "5" "2021-06-10" "shards 0.14.1" "File Formats"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -349,7 +349,8 @@ POSIX platforms). When installed as a dependency for another project the
 executables will be copied to the \fIbin\fP folder of that project.
 .sp
 Executables are always installed last, after the \fIpostinstall\fP script is run, so
-libraries can build the executables when they are installed by Shards.
+libraries can build the executables when they are installed by Shards. Installation
+can be disabled by passing the flag \fI\-\-skip\-executables\fP.
 .sp
 \fBExample:\fP
 .sp

--- a/man/shard.yml.5
+++ b/man/shard.yml.5
@@ -2,12 +2,12 @@
 .\"     Title: shard.yml
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.12
-.\"      Date: 2021-06-10
+.\"      Date: 2021-06-24
 .\"    Manual: File Formats
 .\"    Source: shards 0.14.1
 .\"  Language: English
 .\"
-.TH "SHARD.YML" "5" "2021-06-10" "shards 0.14.1" "File Formats"
+.TH "SHARD.YML" "5" "2021-06-24" "shards 0.14.1" "File Formats"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/man/shards.1
+++ b/man/shards.1
@@ -2,12 +2,12 @@
 .\"     Title: shards
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.12
-.\"      Date: 2021-06-09
+.\"      Date: 2021-06-10
 .\"    Manual: Shards Manual
 .\"    Source: shards 0.14.1
 .\"  Language: English
 .\"
-.TH "SHARDS" "1" "2021-06-09" "shards 0.14.1" "Shards Manual"
+.TH "SHARDS" "1" "2021-06-10" "shards 0.14.1" "Shards Manual"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -92,7 +92,7 @@ Dependencies are not satisfied.
 Initializes a default \fIshard.yml\fP in the current folder.
 .RE
 .sp
-\fBinstall\fP [\-\-frozen] [\-\-without\-development] [\-\-production] [\-\-skip\-postinstall]
+\fBinstall\fP [\-\-frozen] [\-\-without\-development] [\-\-production] [\-\-skip\-postinstall] [\-\-skip\-executables]
 .RS 4
 Resolves and installs dependencies into the \fIlib\fP folder. If not already
 present, generates a \fIshard.lock\fP file from resolved dependencies, locking
@@ -121,6 +121,11 @@ same as \fI\-\-frozen\fP and \fI\-\-without\-development\fP
 \-\-skip\-postinstall
 .RS 4
 Does not run postinstall of dependencies.
+.RE
+.sp
+\-\-skip\-executables
+.RS 4
+Does not install executables.
 .RE
 .RE
 .sp

--- a/man/shards.1
+++ b/man/shards.1
@@ -2,12 +2,12 @@
 .\"     Title: shards
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.12
-.\"      Date: 2021-06-10
+.\"      Date: 2021-06-24
 .\"    Manual: Shards Manual
 .\"    Source: shards 0.14.1
 .\"  Language: English
 .\"
-.TH "SHARDS" "1" "2021-06-10" "shards 0.14.1" "Shards Manual"
+.TH "SHARDS" "1" "2021-06-24" "shards 0.14.1" "Shards Manual"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/man/shards.1
+++ b/man/shards.1
@@ -2,12 +2,12 @@
 .\"     Title: shards
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.12
-.\"      Date: 2021-03-10
+.\"      Date: 2021-06-09
 .\"    Manual: Shards Manual
 .\"    Source: shards 0.14.1
 .\"  Language: English
 .\"
-.TH "SHARDS" "1" "2021-03-10" "shards 0.14.1" "Shards Manual"
+.TH "SHARDS" "1" "2021-06-09" "shards 0.14.1" "Shards Manual"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -193,11 +193,6 @@ Disables colored output.
 Don\(cqt update remote repositories, use the local cache only.
 .RE
 .sp
-\-\-ignore\-crystal\-version
-.RS 4
-Do not enforce crystal version restrictions on shards.
-.RE
-.sp
 \-q, \-\-quiet
 .RS 4
 Decreases the log verbosity, printing only warnings and errors.
@@ -222,7 +217,7 @@ should be added to \fBPATH\fP.
 SHARDS_OPTS
 .RS 4
 Allows general options to be passed in as environment variable.
-\fBExample\fP: \fISHARDS_OPTS="\-\-ignore\-crystal\-version" shards update\fP
+\fBExample\fP: \fISHARDS_OPTS="\-\-no\-color" shards update\fP
 .RE
 .sp
 SHARDS_CACHE_PATH
@@ -253,7 +248,7 @@ Defaults to the output of \fIcrystal env CRYSTAL_VERSION\fP.
 .sp
 SHARDS_OVERRIDE
 .RS 4
-Defines the location of \fIshard.override.yml\fP.
+Defines an alternate location of \fIshard.override.yml\fP.
 .RE
 .SH "FILES"
 .sp
@@ -265,7 +260,16 @@ See \fBshard.yml\fP(5) for documentation.
 .sp
 shard.override.yml
 .RS 4
-Local overrides to \fIshard.yml\fP.
+Allows overriding the source and restriction of dependencies. An alternative
+location can be configured with the env var \fBSHARDS_OVERRIDE\fP.
+.sp
+The file contains a YAML document with a single \fBdependencies\fP key. It has the
+same semantics as in \fBshard.yml\fP. Dependency configuration takes precedence over
+the configuration in \fBshard.yml\fP or any dependency\(cqs \fBshard.yml\fP.
+.sp
+Use cases are local working copies, forcing a specific dependency version
+despite mismatching constraints, fixing a dependency, checking compatibility
+with unreleased dependency versions.
 .RE
 .sp
 shard.lock

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -845,6 +845,21 @@ describe "install" do
     `#{Process.quote(baz)}`.should eq("KO")
   end
 
+  it "skips installing executables" do
+    metadata = {
+      dependencies: {binary: "0.1.0"},
+    }
+    with_shard(metadata) { run("shards install --no-color --skip-executables") }
+
+    foobar = File.join(application_path, "bin", Shards::Helpers.exe("foobar"))
+    baz = File.join(application_path, "bin", Shards::Helpers.exe("baz"))
+    foo = File.join(application_path, "bin", Shards::Helpers.exe("foo"))
+
+    File.exists?(foobar).should be_false
+    File.exists?(baz).should be_false
+    File.exists?(foo).should be_false
+  end
+
   it "installs executables at refs" do
     metadata = {
       dependencies: {

--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -262,6 +262,20 @@ describe "update" do
     `#{Process.quote(foo)}`.should eq("FOO")
   end
 
+  it "skips installing new executables" do
+    metadata = {dependencies: {binary: "0.2.0"}}
+    lock = {binary: "0.1.0"}
+    with_shard(metadata, lock) { run("shards update --no-color --skip-executables") }
+
+    foobar = File.join(application_path, "bin", Shards::Helpers.exe("foobar"))
+    baz = File.join(application_path, "bin", Shards::Helpers.exe("baz"))
+    foo = File.join(application_path, "bin", Shards::Helpers.exe("foo"))
+
+    File.exists?(foobar).should be_false
+    File.exists?(baz).should be_false
+    File.exists?(foo).should be_false
+  end
+
   it "doesn't update local cache" do
     metadata = {
       dependencies: {local_cache: "*"},

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -43,6 +43,9 @@ module Shards
       opts.on("--skip-postinstall", "Does not run postinstall of dependencies") do
         self.skip_postinstall = true
       end
+      opts.on("--skip-executables", "Does not install executables") do
+        self.skip_executables = true
+      end
       opts.on("--local", "Don't update remote repositories, use the local cache only.") { self.local = true }
       # TODO: remove in the future
       opts.on("--ignore-crystal-version", "Has no effect. Kept for compatibility, to be removed in the future.") { }

--- a/src/config.cr
+++ b/src/config.cr
@@ -98,4 +98,5 @@ module Shards
   class_property? with_development = true
   class_property? local = false
   class_property? skip_postinstall = false
+  class_property? skip_executables = false
 end

--- a/src/package.cr
+++ b/src/package.cr
@@ -101,7 +101,7 @@ module Shards
     end
 
     def install_executables
-      return if !installed? || spec.executables.empty?
+      return if !installed? || spec.executables.empty? || Shards.skip_executables?
 
       Dir.mkdir_p(Shards.bin_path)
 


### PR DESCRIPTION
This patch adds a `--skip-executables` flag for the `install` and `update` commands which disables installing files defined as `executables` in any `shard.yml`

This is a minimal solution for #498 with behaviour I think we can all agree on.

I would go one step further and also imply this flag when `--skip-postinstall` is used, because executables are typically built by postinstall hooks and if they're not executed, installing the executables will fail (see https://github.com/crystal-lang/shards/issues/498#issuecomment-826122183).
But this is not strictly necessary for this PR, we can at least provide an option (even if it's more lengthy) to skip installation of executables.

The manpages diff is big and contains unrelated changes because of #505, which is included as the first commit here and thus should be merged first.