### PR TITLE
Add subdirectory support for git dependencies

### DIFF
--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -231,6 +231,11 @@ module Shards
     def subdir
       uri = parse_uri(git_url)
       subdir = uri.query_params.fetch("subdir", "")
+      if subdir.blank? && git_url.includes?("?")
+        params = git_url.split("?").last
+        subdir = URI::Params.parse(params).fetch("subdir", "")
+      end
+      subdir
     end
 
     def local_path


### PR DESCRIPTION
Provides a way to load a shard that is a subdirectory in a git repo. Allows for the possibility of "monorepos" with multiple shards. I know this has been discussed a lot, though I can't find a related issue at the moment, but I don't believe I've seen anyone discuss this way of solving it. This follows a pattern used in other package managers, but the one I was most recently referenced was [nim's package manager, nimble](https://github.com/nim-lang/nimble#package-urls). To reference a subdirectory of a github repo, you add a query param to the url with a key of `subdir` and a value of the directory to use (`?subdir=alpha`).

## Example

```yaml
alpha:
  git: https://github.com/matthewmcgarvey/cronorepo.git?subdir=alpha
  branch: main
```

## Technical

The way this works is by cloning the larger monorepo as normal, but then checking out the desired commit/branch/tag into a temp directory. From there, the subdirectory is copied over to the install path. I believe the temp directory is required because I did not find a way to checkout the ref into the install path directly with only the subdirectory and it be flattened as expected.

This `subdir` query param causes the clone to fail (I believe) so I also added code to remove it before cloning.

## Other Considerations

This code is not clean, and I didn't intend for it to be. There doesn't seem to be consensus on whether or not things like this even _should_ be done so I don't want to spend a bunch of time making the code perfect if it's going to be rejected on a foundational level.

This code _only_ supports git urls. This is for many of the same reasons as above. If it's acceptable and merged, I would like to move on to considering what it might look like to include this in the github shorter version instead of the full url but I don't want to get ahead of myself.

## Considered Alternative

I considered a different way of doing it that seems cleaner with our yaml files which was to have something like:

```yaml
alpha:
  git: https://github.com/matthewmcgarvey/cronorepo.git
  branch: main
  subdir: alpha
```

But we currently only handle one `Requirement` and it's not passed to the `Resolver` anyways. I think a good refactor in the future would be to simply pass the `Dependency` into the resolver instead of pieces but I'm sure there's tradeoffs.