### PR TITLE
Add expanded local path to `shard.yml` error message in `PathResolver`

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -915,10 +915,10 @@ describe "install" do
     end
 
     it "path" do
-      metadata = {dependencies: {nonexistent: { path: "nonexistent-path"}}}
+      metadata = {dependencies: {reallynoshardyml: { path: rel_path("reallynoshardyml") }}}
       with_shard(metadata) do
         ex = expect_raises(FailedCommand) { run "shards install --no-color -v" }
-        ex.stdout.should contain(%(E: Missing "shard.yml" for "nonexistent" at "#{File.expand_path("nonexistent-path")}"))
+        ex.stdout.should contain(%(E: Missing "shard.yml" for "reallynoshardyml" at "#{File.expand_path(rel_path("reallynoshardyml"))}"))
       end
     end
   end

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -904,12 +904,22 @@ describe "install" do
     end
   end
 
-  it "shows missing shard.yml in debug info" do
-    metadata = {dependencies: {noshardyml: "*"}}
-    with_shard(metadata) do
-      stdout = run "shards install --no-color -v"
-      assert_installed "noshardyml", "0.2.0"
-      stdout.should contain(%(D: Missing "shard.yml" for "noshardyml" at tag v0.1.0))
+  describe "shows missing shard.yml in debug info" do
+    it "git" do
+      metadata = {dependencies: {noshardyml: "*"}}
+      with_shard(metadata) do
+        stdout = run "shards install --no-color -v"
+        assert_installed "noshardyml", "0.2.0"
+        stdout.should contain(%(D: Missing "shard.yml" for "noshardyml" at tag v0.1.0))
+      end
+    end
+
+    it "path" do
+      metadata = {dependencies: {nonexistent: { path: "nonexistent-path"}}}
+      with_shard(metadata) do
+        ex = expect_raises(FailedCommand) { run "shards install --no-color -v" }
+        ex.stdout.should contain(%(E: Missing "shard.yml" for "nonexistent" at "#{File.expand_path("nonexistent-path")}"))
+      end
     end
   end
 

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -915,7 +915,7 @@ describe "install" do
     end
 
     it "path" do
-      metadata = {dependencies: {reallynoshardyml: { path: rel_path("reallynoshardyml") }}}
+      metadata = {dependencies: {reallynoshardyml: {path: rel_path("reallynoshardyml")}}}
       with_shard(metadata) do
         ex = expect_raises(FailedCommand) { run "shards install --no-color -v" }
         ex.stdout.should contain(%(E: Missing "shard.yml" for "reallynoshardyml" at "#{File.expand_path(rel_path("reallynoshardyml"))}"))

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -918,7 +918,7 @@ describe "install" do
       metadata = {dependencies: {reallynoshardyml: {path: rel_path("reallynoshardyml")}}}
       with_shard(metadata) do
         ex = expect_raises(FailedCommand) { run "shards install --no-color -v" }
-        ex.stdout.should contain(%(E: Missing "shard.yml" for "reallynoshardyml" at "#{File.expand_path(rel_path("reallynoshardyml"))}"))
+        ex.stdout.should contain(%(E: Missing "shard.yml" for "reallynoshardyml" at #{File.expand_path(rel_path("reallynoshardyml")).inspect}))
       end
     end
   end

--- a/spec/integration/spec_helper.cr
+++ b/spec/integration/spec_helper.cr
@@ -62,6 +62,9 @@ private def setup_repositories
   create_git_release "noshardyml", "0.1.0", false
   create_git_release "noshardyml", "0.2.0"
 
+  create_git_repository "reallynoshardyml"
+  create_git_release "reallynoshardyml", "0.1.0", false
+
   create_git_repository "invalidspec"
   create_git_release "invalidspec", "0.1.0", {crystal: [""]}
 

--- a/src/resolvers/path.cr
+++ b/src/resolvers/path.cr
@@ -12,7 +12,7 @@ module Shards
       if File.exists?(spec_path)
         File.read(spec_path)
       else
-        raise Error.new("Missing #{SPEC_FILENAME.inspect} for #{name.inspect}")
+        raise Error.new("Missing #{SPEC_FILENAME.inspect} for #{name.inspect} at #{File.expand_path(local_path).inspect}")
       end
     end
 


### PR DESCRIPTION
This patch enhances the error information when a path resolver can't find `shard.yml`: It shows the expanded path of the directory where it looked for the file.

/cc #308,  #309