### PR TITLE
Fix swallowing original error message in `git_retry`

### DIFF
--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -1266,4 +1266,12 @@ describe "install" do
       end
     end
   end
+
+  it "fails when git is missing" do
+    metadata = {dependencies: {web: "*"}}
+    with_shard(metadata) do
+      ex = expect_raises(FailedCommand) { run "shards install --no-color", env: {"PATH" => File.expand_path("../../bin", __DIR__), "SHARDS_CACHE_PATH" => "" } }
+      ex.stdout.should contain "Error missing git command line tool. Please install Git first!"
+    end
+  end
 end

--- a/spec/integration/install_spec.cr
+++ b/spec/integration/install_spec.cr
@@ -1270,7 +1270,7 @@ describe "install" do
   it "fails when git is missing" do
     metadata = {dependencies: {web: "*"}}
     with_shard(metadata) do
-      ex = expect_raises(FailedCommand) { run "shards install --no-color", env: {"PATH" => File.expand_path("../../bin", __DIR__), "SHARDS_CACHE_PATH" => "" } }
+      ex = expect_raises(FailedCommand) { run "shards install --no-color", env: {"PATH" => File.expand_path("../../bin", __DIR__), "SHARDS_CACHE_PATH" => ""} }
       ex.stdout.should contain "Error missing git command line tool. Please install Git first!"
     end
   end

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -332,10 +332,11 @@ module Shards
       loop do
         yield
         break
-      rescue Error
+      rescue inner_err : Error
         retries += 1
         next if retries < 3
-        raise Error.new(err)
+        Log.debug { inner_err }
+        raise Error.new("#{err}: #{inner_err}")
       end
     end
 


### PR DESCRIPTION
The equivalent method in the other resolvers already prints the original error message, just `git` didn't do that.

Fixes #525