### PR TITLE
Avoid user defined git template in resolver

### DIFF
--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -317,7 +317,7 @@ module Shards
       # This configuration can be overriden by defining the environment
       # variable `GIT_ASKPASS`.
       git_retry(err: "Failed to clone #{git_url}") do
-        run_in_current_folder "git clone -c core.askPass=true --mirror --quiet -- #{Process.quote(git_url)} #{Process.quote(local_path)}"
+        run_in_current_folder "git clone -c core.askPass=true init.templateDir= --mirror --quiet -- #{Process.quote(git_url)} #{Process.quote(local_path)}"
       end
     end
 

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -317,7 +317,7 @@ module Shards
       # This configuration can be overriden by defining the environment
       # variable `GIT_ASKPASS`.
       git_retry(err: "Failed to clone #{git_url}") do
-        run_in_current_folder "git clone -c core.askPass=true init.templateDir= --mirror --quiet -- #{Process.quote(git_url)} #{Process.quote(local_path)}"
+        run_in_current_folder "git clone -c core.askPass=true -c init.templateDir= --mirror --quiet -- #{Process.quote(git_url)} #{Process.quote(local_path)}"
       end
     end
 


### PR DESCRIPTION
I have couple of hooks in my global git template (skeleton) directory, this breaks shards completely and it was such a pain to figure it out. Symptoms are:

```
Resolving dependencies
Fetching https://github.com/will/crystal-pg.git
Installing pg (0.24.0)
Failed git --work-tree=/home/lzap/work/invidious/lib/pg checkout
 refs/tags/v0.24.0 -- . ().
 Maybe a commit, branch or file doesn't exist?
```

The patch overrides the user-defined configuration so git checkouts are clean.