### PR TITLE
prune - Don't raise an exception if install_path doesn't exist

### DIFF
--- a/spec/integration/prune_spec.cr
+++ b/spec/integration/prune_spec.cr
@@ -36,4 +36,9 @@ describe "prune" do
     Dir.cd(application_path) { run "shards prune" }
     installed_dependencies.sort.should eq([".keep_hidden", "keep_not_hidden", "web"])
   end
+
+  it "should not fail if the install directory does not exist" do
+    run "rm -rf #{install_path}"
+    Dir.cd(application_path) { run "shards prune" }
+  end
 end

--- a/src/commands/prune.cr
+++ b/src/commands/prune.cr
@@ -8,6 +8,11 @@ module Shards
       def run
         return unless lockfile?
 
+        unless Dir.exists?(Shards.install_path)
+          Log.info { "Pruned nothing, because #{File.basename(Shards.install_path)}/ does not exist" }
+          return
+        end
+
         Dir.each_child(Shards.install_path) do |name|
           path = File.join(Shards.install_path, name)
           next unless File.directory?(path)

--- a/src/commands/prune.cr
+++ b/src/commands/prune.cr
@@ -6,12 +6,7 @@ module Shards
   module Commands
     class Prune < Command
       def run
-        return unless lockfile?
-
-        unless Dir.exists?(Shards.install_path)
-          Log.info { "Pruned nothing, because #{File.basename(Shards.install_path)}/ does not exist" }
-          return
-        end
+        return unless lockfile? && Dir.exists?(Shards.install_path)
 
         Dir.each_child(Shards.install_path) do |name|
           path = File.join(Shards.install_path, name)


### PR DESCRIPTION
I noticed that if you run `shards prune` in a project with the following two conditions:

1. `shards.lock` exists
2. The install directory (`lib/`) does not exist

Then the command raises an exception. This might not be a super common scenario, but in the context of CI it can be frustrating for this command to throw and then interrupt the whole job rather than just not doing anything.