### PR TITLE
ci: Ensure manpages are generated with no diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,6 @@ jobs:
       - name: Build manpages
         uses: Analog-inc/asciidoctor-action@master
         with:
-          shellcommand: "make manpages"
+          shellcommand: "make -B manpages SOURCE_DATE_EPOCH=\"$(date +%s --utc --date \"$(grep -m1 -o -E 'Date: .*' man/shard.yml.5 | cut -d' ' -f2)\")\""
+      - name: Ensure no changes
+        run: git diff --exit-code

--- a/man/shard.yml.5
+++ b/man/shard.yml.5
@@ -1,7 +1,7 @@
 '\" t
 .\"     Title: shard.yml
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.18
+.\" Generator: Asciidoctor 2.0.17
 .\"      Date: 2023-04-07
 .\"    Manual: File Formats
 .\"    Source: shards 0.17.3

--- a/man/shards.1
+++ b/man/shards.1
@@ -1,7 +1,7 @@
 '\" t
 .\"     Title: shards
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.18
+.\" Generator: Asciidoctor 2.0.17
 .\"      Date: 2023-04-07
 .\"    Manual: Shards Manual
 .\"    Source: shards 0.17.3
@@ -200,7 +200,9 @@ Disables colored output.
 .sp
 \-\-local
 .RS 4
-Don\(cqt update remote repositories, use the local cache only.
+Do not update remote repository cache. Instead, Shards will use the local copies
+already present in the cache (see \fBSHARDS_CACHE_PATH\fP).
+The command will fail if a depedency is unavailable in the cache.
 .RE
 .sp
 \-q, \-\-quiet


### PR DESCRIPTION
Manpages in `man/` are generated from adoc files in `docs/`. Both source and target format are checked into git.
Often it's forgotten to update the manpages when the adoc sources are updated (latest example: #587).

This change ensures that the manpages are up to date in CI by rebuilding them and checking if they produce a diff.