### PR TITLE
Adjust parameter name for `Resolver#install_sources`

### DIFF
--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -85,7 +85,7 @@ module Shards
     end
 
     abstract def read_spec(version : Version) : String?
-    abstract def install_sources(version : Version, install_dir : String)
+    abstract def install_sources(version : Version, install_path : String)
     abstract def report_version(version : Version) : String
 
     def update_local_cache


### PR DESCRIPTION
All implementations of `#install_sources` have a second parameter called `install_path`, only the abstract definition in `Resolver` uses the name `install_dir`, which results in a warning:
> positional parameter 'install_path' corresponds to parameter 'install_dir' of the overridden method Shards::Resolver#install_sources(version : Version, install_dir : String), which has a different name and may affect named argument passing

This patch renames the parameter name in the abstract definition to match the one used in all the implementations.