### PR TITLE
Honour `CRYSTAL` env var

### DIFF
--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -106,7 +106,7 @@ private def setup_repositories
   create_git_release "transitive", "0.2.0", {
     dependencies: {version: {git: git_url(:version)}},
     scripts:      {
-      postinstall: %(${CRYSTAL:-crystal} build src/version.cr),
+      postinstall: %(#{{{ flag?(:win32) ? "crystal" : "${CRYSTAL:-crystal}" }}} build src/version.cr),
     },
   }
 

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -106,7 +106,7 @@ private def setup_repositories
   create_git_release "transitive", "0.2.0", {
     dependencies: {version: {git: git_url(:version)}},
     scripts:      {
-      postinstall: "crystal build src/version.cr",
+      postinstall: %(${CRYSTAL:-crystal} build src/version.cr),
     },
   }
 

--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -240,7 +240,7 @@ describe "update" do
       output = run "shards update --no-color --skip-postinstall"
       binary = install_path("transitive", Shards::Helpers.exe("version"))
       File.exists?(binary).should be_false
-      output.should contain("Postinstall of transitive: crystal build src/version.cr (skipped)")
+      output.should contain("Postinstall of transitive: ${CRYSTAL:-crystal} build src/version.cr (skipped)")
     end
   end
 

--- a/spec/integration/update_spec.cr
+++ b/spec/integration/update_spec.cr
@@ -240,7 +240,7 @@ describe "update" do
       output = run "shards update --no-color --skip-postinstall"
       binary = install_path("transitive", Shards::Helpers.exe("version"))
       File.exists?(binary).should be_false
-      output.should contain("Postinstall of transitive: ${CRYSTAL:-crystal} build src/version.cr (skipped)")
+      output.should contain("Postinstall of transitive: #{{{ flag?(:win32) ? "crystal" : "${CRYSTAL:-crystal}" }}} build src/version.cr (skipped)")
     end
   end
 

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -226,7 +226,7 @@ module Shards::Specs
   def self.crystal_path
     # Memoize so each integration spec do not need to create this process.
     # If crystal is bin/crystal this also reduce the noise of Using compiled compiler at ...
-    @@crystal_path ||= "#{Shards::INSTALL_DIR}#{Process::PATH_DELIMITER}#{`crystal env CRYSTAL_PATH`.chomp}"
+    @@crystal_path ||= "#{Shards::INSTALL_DIR}#{Process::PATH_DELIMITER}#{`#{Shards.crystal_bin} env CRYSTAL_PATH`.chomp}"
   end
 end
 

--- a/src/commands/build.cr
+++ b/src/commands/build.cr
@@ -41,10 +41,11 @@ module Shards
           args << "--verbose"
         end
         options.each { |option| args << option }
-        Log.debug { "crystal #{args.join(' ')}" }
+        Log.debug { "#{Shards.crystal_bin} #{args.join(' ')}" }
 
         error = IO::Memory.new
-        status = Process.run("crystal", args: args, output: Process::Redirect::Inherit, error: error)
+
+        status = Process.run(Shards.crystal_bin, args: args, output: Process::Redirect::Inherit, error: error)
         raise Error.new("Error target #{target.name} failed to compile:\n#{error}") unless status.success?
       end
     end

--- a/src/config.cr
+++ b/src/config.cr
@@ -66,6 +66,13 @@ module Shards
   def self.bin_path=(@@bin_path : String)
   end
 
+  def self.crystal_bin
+    @@crystal_bin ||= ENV.fetch("CRYSTAL", "crystal")
+  end
+
+  def self.crystal_bin=(@@crystal_bin : String)
+  end
+
   def self.global_override_filename
     ENV["SHARDS_OVERRIDE"]?.try { |p| File.expand_path(p) }
   end
@@ -75,9 +82,9 @@ module Shards
       output = IO::Memory.new
       error = IO::Memory.new
       status = begin
-        Process.run("crystal", {"env", "CRYSTAL_VERSION"}, output: output, error: error)
+        Process.run(crystal_bin, {"env", "CRYSTAL_VERSION"}, output: output, error: error)
       rescue e
-        raise Error.new("Could not execute 'crystal': #{e.message}")
+        raise Error.new("Could not execute '#{crystal_bin}': #{e.message}")
       end
       raise Error.new("Error executing crystal:\n#{error}") unless status.success?
       output.to_s.strip

--- a/src/config.cr
+++ b/src/config.cr
@@ -84,7 +84,7 @@ module Shards
     end)
   end
 
-  def self.crystal_version(@@crystal_version : String)
+  def self.crystal_version=(@@crystal_version : String)
   end
 
   private def self.without_prerelease(version)


### PR DESCRIPTION
This is a reissue of #415 reduced to the original scope. It makes `shards` honour the `CRYSTAL` environment variable when calling the `crystal` program to determine the Crystal version and for `shards build`.

Resolves #406