### PR TITLE
Add JSON schema for `shard.yml`

### DIFF
--- a/docs/shard.yml.schema.json
+++ b/docs/shard.yml.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "shard.yml",
-  "description": "Metadata for projects managed by shards",
+  "description": "Metadata for projects managed by Crystal Shards",
   "type": "object",
   "properties": {
     "name": {

--- a/docs/shard.yml.schema.json
+++ b/docs/shard.yml.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "shard.yml",
-  "description": "Metadata for projects managed by Crystal Shards",
+  "description": "Metadata for projects managed by Shards",
   "type": "object",
   "properties": {
     "name": {
@@ -22,7 +22,9 @@
       "title": "authors",
       "description": "A list of authors, along with their contact email",
       "items": {
-        "type": "string"
+        "type": "string",
+        "title": "author",
+        "description": "An authors name and contact email"
       }
     },
     "crystal": {
@@ -38,35 +40,36 @@
         "type": "object",
         "title": "dependency name",
         "description": "The name of the dependency",
+        "additionalProperties": false,
         "properties": {
           "github": {
             "type": "string",
-            "title": "github url",
+            "title": "GitHub URL",
             "description": "GitHub repository URL as user/repo"
           },
           "gitlab": {
             "type": "string",
-            "title": "gitlab url",
+            "title": "GitLab URL",
             "description": "GitLab repository URL as user/repo"
           },
           "bitbucket": {
             "type": "string",
-            "title": "bitbucket url",
+            "title": "Bitbucket URL",
             "description": "Bitbucket repository URL as user/repo"
           },
           "git": {
             "type": "string",
-            "title": "git url",
+            "title": "git URL",
             "description": "A Git repository URL"
           },
           "hg": {
             "type": "string",
-            "title": "mercurial url",
+            "title": "Mercurial URL",
             "description": "A Mercurial repository URL"
           },
           "fossil": {
             "type": "string",
-            "title": "fossil url",
+            "title": "Fossil URL",
             "description": "A Fossil repository URL"
           },
           "path": {
@@ -110,35 +113,36 @@
         "type": "object",
         "title": "dependency name",
         "description": "The name of the dependency",
+        "additionalProperties": false,
         "properties": {
           "github": {
             "type": "string",
-            "title": "github url",
+            "title": "GitHub URL",
             "description": "GitHub repository URL as user/repo"
           },
           "gitlab": {
             "type": "string",
-            "title": "gitlab url",
+            "title": "GitLab URL",
             "description": "GitLab repository URL as user/repo"
           },
           "bitbucket": {
             "type": "string",
-            "title": "bitbucket url",
+            "title": "Bitbucket URL",
             "description": "Bitbucket repository URL as user/repo"
           },
           "git": {
             "type": "string",
-            "title": "git url",
+            "title": "git URL",
             "description": "A Git repository URL"
           },
           "hg": {
             "type": "string",
-            "title": "mercurial url",
+            "title": "Mercurial URL",
             "description": "A Mercurial repository URL"
           },
           "fossil": {
             "type": "string",
-            "title": "fossil url",
+            "title": "Fossil URL",
             "description": "A Fossil repository URL"
           },
           "path": {
@@ -181,7 +185,7 @@
     },
     "documentation": {
       "type": "string",
-      "title": "documentation url",
+      "title": "documentation URL",
       "description": "The URL to a website providing the project's documentation for online browsing"
     },
     "executables": {
@@ -194,7 +198,7 @@
     },
     "homepage": {
       "type": "string",
-      "title": "homepage url",
+      "title": "homepage URL",
       "description": "The URL of the project's homepage"
     },
     "libraries": {
@@ -212,7 +216,7 @@
     },
     "repository": {
       "type": "string",
-      "title": "repository url",
+      "title": "repository URL",
       "description": "The URL of the project's canonical repository"
     },
     "scripts": {
@@ -234,6 +238,9 @@
       "description": "A list of targets to build",
       "additionalProperties": {
         "type": "object",
+        "title": "target name",
+        "description": "The name of the target",
+        "additionalProperties": false,
         "properties": {
           "main": {
             "type": "string",

--- a/docs/shard.yml.schema.json
+++ b/docs/shard.yml.schema.json
@@ -1,0 +1,255 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "shard.yml",
+  "description": "Metadata for projects managed by shards",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "title": "project name",
+      "description": "The name of the project",
+      "maxLength": 50,
+      "pattern": "^(?!.*__|.*--|.*crystal|[0-9_-])[a-z0-9_-]+(?<![_-])$"
+    },
+    "version": {
+      "type": "string",
+      "title": "project version",
+      "description": "The version number of the project",
+      "pattern": "^(?!.*\\.\\.|.*--)[0-9a-zA-Z.-]+$"
+    },
+    "authors": {
+      "type": "array",
+      "title": "authors",
+      "description": "A list of authors, along with their contact email",
+      "items": {
+        "type": "string"
+      }
+    },
+    "crystal": {
+      "type": "string",
+      "title": "crystal version",
+      "description": "A restriction to indicate what Crystal versions are supported"
+    },
+    "dependencies": {
+      "type": "object",
+      "title": "dependencies",
+      "description": "A list of required dependencies\nhttps://github.com/crystal-lang/shards/blob/master/docs/shard.yml.adoc#dependency-attributes",
+      "additionalProperties": {
+        "type": "object",
+        "title": "dependency name",
+        "description": "The name of the dependency",
+        "properties": {
+          "github": {
+            "type": "string",
+            "title": "github url",
+            "description": "GitHub repository URL as user/repo"
+          },
+          "gitlab": {
+            "type": "string",
+            "title": "gitlab url",
+            "description": "GitLab repository URL as user/repo"
+          },
+          "bitbucket": {
+            "type": "string",
+            "title": "bitbucket url",
+            "description": "Bitbucket repository URL as user/repo"
+          },
+          "git": {
+            "type": "string",
+            "title": "git url",
+            "description": "A Git repository URL"
+          },
+          "hg": {
+            "type": "string",
+            "title": "mercurial url",
+            "description": "A Mercurial repository URL"
+          },
+          "fossil": {
+            "type": "string",
+            "title": "fossil url",
+            "description": "A Fossil repository URL"
+          },
+          "path": {
+            "type": "string",
+            "title": "local path",
+            "description": "A local path to the dependency"
+          },
+          "version": {
+            "type": "string",
+            "title": "version requirement",
+            "description": "A version requirement for the dependency"
+          },
+          "branch": {
+            "type": "string",
+            "title": "branch",
+            "description": "Install the specified branch of a Git dependency"
+          },
+          "commit": {
+            "type": "string",
+            "title": "commit",
+            "description": "Install the specified commit of a Git, Mercurial, or Fossil dependency"
+          },
+          "tag": {
+            "type": "string",
+            "title": "tag",
+            "description": "Install the specified tag of a Git, Mercurial, or Fossil dependency"
+          },
+          "bookmark": {
+            "type": "string",
+            "title": "bookmark",
+            "description": "Install the specified bookmark of a Mercurial dependency"
+          }
+        }
+      }
+    },
+    "development_dependencies": {
+      "type": "object",
+      "title": "development dependencies",
+      "description": "A list of dependencies required to work on the project, but not necessary to build and run the project\nhttps://github.com/crystal-lang/shards/blob/master/docs/shard.yml.adoc#dependency-attributes",
+      "additionalProperties": {
+        "type": "object",
+        "title": "dependency name",
+        "description": "The name of the dependency",
+        "properties": {
+          "github": {
+            "type": "string",
+            "title": "github url",
+            "description": "GitHub repository URL as user/repo"
+          },
+          "gitlab": {
+            "type": "string",
+            "title": "gitlab url",
+            "description": "GitLab repository URL as user/repo"
+          },
+          "bitbucket": {
+            "type": "string",
+            "title": "bitbucket url",
+            "description": "Bitbucket repository URL as user/repo"
+          },
+          "git": {
+            "type": "string",
+            "title": "git url",
+            "description": "A Git repository URL"
+          },
+          "hg": {
+            "type": "string",
+            "title": "mercurial url",
+            "description": "A Mercurial repository URL"
+          },
+          "fossil": {
+            "type": "string",
+            "title": "fossil url",
+            "description": "A Fossil repository URL"
+          },
+          "path": {
+            "type": "string",
+            "title": "local path",
+            "description": "A local path to the dependency"
+          },
+          "version": {
+            "type": "string",
+            "title": "version requirement",
+            "description": "A version requirement for the dependency"
+          },
+          "branch": {
+            "type": "string",
+            "title": "branch",
+            "description": "Install the specified branch of a Git dependency"
+          },
+          "commit": {
+            "type": "string",
+            "title": "commit",
+            "description": "Install the specified commit of a Git, Mercurial, or Fossil dependency"
+          },
+          "tag": {
+            "type": "string",
+            "title": "tag",
+            "description": "Install the specified tag of a Git, Mercurial, or Fossil dependency"
+          },
+          "bookmark": {
+            "type": "string",
+            "title": "bookmark",
+            "description": "Install the specified bookmark of a Mercurial dependency"
+          }
+        }
+      }
+    },
+    "description": {
+      "type": "string",
+      "title": "project description",
+      "description": "A single line description of the project"
+    },
+    "documentation": {
+      "type": "string",
+      "title": "documentation url",
+      "description": "The URL to a website providing the project's documentation for online browsing"
+    },
+    "executables": {
+      "type": "array",
+      "title": "executables",
+      "description": "A list of executables to be installed",
+      "items": {
+        "type": "string"
+      }
+    },
+    "homepage": {
+      "type": "string",
+      "title": "homepage url",
+      "description": "The URL of the project's homepage"
+    },
+    "libraries": {
+      "type": "object",
+      "title": "libraries",
+      "description": "A list of shared libraries the shard tries to link to",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "license": {
+      "type": "string",
+      "title": "license",
+      "description": "An OSI license name or an URL to a license file"
+    },
+    "repository": {
+      "type": "string",
+      "title": "repository url",
+      "description": "The URL of the project's canonical repository"
+    },
+    "scripts": {
+      "type": "object",
+      "title": "scripts",
+      "description": "Script hooks to run",
+      "properties": {
+        "postinstall": {
+          "type": "string",
+          "title": "postinstall script",
+          "description": "Will be run whenever the dependency is installed or upgraded in a project that requires it"
+        }
+      },
+      "additionalProperties": false
+    },
+    "targets": {
+      "type": "object",
+      "title": "targets",
+      "description": "A list of targets to build",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "main": {
+            "type": "string",
+            "title": "target main file",
+            "description": "The main source file to compile for this target"
+          }
+        },
+        "required": [
+          "main"
+        ]
+      }
+    }
+  },
+  "required": [
+    "name",
+    "version"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Implements #622. I can add automated tests if desired. After this, I can add it to [JSON Schema Store](https://github.com/SchemaStore/schemastore).

I wasn't sure if we should restrict additional properties in the file, as there may be other tools that add stuff to the shard.yml. Off the top of my head, I can't remember any though, and they should probably move those kinds of things to their own config file.

Also if you're using VSCode, you can add this to the `.vscode/settings.json` and it will use the schema to vaidate the shard.yml that shards uses. I used this for testing.

```jsonc
// .vscode/settings.json
{
  "yaml.schemas": {
    "docs/shard.yml.schema.json": "shard.yml"
  }
}
```