### PR TITLE
Fix avoid swallowing error message if git command failed

### DIFF
--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -433,8 +433,10 @@ module Shards
         str = error.to_s
         if str.starts_with?("error: ") && (idx = str.index('\n'))
           message = str[7...idx]
+          raise Error.new("Failed #{command} (#{message}). Maybe a commit, branch or file doesn't exist?")
+        else
+          raise Error.new("Failed #{command}.\n#{str}")
         end
-        raise Error.new("Failed #{command} (#{message}). Maybe a commit, branch or file doesn't exist?")
       end
     end
 

--- a/src/resolvers/hg.cr
+++ b/src/resolvers/hg.cr
@@ -457,10 +457,10 @@ module Shards
         str = error.to_s
         if str.starts_with?("abort: ") && (idx = str.index('\n'))
           message = str[7...idx]
+          raise Error.new("Failed #{command} (#{message}). Maybe a commit, branch, bookmark or file doesn't exist?")
         else
-          message = str
+          raise Error.new("Failed #{command}.\n#{str}")
         end
-        raise Error.new("Failed #{command} (#{message}). Maybe a commit, branch, bookmark or file doesn't exist?")
       end
     end
 


### PR DESCRIPTION
When a git command failed and the error output did not start with "error:", the entire message would be hidden.
With this change, it's printed in full.

The other resolvers already have a similar behaviour in place. I'm also adjusting the on for hg in the second commit to follow git.

This was reported in https://forum.crystal-lang.org/t/shards-install-ends-with-faild-git-tag-list-column-never/5242