### PR TITLE
Forward unmodified ARGV to subcommand

### DIFF
--- a/spec/integration/subcommand_spec.cr
+++ b/spec/integration/subcommand_spec.cr
@@ -1,0 +1,21 @@
+require "./spec_helper"
+
+describe "subcommand" do
+  it "forwards all arguments to subcommand" do
+    create_shard("dummy", "0.1.0")
+    create_executable "dummy", "bin/shards-dummy", %(print "args: "; print ARGV)
+
+    with_path(git_path("dummy/bin")) do
+      output = run("shards dummy --no-color --verbose --unknown other argument")
+      output.should contain(%(args: ["--no-color", "--verbose", "--unknown", "other", "argument"]))
+    end
+  end
+end
+
+private def with_path(path)
+  old_path = ENV["PATH"]
+  ENV["PATH"] = "#{File.expand_path(path)}#{Process::PATH_DELIMITER}#{ENV["PATH"]}"
+  yield
+ensure
+  ENV["PATH"] = old_path
+end

--- a/spec/integration/subcommand_spec.cr
+++ b/spec/integration/subcommand_spec.cr
@@ -10,6 +10,16 @@ describe "subcommand" do
       output.should contain(%(args: ["--no-color", "--verbose", "--unknown", "other", "argument"]))
     end
   end
+
+  it "correctly forwards '--help' option to subcommand" do
+    create_shard("dummy", "0.1.0")
+    create_executable "dummy", "bin/shards-dummy", %(print "args: "; print ARGV)
+
+    with_path(git_path("dummy/bin")) do
+      output = run("shards dummy --help")
+      output.should contain(%(args: ["--help"]))
+    end
+  end
 end
 
 private def with_path(path)

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -101,7 +101,7 @@ module Shards
         else
           program_name = "shards-#{args[0]}"
           if program_path = Process.find_executable(program_name)
-            run_shards_subcommand(program_path, args)
+            run_shards_subcommand(program_path, cli_options)
           else
             display_help_and_exit(opts)
           end
@@ -119,7 +119,7 @@ module Shards
     {% else %}
       shards_opts = ENV.fetch("SHARDS_OPTS", "").split
     {% end %}
-    ARGV.concat(shards_opts)
+    ARGV.dup.concat(shards_opts)
   end
 
   def self.run_shards_subcommand(process_name, args)

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -2,6 +2,8 @@ require "option_parser"
 require "./commands/*"
 
 module Shards
+  class_property? display_help : Bool = false
+
   def self.display_help_and_exit(opts)
     puts <<-HELP
       shards [<options>...] [<command>]
@@ -53,7 +55,7 @@ module Shards
       opts.on("--ignore-crystal-version", "Has no effect. Kept for compatibility, to be removed in the future.") { }
       opts.on("-v", "--verbose", "Increase the log verbosity, printing all debug statements.") { self.set_debug_log_level }
       opts.on("-q", "--quiet", "Decrease the log verbosity, printing only warnings and errors.") { self.set_warning_log_level }
-      opts.on("-h", "--help", "Print usage synopsis.") { self.display_help_and_exit(opts) }
+      opts.on("-h", "--help", "Print usage synopsis.") { self.display_help = true }
 
       opts.unknown_args do |args, options|
         case args[0]? || DEFAULT_COMMAND
@@ -105,6 +107,10 @@ module Shards
           else
             display_help_and_exit(opts)
           end
+        end
+
+        if display_help?
+          display_help_and_exit(opts)
         end
 
         exit


### PR DESCRIPTION
Hello, this PR aims to forward all arguments supplied to `shards` to the subcommand, if found.

It does this to allow correct parsing of all ARGV supplied, including `SHARDS_OPTS` that might be appended, avoids altering the original `ARGV` when combining it.

Introduces a naive integration test for subcommand to validate the change works correctly.

Last but not least, allows also forwarding `--help` by avoiding it to short-circuit and return immediately by
setting a flag for it and evaluating at the end of the processing of unknown options.

This is only done for the CLI invocation and is not part of Shards module (as the help and usage options are only available in this context).

I'm not sure about the implementation as this was the first integration test for subcommands, so would appreciate some notes on additional changes.

Thank you.

Fixes #600 