### PR TITLE
Add devenv configuration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+source_url "https://raw.githubusercontent.com/cachix/devenv/d1f7b48e35e6dee421cfd0f51481d17f77586997/direnvrc" "sha256-YBzqskFZxmNb3kYVoKD9ZixoPXJh1C9ZvTLGFRkauZ0="
+
+use devenv

--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,3 @@
-source_url "https://raw.githubusercontent.com/cachix/devenv/d1f7b48e35e6dee421cfd0f51481d17f77586997/direnvrc" "sha256-YBzqskFZxmNb3kYVoKD9ZixoPXJh1C9ZvTLGFRkauZ0="
+source_url "https://raw.githubusercontent.com/cachix/devenv/95f329d49a8a5289d31e0982652f7058a189bfca/direnvrc" "sha256-d+8cBpDfDBj41inrADaJt+bDWhOktwslgoP5YiGJ1v0="
 
 use devenv

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@
 /spec/unit/.lib
 /tmp
 /docs/*.html
+
+# Devenv
+.devenv*
+devenv.local.nix
+.direnv/

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,12 @@
 /spec/unit/.lib
 /tmp
 /docs/*.html
-
 # Devenv
 .devenv*
 devenv.local.nix
-.direnv/
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,1 @@
+/nix/store/2bvs1hdl54w2x8wjbh2icvv6wqn69dzj-pre-commit-config.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,1 +1,0 @@
-/nix/store/2bvs1hdl54w2x8wjbh2icvv6wqn69dzj-pre-commit-config.json

--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ Run `make test` to run the test suites:
 
 Run `make docs` to build the manpages.
 
+### Devenv
+
+This repository contains a configuration for [devenv.sh](https://devenv.sh) which
+makes it easy to setup a reproducible environment with all necessary tools for
+building and testing.
+
+- Checkout the repository
+- Run `devenv shell` to get a shell with development environment
+
+A hook for [automatic shell activation](https://devenv.sh/automatic-shell-activation/)
+is also included. If you have `direnv` installed, the devenv environment loads
+automatically upon entering the repo folder.
+
 ## License
 
 Licensed under the Apache License, Version 2.0. See [LICENSE](./LICENSE) for

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,156 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1713968789,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "b26b52a4dac68bdc305f6b9df948c97f49b2c3ee",
+        "treeHash": "4a034bbd3511c196f4075a1eb0da1b422d1011db",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "treeHash": "2addb7b71a20a25ea74feeaf5c2f6a6b30898ecb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "treeHash": "bd263f021e345cb4a39d80c126ab650bebc3c10c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "treeHash": "ca14199cabdfe1a06a7b1654c76ed49100a689f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1713805509,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1e1dc66fe68972a76679644a5577828b6a7e8be4",
+        "treeHash": "45178d59be92731d710aea19878b2f10c925a040",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1713828541,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b500489fd3cf653eafc075f9362423ad5cdd8676",
+        "treeHash": "36037c2cc4ca42960ec785fb7eea87289846dd21",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1713954846,
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "6fb82e44254d6a0ece014ec423cb62d92435336f",
+        "treeHash": "a456512c8da29752b79131f1e5b45053e2394078",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "treeHash": "cce81f2a0f0743b2eb61bc2eb6c7adbe2f2c6beb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.lock
+++ b/devenv.lock
@@ -74,27 +74,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713805509,
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1e1dc66fe68972a76679644a5577828b6a7e8be4",
-        "treeHash": "45178d59be92731d710aea19878b2f10c925a040",
+        "lastModified": 1713361204,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "285676e87ad9f0ca23d8714a6ab61e7e027020c6",
+        "treeHash": "50354b35a3e0277d4a83a0a88fa0b0866b5f392f",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1713828541,
+        "lastModified": 1713995372,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b500489fd3cf653eafc075f9362423ad5cdd8676",
-        "treeHash": "36037c2cc4ca42960ec785fb7eea87289846dd21",
+        "rev": "dd37924974b9202f8226ed5d74a252a9785aedf8",
+        "treeHash": "8114bf8e19ad8c67c0e2639b83c606c58c7bccec",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,24 @@
+{ pkgs, ... }:
+
+{
+  # https://devenv.sh/packages/
+  packages = with pkgs; [
+    # build deps
+    gnumake
+    asciidoctor
+
+    # test deps
+    git
+    fossil
+    mercurial
+  ];
+  enterShell = ''
+    crystal --version
+  '';
+
+  languages.crystal.enable = true;
+
+  # https://devenv.sh/pre-commit-hooks/
+  pre-commit.hooks.shellcheck.enable = true;
+  pre-commit.hooks.crystal.enable = true;
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, config, inputs, ... }:
 
 {
   # https://devenv.sh/packages/

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,4 @@
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable
+# can't point to the local modules here as it's used as a template

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,4 +1,14 @@
 inputs:
   nixpkgs:
-    url: github:NixOS/nixpkgs/nixpkgs-unstable
-# can't point to the local modules here as it's used as a template
+    url: github:cachix/devenv-nixpkgs/rolling
+
+# If you're using non-OSS software, you can set allowUnfree to true.
+# allowUnfree: true
+
+# If you're willing to use a package that's vulnerable
+# permittedInsecurePackages:
+#  - "openssl-1.1.1w"
+
+# If you have more than one devenv you can merge them
+#imports:
+# - ./backend


### PR DESCRIPTION
Configuration for a https://devenv.sh environment with all necessary tools to build and test shards.
I'm using this locally and it makes sense to share it in the repo so others can make use of it as well.