### PR TITLE
Fix unexpected token compiler error match

### DIFF
--- a/spec/integration/build_spec.cr
+++ b/spec/integration/build_spec.cr
@@ -67,7 +67,7 @@ describe "build" do
         run "shards build --no-color app"
       end
       ex.stdout.should contain("target app failed to compile")
-      ex.stdout.should contain("unexpected token: ...")
+      ex.stdout.should match(/unexpected token: "?.../)
       File.exists?(bin_path("app")).should be_false
     end
   end


### PR DESCRIPTION
After crystal-lang/crystal#11473 the following spec in shards' spec suite is broken:

```
  1) build reports error when target failed to compile
     Failure/Error: ex.stdout.should contain("unexpected token: ...")

       Expected:   "I: Dependencies are satisfied\nI: Building: app\nE: Error target app failed to compile:\n\e[33mUsing compiled compiler at /home/johannes/Projects/crystal-lang/crystal/.build/crystal\e[0m\nIn src/cli.cr:1:8\n\n 1 | a = ......\n            ^\nError: unexpected token: \"...\"\n\n"
       to include: "unexpected token: ..."

     # spec/integration/build_spec.cr:70
```