### PR TITLE
Feat: output STDERR from the building process

### DIFF
--- a/spec/integration/build_spec.cr
+++ b/spec/integration/build_spec.cr
@@ -72,7 +72,7 @@ describe "build" do
     end
   end
 
-  pending "reports warning without failing" do
+  it "reports warning without failing" do
     File.write File.join(application_path, "src", "cli.cr"), <<-CODE
       @[Deprecated]
       def a

--- a/spec/integration/build_spec.cr
+++ b/spec/integration/build_spec.cr
@@ -72,20 +72,22 @@ describe "build" do
     end
   end
 
-  it "reports warning without failing" do
-    File.write File.join(application_path, "src", "cli.cr"), <<-CODE
+  {% unless flag?(:win32) %}
+    it "reports warning without failing" do
+      File.write File.join(application_path, "src", "cli.cr"), <<-CODE
       @[Deprecated]
       def a
       end
       a
       CODE
 
-    Dir.cd(application_path) do
-      err = run "shards build --no-color app"
-      err.should match(/eprecated/)
-      File.exists?(bin_path("app")).should be_true
+      Dir.cd(application_path) do
+        err = run "shards build --no-color app"
+        err.should match(/eprecated/)
+        File.exists?(bin_path("app")).should be_true
+      end
     end
-  end
+  {% end %}
 
   it "errors when no targets defined" do
     File.write File.join(application_path, "shard.yml"), <<-YAML

--- a/spec/integration/build_spec.cr
+++ b/spec/integration/build_spec.cr
@@ -72,6 +72,21 @@ describe "build" do
     end
   end
 
+  pending "reports warning without failing" do
+    File.write File.join(application_path, "src", "cli.cr"), <<-CODE
+      @[Deprecated]
+      def a
+      end
+      a
+      CODE
+
+    Dir.cd(application_path) do
+      err = run "shards build --no-color app"
+      err.should match(/eprecated/)
+      File.exists?(bin_path("app")).should be_true
+    end
+  end
+
   it "errors when no targets defined" do
     File.write File.join(application_path, "shard.yml"), <<-YAML
       name: build

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -254,10 +254,12 @@ def run(command, *, env = nil, return_error = false)
   {% end %}
   status = Process.run(command, shell: true, env: cmd_env, output: output, error: error || Process::Redirect::Close)
 
+  output = output.to_s.gsub("\r\n", "\n")
+  error = error.to_s.gsub("\r\n", "\n")
+
   if status.success?
-    output = output.to_s.gsub("\r\n", "\n")
-    output + error.to_s
+    output + error
   else
-    raise FailedCommand.new("command failed: #{command}", output.to_s.gsub("\r\n", "\n"), error.to_s.gsub("\r\n", "\n"))
+    raise FailedCommand.new("command failed: #{command}", output, error)
   end
 end

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -242,7 +242,7 @@ def tmp_path
   Shards::Specs.tmp_path
 end
 
-def run(command, *, env = nil, return_error = false)
+def run(command, *, env = nil)
   cmd_env = {
     "CRYSTAL_PATH" => Shards::Specs.crystal_path,
   }

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -234,7 +234,7 @@ def tmp_path
   Shards::Specs.tmp_path
 end
 
-def run(command, *, env = nil)
+def run(command, *, env = nil, return_error = false)
   cmd_env = {
     "CRYSTAL_PATH" => Shards::Specs.crystal_path,
   }
@@ -247,7 +247,8 @@ def run(command, *, env = nil)
   status = Process.run(command, shell: true, env: cmd_env, output: output, error: error || Process::Redirect::Close)
 
   if status.success?
-    output.to_s.gsub("\r\n", "\n")
+    output = output.to_s.gsub("\r\n", "\n")
+    output + error.to_s
   else
     raise FailedCommand.new("command failed: #{command}", output.to_s.gsub("\r\n", "\n"), error.to_s.gsub("\r\n", "\n"))
   end

--- a/src/commands/build.cr
+++ b/src/commands/build.cr
@@ -45,10 +45,10 @@ module Shards
 
         error = IO::Memory.new
         status = Process.run(Shards.crystal_bin, args: args, output: Process::Redirect::Inherit, error: error)
-        unless status.success?
-          raise Error.new("Error target #{target.name} failed to compile:\n#{error}")
+        if status.success?
+          STDERR.puts error unless error.empty?
         else
-          STDERR << error if error.size > 0
+          raise Error.new("Error target #{target.name} failed to compile:\n#{error}")
         end
       end
     end

--- a/src/commands/build.cr
+++ b/src/commands/build.cr
@@ -45,7 +45,11 @@ module Shards
 
         error = IO::Memory.new
         status = Process.run("crystal", args: args, output: Process::Redirect::Inherit, error: error)
-        raise Error.new("Error target #{target.name} failed to compile:\n#{error}") unless status.success?
+        unless status.success?
+          raise Error.new("Error target #{target.name} failed to compile:\n#{error}")
+        else
+          STDERR << error if error.size > 0
+        end
       end
     end
   end


### PR DESCRIPTION
Solves #535 by outputting the STDERR of the `crystal` build to the STDERR of the `shards` process _only if the build is successful_. This allows to notice deprecation warnings and the like.

In order to test it, I had to concatenate the STDOUT and STDERR, which isn't as clean as possible but works.  

