### PR TITLE
Revert "Run `git config` instead of reading `config` file manually"

### DIFF
--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -351,7 +351,10 @@ module Shards
     end
 
     private def valid_repository?
-      capture("git config --get-regexp 'remote\\..+\\.mirror'").each_line.any?(&.==("true"))
+      File.each_line(File.join(local_path, "config")) do |line|
+        return true if line =~ /mirror\s*=\s*true/
+      end
+      false
     end
 
     private def origin_url


### PR DESCRIPTION
The change is broken on Windows. This was masked by the CI failure due to #640.

> E: Failed git config --get-regexp 'remote\..+\.mirror'.

Reverts crystal-lang/shards#639