### PR TITLE
Fix `GitResolver#valid_repository?`

### DIFF
--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -351,7 +351,14 @@ module Shards
     end
 
     private def valid_repository?
-      capture("git config --get-regexp 'remote\\..+\\.mirror'").each_line.any?(&.==("true"))
+      command = "git config --get remote.origin.mirror"
+      Log.debug { command }
+
+      output = Process.run(command, shell: true, output: :pipe, chdir: local_path) do |process|
+        process.output.gets_to_end
+      end
+
+      return $?.success? && output.chomp == "true"
     end
 
     private def origin_url


### PR DESCRIPTION
Fixup for https://github.com/crystal-lang/shards/pull/639

`git config` exits with status code 1 if the config value was not found. This would raise an exception but instead, `#valid_repository?` should just return `false`. This patch fixes that. It also moves from `--get-regexp` to plain `--get`. The remote name `origin` is fixed anyway (e.g. `git ls-remote --get-url origin` in `#origin_url`) and we only care about this.

The change is broken on Windows. This was masked by the CI failure due to https://github.com/crystal-lang/shards/issues/640.

Closes #642