### PR TITLE
Add make `build recipe`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,11 @@ INSTALL ?= /usr/bin/install
 MOLINILLO_VERSION = $(shell $(CRYSTAL) eval 'require "yaml"; puts YAML.parse(File.read("shard.lock"))["shards"]["molinillo"]["version"]')
 MOLINILLO_URL = "https://github.com/crystal-lang/crystal-molinillo/archive/v$(MOLINILLO_VERSION).tar.gz"
 
-all: bin/shards
+all: build
 
 include docs.mk
+
+build: phony bin/shards
 
 clean: phony clean_docs
 	rm -f bin/shards


### PR DESCRIPTION
`make build` is commonly established as a recipe for building. I tried to run `make clean build` (which I do a lot in other repositories) and it didn't work because `build` is missing. This patch adds it.