### PR TITLE
Using libgit2 for cloning, listing tags, etc

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -1,5 +1,9 @@
 version: 2.0
 shards:
+  grits:
+    git: https://gitlab.com/skinnyjames/grits.git
+    version: 0.1.0+git.commit.b1b6d10dec3ba5c84f6c6b5cdad3ab3eec9f2e87
+
   molinillo:
     git: https://github.com/crystal-lang/crystal-molinillo.git
     version: 0.2.0

--- a/shard.yml
+++ b/shard.yml
@@ -7,6 +7,8 @@ authors:
 dependencies:
   molinillo:
     github: crystal-lang/crystal-molinillo
+  grits:
+    gitlab: skinnyjames/grits
 
 targets:
   shards:


### PR DESCRIPTION
## Changes

This PR replaces most (but not all) git commands in the git resolve with libgit2 behaviors.  

## Benchmarks

Overall true git clones appear faster than libgit2, but libgit2 clones consume significantly less memory.  If not employed already, concurrency may help.

A benchmark on a repo with many dependencies using `hyperfine` (_gshards_ is the release binary using libgit2).

`hyperfine 'rm -Rf lib && shards install --without-development' 'rm -Rf lib && gshards install --without-development'`

```
Benchmark 1: rm -Rf lib && shards install --without-development
  Time (mean ± σ):      4.076 s ±  0.263 s    [User: 1.844 s, System: 1.789 s]
  Range (min … max):    3.847 s …  4.669 s    10 runs
 
Benchmark 2: rm -Rf lib && gshards install --without-development
  Time (mean ± σ):      5.929 s ±  0.827 s    [User: 0.721 s, System: 1.340 s]
  Range (min … max):    5.484 s …  8.264 s    10 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Summary
  'rm -Rf lib && shards install --without-development' ran
    1.45 ± 0.22 times faster than 'rm -Rf lib && gshards install --without-development'
````

## Notes

* Libgit2 is highly configurable, and so is Grits so far.  Supporting more complex features programmatically may be easier.
* Statically linking libgit2 would remove a dependency (known)
* Historically libgit2 hasn't had support for shallow clones. This is no longer the case as of [2 weeks ago](https://github.com/libgit2/libgit2/issues/3058#issuecomment-1540940627).  Clones can do shallow fetches and it appears a fetch can `unshallow` a shallow clone.  This could significantly improve performance.  Grits is currently locked at `v1.3` so it would need to  be updated. 