### PR TITLE
Inherit the standard input descriptor

### DIFF
--- a/spec/integration/run_spec.cr
+++ b/spec/integration/run_spec.cr
@@ -148,4 +148,25 @@ describe "run" do
       output.should contain("args: foo,bar,baz")
     end
   end
+
+  it "works well with stdin" do
+    File.write File.join(application_path, "src", "stdin.cr"), <<-CR
+      print "input: ", STDIN.gets.inspect
+      CR
+
+    File.write File.join(application_path, "shard.yml"), <<-YAML
+      name: build
+      version: 0.1.0
+      targets:
+        app:
+          main: src/stdin.cr
+      YAML
+
+    Dir.cd(application_path) do
+      input = IO::Memory.new("hello from stdin")
+      output = run("shards run --no-color", input: input)
+      output.should contain("Executing: app")
+      output.should contain(%(input: "hello from stdin"))
+    end
+  end
 end

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -352,7 +352,7 @@ def tmp_path
   Shards::Specs.tmp_path
 end
 
-def run(command, *, env = nil, clear_env = false)
+def run(command, *, env = nil, clear_env = false, input = Process::Redirect::Close)
   cmd_env = {
     "CRYSTAL_PATH" => Shards::Specs.crystal_path,
   }
@@ -366,7 +366,7 @@ def run(command, *, env = nil, clear_env = false)
     error = nil
   {% end %}
 
-  status = Process.run(command, shell: true, env: cmd_env, output: output, error: error || Process::Redirect::Close)
+  status = Process.run(command, shell: true, env: cmd_env, input: input, output: output, error: error || Process::Redirect::Close)
 
   output = output.to_s.gsub("\r\n", "\n")
   error = error.to_s.gsub("\r\n", "\n")

--- a/src/commands/run.cr
+++ b/src/commands/run.cr
@@ -28,7 +28,7 @@ module Shards
           Commands::Build.run(path, [target.name], options)
 
           Log.info { "Executing: #{target.name} #{run_options.join(' ')}" }
-          status = Process.run(File.join(Shards.bin_path, target.name), args: run_options, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+          status = Process.run(File.join(Shards.bin_path, target.name), args: run_options, input: Process::Redirect::Inherit, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
           unless status.success?
             exit status.exit_code
           end


### PR DESCRIPTION
When running `shards run`, you should be able to work with standard input.

Fix #550 