### PR TITLE
Fix clear ENV in integration spec

### DIFF
--- a/spec/integration/build_spec.cr
+++ b/spec/integration/build_spec.cr
@@ -82,7 +82,7 @@ describe "build" do
       CODE
 
       Dir.cd(application_path) do
-        err = run "shards build --no-color app"
+        err = run "shards build --no-color app", clear_env: true
         err.should match(/eprecated/)
         File.exists?(bin_path("app")).should be_true
       end

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -356,6 +356,9 @@ def run(command, *, env = nil, clear_env = false)
   cmd_env = {
     "CRYSTAL_PATH" => Shards::Specs.crystal_path,
   }
+  if clear_env
+    cmd_env["CRYSTAL_OPTS"] = ""
+  end
   cmd_env.merge!(env) if env
   output, error = IO::Memory.new, IO::Memory.new
   {% if flag?(:win32) %}
@@ -363,7 +366,7 @@ def run(command, *, env = nil, clear_env = false)
     error = nil
   {% end %}
 
-  status = Process.run(command, shell: true, env: cmd_env, clear_env: clear_env, output: output, error: error || Process::Redirect::Close)
+  status = Process.run(command, shell: true, env: cmd_env, output: output, error: error || Process::Redirect::Close)
 
   output = output.to_s.gsub("\r\n", "\n")
   error = error.to_s.gsub("\r\n", "\n")

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -352,7 +352,7 @@ def tmp_path
   Shards::Specs.tmp_path
 end
 
-def run(command, *, env = nil)
+def run(command, *, env = nil, clear_env = false)
   cmd_env = {
     "CRYSTAL_PATH" => Shards::Specs.crystal_path,
   }
@@ -363,7 +363,7 @@ def run(command, *, env = nil)
     error = nil
   {% end %}
 
-  status = Process.run(command, shell: true, env: cmd_env, output: output, error: error || Process::Redirect::Close)
+  status = Process.run(command, shell: true, env: cmd_env, clear_env: clear_env, output: output, error: error || Process::Redirect::Close)
 
   output = output.to_s.gsub("\r\n", "\n")
   error = error.to_s.gsub("\r\n", "\n")


### PR DESCRIPTION
Clear environment when running integration spec. If the environment has `CRYSTAL_OPTS=--error-on-warnings` it would get passed through to the compiler and the spec fails (see https://github.com/crystal-lang/test-ecosystem/runs/6116920991).

This is a minimal change to fix the immediate issue. It could be considered that we apply this to more uses of `run`. Maybe inheriting the environment should even be opt-in.