### PR TITLE
Use `FileUtils.rm_rf` instead of shell command in spec

### DIFF
--- a/spec/integration/prune_spec.cr
+++ b/spec/integration/prune_spec.cr
@@ -38,7 +38,7 @@ describe "prune" do
   end
 
   it "should not fail if the install directory does not exist" do
-    run "rm -rf #{install_path}"
+    FileUtils.rm_rf(install_path)
     Dir.cd(application_path) { run "shards prune" }
   end
 end


### PR DESCRIPTION
This is needed for one spec to pass on Windows where `rm` doesn't exist as a built-in.