### PR TITLE
Update CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-12]
+        os: [ubuntu-24.04, macos-13, macos-14]
         crystal: [latest, nightly]
         include:
           - os: windows-2022


### PR DESCRIPTION
Updates to the latest CI images. Using both `macos-13` and `macos-14` because the former is x86_64 and the latter aarch64.

This still doesn't fix the CI failure on macos, but it's a good thing anyway (`macos-12` is being phased out)