### PR TITLE
Improve error message when symlink failed on Windows

### DIFF
--- a/src/cli.cr
+++ b/src/cli.cr
@@ -162,4 +162,17 @@ rescue ex : Shards::ParseError
 rescue ex : Shards::Error
   Shards::Log.error { ex.message }
   exit 1
+rescue exc : File::AccessDeniedError
+  {% if flag?(:windows) %}
+    if exc.os_error == WinError::ERROR_PRIVILEGE_NOT_HELD && exc.message.try &.starts_with?("Error creating symlink")
+      Shards::Log.error { <<-TXT }
+        #{exc}
+
+        Shards needs symlinks to work. Please make sure to enable developer mode:
+            https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development
+        TXT
+      exit 1
+    end
+  {% end %}
+  raise exc
 end


### PR DESCRIPTION
This patch adds a helpful message when encountering a failure to create symlinks in Windows which can likely be fixed by enabling developer mode.

The implementation is very dumb, just catching all `File::AccessDeniedError` and check whether it was caused by a missing privilege for `symlink` creation.
Alterantively, we could use a wrapper for `File.symlink` which checks this directly at every call site (it's only 2). But I think it's easier this way.

Resolves #556