### PR TITLE
Clarify documentation of `--local` flag

### DIFF
--- a/docs/shards.adoc
+++ b/docs/shards.adoc
@@ -125,7 +125,9 @@ after a command.
   Disables colored output.
 
 --local::
-  Don't update remote repositories, use the local cache only.
+  Do not update remote repository cache. Instead, Shards will use the local copies
+  already present in the cache (see *SHARDS_CACHE_PATH*).
+  The command will fail if a depedency is unavailable in the cache.
 
 -q, --quiet::
   Decreases the log verbosity, printing only warnings and errors.


### PR DESCRIPTION
The previous documentation was prone to misunderstanding (example: #584). This makes it more clear what the flag is about.