### PR TITLE
[CI] Update circleci xcode 13.2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
 
   test-on-osx:
     macos:
-      xcode: 11.1.0 # latest mojave
+      xcode: 13.2.1
     steps:
       - with-brew-cache:
           steps:


### PR DESCRIPTION
circleci is deprecating the images with xcode 11.1, so we need to update.

I'm updating to the latest version available, 13.2.1

https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions