### PR TITLE
Allow `scripts` and `targets` in schema to be permissive

### DIFF
--- a/docs/shard.yml.schema.json
+++ b/docs/shard.yml.schema.json
@@ -230,7 +230,7 @@
           "description": "Will be run whenever the dependency is installed or upgraded in a project that requires it"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "targets": {
       "type": "object",
@@ -240,7 +240,7 @@
         "type": "object",
         "title": "target name",
         "description": "The name of the target",
-        "additionalProperties": false,
+        "additionalProperties": true,
         "properties": {
           "main": {
             "type": "string",


### PR DESCRIPTION
Geode makes use of custom properties in these fields which show as invalid in the editor. In future it would probably be a good idea to also make other parts of the schema permissive.