### PR TITLE
No longer depend of external git user config

### DIFF
--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -18,6 +18,9 @@ def create_git_repository(project, *versions)
     run "git init #{Process.quote(project)}"
     Dir.cd(Process.quote(project)) do
       run "git checkout --orphan master"
+
+      run "git config user.email author@example.com"
+      run "git config user.name Author"
     end
   end
 
@@ -34,6 +37,11 @@ end
 def create_fork_git_repository(project, upstream)
   Dir.cd(tmp_path) do
     run "git clone #{Process.quote(git_url(upstream))} #{Process.quote(project)}"
+
+    Dir.cd(Process.quote(project)) do
+      run "git config user.email fork@example.com"
+      run "git config user.name Fork"
+    end
   end
 end
 

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -16,7 +16,7 @@ end
 def create_git_repository(project, *versions)
   Dir.cd(tmp_path) do
     run "git init #{Process.quote(project)}"
-    Dir.cd(Process.quote(project)) do
+    Dir.cd(git_path(project)) do
       run "git checkout --orphan master"
 
       run "git config user.email author@example.com"
@@ -38,7 +38,7 @@ def create_fork_git_repository(project, upstream)
   Dir.cd(tmp_path) do
     run "git clone #{Process.quote(git_url(upstream))} #{Process.quote(project)}"
 
-    Dir.cd(Process.quote(project)) do
+    Dir.cd(git_path(project)) do
       run "git config user.email fork@example.com"
       run "git config user.name Fork"
     end


### PR DESCRIPTION
Some Git-related tests required external configuration of email and name. This forced tweaks in CI and other environments to have those set globally before running tests.

This change makes this self-contained: Git repositories created part of the test suite are going to automatically set a default email and name.

Note: this might look silly, but removes the need to set that up when running the specs in a controlled container environment (and not a development one) and has no impact on existing CI or others running it.

Thank you.
❤️ ❤️ ❤️ 