### PR TITLE
Fix Fossil resolver when multiple dependencies are coming from the same website

### DIFF
--- a/src/resolvers/fossil.cr
+++ b/src/resolvers/fossil.cr
@@ -320,9 +320,7 @@ module Shards
       when VERSION_AT_FOSSIL_COMMIT
         FossilVersion.new $1, $2
       else
-        err = Error.new("Invalid version for fossil resolver: #{version}")
-        pp err.backtrace
-        raise err
+        raise Error.new("Invalid version for fossil resolver: #{version}")
       end
     end
 

--- a/src/resolvers/fossil.cr
+++ b/src/resolvers/fossil.cr
@@ -320,7 +320,9 @@ module Shards
       when VERSION_AT_FOSSIL_COMMIT
         FossilVersion.new $1, $2
       else
-        raise Error.new("Invalid version for fossil resolver: #{version}")
+        err = Error.new("Invalid version for fossil resolver: #{version}")
+        pp err.backtrace
+        raise err
       end
     end
 
@@ -402,7 +404,10 @@ module Shards
     end
 
     private def cloned_repository?
-      Dir.exists?(local_path)
+      # Check for both the local_path and the local_fossil_file, otherwise this
+      # method can give false positives if it's looking for repositories from
+      # the same base site.
+      Dir.exists?(local_path) && File.exists?(local_fossil_file)
     end
 
     private def valid_repository?


### PR DESCRIPTION
This is something I ran into while actually using the new Fossil resolver heavily.  If you have multiple shards coming from the same website (say, chiselapp.com), the resolver would sometimes fail because it would think a shard was pulled when it wasn't.  This fixes the problem.