### PR TITLE
Add run command

### DIFF
--- a/spec/integration/run_spec.cr
+++ b/spec/integration/run_spec.cr
@@ -1,0 +1,129 @@
+require "./spec_helper"
+
+def bin_path(name)
+  File.join(application_path, "bin", name)
+end
+
+describe "run" do
+  before_each do
+    Dir.mkdir(File.join(application_path, "src"))
+    File.write(File.join(application_path, "src", "cli.cr"), "puts __FILE__")
+  end
+
+  after_each do
+    File.delete File.join(application_path, "shard.yml")
+  end
+
+  it "fails when no targets defined" do
+    File.write File.join(application_path, "shard.yml"), <<-YAML
+      name: build
+      version: 0.1.0
+      YAML
+
+    Dir.cd(application_path) do
+      ex = expect_raises(FailedCommand) do
+        run "shards run --no-color"
+      end
+      ex.stdout.should contain("Targets not defined in shard.yml")
+    end
+  end
+
+  it "fails when passing multiple targets" do
+    File.write File.join(application_path, "shard.yml"), <<-YAML
+      name: build
+      version: 0.1.0
+      targets:
+        app:
+          main: src/cli.cr
+        alt:
+          main: src/cli.cr
+      YAML
+
+    Dir.cd(application_path) do
+      ex = expect_raises(FailedCommand) do
+        run "shards run --no-color app alt"
+      end
+      ex.stdout.should contain("Error please specify only one target. If you meant to pass arguments you may use 'shards run target -- args'")
+    end
+  end
+
+  it "fails when multiple targets, no arg" do
+    File.write File.join(application_path, "shard.yml"), <<-YAML
+      name: build
+      version: 0.1.0
+      targets:
+        app:
+          main: src/cli.cr
+        alt:
+          main: src/cli.cr
+      YAML
+
+    Dir.cd(application_path) do
+      ex = expect_raises(FailedCommand) do
+        run "shards run --no-color"
+      end
+      ex.stdout.should contain("Error please specify the target with 'shards run target'")
+    end
+  end
+
+  it "runs when only one target" do
+    File.write File.join(application_path, "shard.yml"), <<-YAML
+      name: build
+      version: 0.1.0
+      targets:
+        app:
+          main: src/cli.cr
+      YAML
+
+    Dir.cd(application_path) do
+      run "shards run --no-color"
+
+      File.exists?(bin_path("app")).should be_true
+
+      `#{bin_path("app")}`.chomp.should eq(File.join(application_path, "src", "cli.cr"))
+    end
+  end
+
+  it "runs specified target" do
+    File.write File.join(application_path, "shard.yml"), <<-YAML
+      name: build
+      version: 0.1.0
+      targets:
+        app:
+          main: src/cli.cr
+        alt:
+          main: src/cli.cr
+      YAML
+
+    Dir.cd(application_path) do
+      run "shards run --no-color app"
+
+      File.exists?(bin_path("app")).should be_true
+      File.exists?(bin_path("alt")).should be_false
+
+      `#{bin_path("app")}`.chomp.should eq(File.join(application_path, "src", "cli.cr"))
+    end
+  end
+
+  it "passes back execution failure from child process" do
+    File.write File.join(application_path, "src", "fail.cr"), <<-CR
+      puts "This command fails"
+      exit 5
+      CR
+
+    File.write File.join(application_path, "shard.yml"), <<-YAML
+      name: build
+      version: 0.1.0
+      targets:
+        fail:
+          main: src/fail.cr
+      YAML
+
+    Dir.cd(application_path) do
+      ex = expect_raises(FailedCommand) do
+        run "shards run --no-color"
+      end
+      ex.stdout.should contain("This command fails")
+    end
+  end
+end

--- a/src/commands/run.cr
+++ b/src/commands/run.cr
@@ -1,0 +1,41 @@
+require "./command"
+
+module Shards
+  module Commands
+    class Run < Command
+      def run(targets, options, run_options)
+        if spec.targets.empty?
+          raise Error.new("Targets not defined in #{SPEC_FILENAME}")
+        end
+
+        # when more than one target was specified
+        if targets.size > 1
+          raise Error.new("Error please specify only one target. If you meant to pass arguments you may use 'shards run target -- args'")
+        end
+
+        # when no target was specified
+        if targets.empty?
+          if spec.targets.size > 1
+            raise Error.new("Error please specify the target with 'shards run target'")
+          else
+            name = spec.targets.first.name
+          end
+        else
+          name = targets.first
+        end
+
+        if target = spec.targets.find { |t| t.name == name }
+          Commands::Build.run(path, [target.name], options)
+
+          Log.info { "Executing: #{target.name} #{run_options.join(' ')}" }
+          status = Process.run(File.join(Shards.bin_path, target.name), args: run_options, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+          unless status.success?
+            exit status.exit_code
+          end
+        else
+          raise Error.new("Error target #{name} was not found in #{SPEC_FILENAME}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduces `shards run`, similar to `shards build`, that builds and runs the specified target, providing a unified interface to developers.

With this, a developer can directly use `shards run <target>` in a single step without having first to compile (build) and then execute it with `./bin/target`. No need for a script or wrapper.

This is inspired by `crystal build` and `crystal run` user experience (with the difference that `crystal run` creates a temporary binary).

This is very helpful for automatic rebuild scenarios, where a process is monitoring your code and can rebuild and relaunch your application.

When invoking `shards run`, it will first build the target (with the supplied options) and then invoke it, passing the extra options:

```console
$ shards run myapp --stats -- --args
```

Is the same as:

```console
$ shards build myapp --stats

$ ./bin/myapp --args
```

If the target exits with error, the exit code is passed back.

Resolves #157
Relates #298

Co-authored-by: Elliot DeNolf <65888+denolfe@users.noreply.github.com>