### PR TITLE
[Makefile] Fix shard.lock recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,6 @@ lib: shard.lock
 	$(SHARDS) install || (curl -L $(MOLINILLO_URL) | tar -xzf - -C lib/molinillo --strip-components=1)
 
 shard.lock: shard.yml
-	$(SHARDS) update
+	[ $(SHARDS) = false ] || $(SHARDS) update
 
 phony:


### PR DESCRIPTION
The `shard.lock` recipe fails if `SHARDS=false` (i.e. building from scratch without a previously installed `shards` binary), we must skip `$SHARDS update` in that case.

see https://github.com/crystal-lang/crystal/issues/10861