### PR TITLE
Use SPDX license identifiers for `license` in `shard.yml`

### DIFF
--- a/docs/shard.yml.adoc
+++ b/docs/shard.yml.adoc
@@ -204,8 +204,13 @@ libraries:
 ----
 
 *license*::
-  An http://opensource.org/[OSI license] name or an URL to a license file
+An https://spdx.org/licenses/[SPDX license identifier] or an URL to a license file
 (string, recommended).
++
+The OSI publishes https://opensource.org/licenses-old/category[a list] of open
+source licenses and their corresponding SPDX identifier.
++
+Examples: _Apache-2.0_, _MIT_, _GPL-3.0-or-later_.
 
 *repository*::
 The URL of the project's canonical repository (string, recommended).

--- a/docs/shard.yml.adoc
+++ b/docs/shard.yml.adoc
@@ -204,13 +204,14 @@ libraries:
 ----
 
 *license*::
-An https://spdx.org/licenses/[SPDX license identifier] or an URL to a license file
-(string, recommended).
+An https://spdx.github.io/spdx-spec/v3.0.1/annexes/spdx-license-expressions/[SPDX license expression]
+or an URL to a license file (string, recommended).
 +
 The OSI publishes https://opensource.org/licenses-old/category[a list] of open
 source licenses and their corresponding SPDX identifier.
 +
-Examples: _Apache-2.0_, _MIT_, _GPL-3.0-or-later_, _https://example.com/LICENSE_.
+Examples: _Apache-2.0_, _GPL-3.0-or-later_, _Apache-2.0 OR MIT_,
+_Apache-2.0 WITH Swift-exception_, _https://example.com/LICENSE_.
 
 *repository*::
 The URL of the project's canonical repository (string, recommended).

--- a/docs/shard.yml.adoc
+++ b/docs/shard.yml.adoc
@@ -210,7 +210,7 @@ An https://spdx.org/licenses/[SPDX license identifier] or an URL to a license fi
 The OSI publishes https://opensource.org/licenses-old/category[a list] of open
 source licenses and their corresponding SPDX identifier.
 +
-Examples: _Apache-2.0_, _MIT_, _GPL-3.0-or-later_.
+Examples: _Apache-2.0_, _MIT_, _GPL-3.0-or-later_, _https://example.com/LICENSE_.
 
 *repository*::
 The URL of the project's canonical repository (string, recommended).

--- a/docs/shard.yml.adoc
+++ b/docs/shard.yml.adoc
@@ -208,7 +208,7 @@ An https://spdx.github.io/spdx-spec/v3.0.1/annexes/spdx-license-expressions/[SPD
 or an URL to a license file (string, recommended).
 +
 The OSI publishes https://opensource.org/licenses-old/category[a list] of open
-source licenses and their corresponding SPDX identifier.
+source licenses and their corresponding SPDX identifiers.
 +
 Examples: _Apache-2.0_, _GPL-3.0-or-later_, _Apache-2.0 OR MIT_,
 _Apache-2.0 WITH Swift-exception_, _https://example.com/LICENSE_.

--- a/docs/shard.yml.schema.json
+++ b/docs/shard.yml.schema.json
@@ -212,7 +212,7 @@
     "license": {
       "type": "string",
       "title": "license",
-      "description": "An OSI license name or an URL to a license file"
+      "description": "An SPDX license identifier or an URL to a license file"
     },
     "repository": {
       "type": "string",

--- a/docs/shard.yml.schema.json
+++ b/docs/shard.yml.schema.json
@@ -212,7 +212,7 @@
     "license": {
       "type": "string",
       "title": "license",
-      "description": "An SPDX license identifier or an URL to a license file"
+      "description": "An SPDX license expression or an URL to a license file."
     },
     "repository": {
       "type": "string",

--- a/man/shard.yml.5
+++ b/man/shard.yml.5
@@ -2,12 +2,12 @@
 .\"     Title: shard.yml
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.20
-.\"      Date: 2024-03-28
+.\"      Date: 2024-10-26
 .\"    Manual: File Formats
 .\"    Source: shards 0.18.0
 .\"  Language: English
 .\"
-.TH "SHARD.YML" "5" "2024-03-28" "shards 0.18.0" "File Formats"
+.TH "SHARD.YML" "5" "2024-10-26" "shards 0.18.0" "File Formats"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -434,10 +434,18 @@ libraries:
 .sp
 \fBlicense\fP
 .RS 4
-  An \c
-.URL "http://opensource.org/" "OSI license" ""
-name or an URL to a license file
-(string, recommended).
+An \c
+.URL "https://spdx.github.io/spdx\-spec/v3.0.1/annexes/spdx\-license\-expressions/" "SPDX license expression"
+or an URL to a license file (string, recommended).
+.sp
+The OSI publishes \c
+.URL "https://opensource.org/licenses\-old/category" "a list" ""
+of open
+source licenses and their corresponding SPDX identifiers.
+.sp
+Examples: \fIApache\-2.0\fP, \fIGPL\-3.0\-or\-later\fP, \fIApache\-2.0 OR MIT\fP,
+\fIApache\-2.0 WITH Swift\-exception\fP, \fI\c
+.URL "https://example.com/LICENSE" "" "\fP."
 .RE
 .sp
 \fBrepository\fP

--- a/man/shards.1
+++ b/man/shards.1
@@ -2,12 +2,12 @@
 .\"     Title: shards
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.20
-.\"      Date: 2024-03-28
+.\"      Date: 2024-10-26
 .\"    Manual: Shards Manual
 .\"    Source: shards 0.18.0
 .\"  Language: English
 .\"
-.TH "SHARDS" "1" "2024-03-28" "shards 0.18.0" "Shards Manual"
+.TH "SHARDS" "1" "2024-10-26" "shards 0.18.0" "Shards Manual"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0

--- a/spec/unit/spec_spec.cr
+++ b/spec/unit/spec_spec.cr
@@ -29,7 +29,7 @@ module Shards
     it "parse license" do
       spec = Spec.from_yaml("name: shards\nversion: 0.1.0\nlicense: BSD-2-Clause")
       spec.license.should eq("BSD-2-Clause")
-      spec.license_url.should eq("http://opensource.org/licenses/BSD-2-Clause")
+      spec.license_url.should eq("https://spdx.org/licenses/BSD-2-Clause")
 
       spec = Spec.from_yaml("name: shards\nversion: 0.1.0\nlicense: http://example.com/LICENSE")
       spec.license.should eq("http://example.com/LICENSE")

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -218,7 +218,7 @@ module Shards
         if license =~ %r(https?://)
           license
         else
-          "http://opensource.org/licenses/#{license}"
+          "https://spdx.org/licenses/#{license}"
         end
       end
     end


### PR DESCRIPTION
I'd love to see #221 implemented. This is my go at it!