### PR TITLE
Add tags to resolver specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 release ?=      ## Compile in release mode
 debug ?=        ## Add symbolic debug info
 static ?=       ## Enable static linking
+skip_fossil ?=  ## Skip fossil tests
+skip_git ?=     ## Skip git tests
+skip_hg ?=      ## Skip hg tests
 
 CRYSTAL ?= crystal
 SHARDS ?= shards
@@ -53,7 +56,7 @@ uninstall: phony
 test: test_unit test_integration
 
 test_unit: phony lib
-	$(CRYSTAL) spec ./spec/unit/
+	$(CRYSTAL) spec ./spec/unit/ $(if $(skip_fossil),--tag ~fossil) $(if $(skip_git),--tag ~git) $(if $(skip_hg),--tag ~hg)
 
 test_integration: bin/shards phony
 	$(CRYSTAL) spec ./spec/integration/

--- a/spec/unit/fossil_resolver_spec.cr
+++ b/spec/unit/fossil_resolver_spec.cr
@@ -12,7 +12,7 @@ module Shards
     end
   end
 
-  describe FossilResolver do
+  describe FossilResolver, tags: %w[fossil] do
     before_each do
       create_fossil_repository "empty"
       create_fossil_commit "empty", "initial release"

--- a/spec/unit/git_resolver_spec.cr
+++ b/spec/unit/git_resolver_spec.cr
@@ -11,7 +11,7 @@ module Shards
     end
   end
 
-  describe GitResolver do
+  describe GitResolver, tags: %w[git] do
     before_each do
       create_git_repository "empty"
       create_git_commit "empty", "initial release"

--- a/spec/unit/hg_resolver_spec.cr
+++ b/spec/unit/hg_resolver_spec.cr
@@ -11,7 +11,7 @@ module Shards
     end
   end
 
-  describe HgResolver do
+  describe HgResolver, tags: %w[hg] do
     before_each do
       create_hg_repository "empty"
       create_hg_commit "empty", "initial release"


### PR DESCRIPTION
Allow skipping specs for individual resolvers which can be useful when the respective dependency (the resolver binary) is unavailable in the spec environment.