### PR TITLE
Add debug information about tags

### DIFF
--- a/src/cli.cr
+++ b/src/cli.cr
@@ -160,6 +160,6 @@ rescue ex : Shards::ParseError
   ex.to_s(STDERR)
   exit 1
 rescue ex : Shards::Error
-  Shards::Log.error { ex.message }
+  Shards::Log.error { ex.message.to_s + "\nYou might find useful information using the --verbose option" }
   exit 1
 end

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -160,6 +160,7 @@ rescue ex : Shards::ParseError
   ex.to_s(STDERR)
   exit 1
 rescue ex : Shards::Error
-  Shards::Log.error { ex.message.to_s + "\nYou might find useful information using the --verbose option" }
+  msg = Shards::Log.level == Log::Severity::Debug ? "" : "\nYou might find useful information using the --verbose option"
+  Shards::Log.error { ex.message.to_s + msg }
   exit 1
 end

--- a/src/resolvers/fossil.cr
+++ b/src/resolvers/fossil.cr
@@ -213,9 +213,16 @@ module Shards
     end
 
     protected def versions_from_tags
-      capture("fossil tag list -R #{Process.quote(local_fossil_file)}")
+      tags = capture("fossil tag list -R #{Process.quote(local_fossil_file)}")
         .split('\n')
-        .compact_map { |tag| Version.new($1) if tag =~ VERSION_TAG }
+
+      Log.debug { "Tags: #{tags.reject(&.empty?).join(", ")}" }
+
+      version_tags = tags.compact_map { |tag| Version.new($1) if tag =~ VERSION_TAG }
+
+      Log.debug { "Version tags (vX.Y): #{version_tags.join(", ")}" }
+
+      version_tags
     end
 
     def install_sources(version : Version, install_path : String)

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -204,9 +204,16 @@ module Shards
     end
 
     protected def versions_from_tags
-      capture("git tag --list #{GitResolver.git_column_never}")
+      tags = capture("git tag --list #{GitResolver.git_column_never}")
         .split('\n')
-        .compact_map { |tag| Version.new($1) if tag =~ VERSION_TAG }
+
+      Log.debug { "Tags: #{tags.reject(&.empty?).join(", ")}" }
+
+      version_tags = tags.compact_map { |tag| Version.new($1) if tag =~ VERSION_TAG }
+
+      Log.debug { "Version tags (vX.Y): #{version_tags.join(", ")}" }
+
+      version_tags
     end
 
     def install_sources(version : Version, install_path : String)

--- a/src/resolvers/hg.cr
+++ b/src/resolvers/hg.cr
@@ -221,10 +221,17 @@ module Shards
     end
 
     protected def versions_from_tags
-      capture("hg tags --template #{Process.quote("{tag}\n")}")
+      tags = capture("hg tags --template #{Process.quote("{tag}\n")}")
         .lines
         .sort!
-        .compact_map { |tag| Version.new($1) if tag =~ VERSION_TAG }
+
+      Log.debug { "Tags: #{tags.reject(&.empty?).join(", ")}" }
+
+      version_tags = tags.compact_map { |tag| Version.new($1) if tag =~ VERSION_TAG }
+
+      Log.debug { "Version tags (vX.Y): #{version_tags.join(", ")}" }
+
+      version_tags
     end
 
     def install_sources(version : Version, install_path : String)


### PR DESCRIPTION
This PR introduces two minor changes as a palliative to #521 :
 * When using `--versbose`, shards lists the tags it found in the repository and those that match pattern `vX.Y`.
 * When failing, it suggests using `--verbose`.
 
 I wasn't sure if `vX.Y` is descriptive enough, but the bare matching string is even less readable...
 
 <details>
<summary>Output on a failing run:</summary>
 

 ```
 ➜  shard-test git:(main) ✗ shards          
Resolving dependencies
Fetching https://github.com/spider-gazelle/priority-queue.git
Unable to satisfy the following requirements:

- `priority-queue (0.2.0)` required by `shard.yml`
Failed to resolve dependencies
You might find useful information using the --verbose option
 ```
</details>

<details>
<summary>Output with `--verbose`:</summary>

```
➜  shard-test git:(main) ✗ shards --verbose
Resolving dependencies
git ls-remote --get-url origin
Fetching https://github.com/spider-gazelle/priority-queue.git
git fetch --all --quiet
git tag --list --column=never
Tags: v1.0.1, v1.1.0
Version tags (vX.Y): 1.0.1, 1.1.0
Unable to satisfy the following requirements:

- `priority-queue (0.2.0)` required by `shard.yml`
Failed to resolve dependencies
```
</details>