### PR TITLE
Run `git config` instead of reading `config` file manually

### DIFF
--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -351,10 +351,7 @@ module Shards
     end
 
     private def valid_repository?
-      File.each_line(File.join(local_path, "config")) do |line|
-        return true if line =~ /mirror\s*=\s*true/
-      end
-      false
+      capture("git config --get-regexp 'remote\\..+\\.mirror'").each_line.any?(&.==("true"))
     end
 
     private def origin_url


### PR DESCRIPTION
I don't think there's a good reason to read the config file directly. Going through the CLI is easier and safer.

ref: https://github.com/crystal-lang/shards/pull/638#issuecomment-2328312139