### PR TITLE
Install mercurial via OS package manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Install Mercurial
         run: pip install mercurial
+        if: ${{ matrix.os != 'windows-2022' }}
 
       - name: Install Crystal
         uses: oprypin/install-crystal@v1
@@ -54,9 +55,9 @@ jobs:
           brew update
           brew install fossil
 
-      - name: Install Fossil
+      - name: Install Fossil and Mercurial
         if: ${{ matrix.os == 'windows-2022' }}
-        run: choco install fossil
+        run: choco install fossil hg
 
       - name: Download source
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,13 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: |
           sudo apt-get update
-          sudo apt-get install fossil hg
+          sudo apt-get install fossil mercurial
 
       - name: Install Fossil and Mercurial
         if: ${{ runner.os == 'macOS' }}
         run: |
           brew update
-          brew install fossil hg
+          brew install fossil mercurial
 
       - name: Install Fossil and Mercurial
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,35 +28,25 @@ jobs:
           git config --global column.ui always
           git config --global core.autocrlf false
 
-      - name: Install Python
-        uses: actions/setup-python@v5
-
-      - name: Upgrade pip
-        run: python -m pip install --upgrade pip
-
-      - name: Install Mercurial
-        run: pip install mercurial
-        if: ${{ matrix.os != 'windows-2022' }}
-
       - name: Install Crystal
         uses: oprypin/install-crystal@v1
         with:
           crystal: ${{ matrix.crystal }}
 
-      - name: Install Fossil
+      - name: Install Fossil and Mercurial
         if: ${{ runner.os == 'Linux' }}
         run: |
           sudo apt-get update
-          sudo apt-get install fossil
-
-      - name: Install Fossil
-        if: ${{ matrix.os == 'macos-12' }}
-        run: |
-          brew update
-          brew install fossil
+          sudo apt-get install fossil hg
 
       - name: Install Fossil and Mercurial
-        if: ${{ matrix.os == 'windows-2022' }}
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          brew update
+          brew install fossil hg
+
+      - name: Install Fossil and Mercurial
+        if: ${{ runner.os == 'Windows' }}
         run: choco install fossil hg
 
       - name: Download source


### PR DESCRIPTION
Installing mercurial via pip on Windows fails due to a missing dependency. But the chocolatey package works, so let's use that.
Actually, let's use OS-specific package managers on all platforms to install mercurial (like we already do for fossil).
The spec suite still fails due to https://github.com/crystal-lang/shards/pull/639#issuecomment-2358259257, but that's a different issue (#639). This patch makes it even work at all.

Resolves #640