### PR TITLE
Add support for Codeberg as a git resolver

### DIFF
--- a/docs/shard.yml.adoc
+++ b/docs/shard.yml.adoc
@@ -273,7 +273,7 @@ A path to the source file to compile (string).
 == DEPENDENCY ATTRIBUTES
 
 Each dependency needs at least one attribute that defines the resolver for this
-dependency. Those can be _path_, _git_, _github_, _gitlab_, _bitbucket_.
+dependency. Those can be _path_, _git_, _github_, _gitlab_, _bitbucket_, _codeberg_.
 
 *path*::
 A local path (string).
@@ -319,6 +319,13 @@ Bitbucket repository URL as _user/repo_ (string).
 Extends the _git_ resolver, and acts exactly like it.
 +
 *Example:* _bitbucket: tom/library_
+
+*codeberg*::
+Codeberg repository URL as _user/repo_ (string).
++
+Extends the _git_ resolver, and acts exactly like it.
++
+*Example:* _codeberg: tom/library_
 
 *hg*::
 

--- a/docs/shard.yml.schema.json
+++ b/docs/shard.yml.schema.json
@@ -57,6 +57,11 @@
             "title": "Bitbucket URL",
             "description": "Bitbucket repository URL as user/repo"
           },
+          "codeberg": {
+            "type": "string",
+            "title": "Codeberg URL",
+            "description": "Codeberg repository URL as user/repo"
+          },
           "git": {
             "type": "string",
             "title": "git URL",
@@ -129,6 +134,11 @@
             "type": "string",
             "title": "Bitbucket URL",
             "description": "Bitbucket repository URL as user/repo"
+          },
+          "codeberg": {
+            "type": "string",
+            "title": "Codeberg URL",
+            "description": "Codeberg repository URL as user/repo"
           },
           "git": {
             "type": "string",

--- a/man/shard.yml.5
+++ b/man/shard.yml.5
@@ -524,7 +524,8 @@ A path to the source file to compile (string).
 .SH "DEPENDENCY ATTRIBUTES"
 .sp
 Each dependency needs at least one attribute that defines the resolver for this
-dependency. Those can be \fIpath\fP, \fIgit\fP, \fIgithub\fP, \fIgitlab\fP, \fIbitbucket\fP.
+dependency. Those can be \fIpath\fP, \fIgit\fP, \fIgithub\fP, \fIgitlab\fP, \fIbitbucket\fP,
+\fIcodeberg\fP.
 .sp
 \fBpath\fP
 .RS 4
@@ -580,6 +581,15 @@ Bitbucket repository URL as \fIuser/repo\fP (string).
 Extends the \fIgit\fP resolver, and acts exactly like it.
 .sp
 \fBExample:\fP \fIbitbucket: tom/library\fP
+.RE
+.sp
+\fBcodeberg\fP
+.RS 4
+Codeberg repository URL as \fIuser/repo\fP (string).
+.sp
+Extends the \fIgit\fP resolver, and acts exactly like it.
+.sp
+\fBExample:\fP \fIcodeberg: tom/library\fP
 .RE
 .sp
 \fBhg\fP

--- a/man/shard.yml.5
+++ b/man/shard.yml.5
@@ -524,8 +524,7 @@ A path to the source file to compile (string).
 .SH "DEPENDENCY ATTRIBUTES"
 .sp
 Each dependency needs at least one attribute that defines the resolver for this
-dependency. Those can be \fIpath\fP, \fIgit\fP, \fIgithub\fP, \fIgitlab\fP, \fIbitbucket\fP,
-\fIcodeberg\fP.
+dependency. Those can be \fIpath\fP, \fIgit\fP, \fIgithub\fP, \fIgitlab\fP, \fIbitbucket\fP, \fIcodeberg\fP.
 .sp
 \fBpath\fP
 .RS 4

--- a/spec/unit/git_resolver_spec.cr
+++ b/spec/unit/git_resolver_spec.cr
@@ -39,12 +39,14 @@ module Shards
       GitResolver.normalize_key_source("gitlab", "repo/path").should eq({"git", "https://gitlab.com/repo/path.git"})
       GitResolver.normalize_key_source("gitlab", "rEpo/pAth").should eq({"git", "https://gitlab.com/repo/path.git"})
       GitResolver.normalize_key_source("gitlab", "REPO/PATH").should eq({"git", "https://gitlab.com/repo/path.git"})
+      GitResolver.normalize_key_source("codeberg", "REPO/PATH").should eq({"git", "https://codeberg.org/repo/path.git"})
 
       # normalise full git paths
       GitResolver.normalize_key_source("git", "HTTPS://User:Pass@Github.com/Repo/Path.git?Shallow=true")[1].should eq "https://User:Pass@github.com/repo/path.git?Shallow=true"
       GitResolver.normalize_key_source("git", "HTTPS://User:Pass@Bitbucket.com/Repo/Path.Git?Shallow=true")[1].should eq "https://User:Pass@bitbucket.com/repo/path.git?Shallow=true"
       GitResolver.normalize_key_source("git", "HTTPS://User:Pass@Gitlab.com/Repo/Path?Shallow=true")[1].should eq "https://User:Pass@gitlab.com/repo/path.git?Shallow=true"
       GitResolver.normalize_key_source("git", "HTTPS://User:Pass@www.Github.com/Repo/Path?Shallow=true")[1].should eq "https://User:Pass@github.com/repo/path.git?Shallow=true"
+      GitResolver.normalize_key_source("git", "HTTPS://User:Pass@codeBerg.org/Repo/Path.Git?Shallow=true")[1].should eq "https://User:Pass@codeberg.org/repo/path.git?Shallow=true"
 
       # don't normalise other domains
       GitResolver.normalize_key_source("git", "HTTPs://mygitserver.com/Repo.git").should eq({"git", "HTTPs://mygitserver.com/Repo.git"})

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -100,7 +100,15 @@ module Shards
       "git"
     end
 
-    private KNOWN_PROVIDERS = {"www.github.com", "github.com", "www.bitbucket.com", "bitbucket.com", "www.gitlab.com", "gitlab.com"}
+    private KNOWN_PROVIDERS = {
+      "www.github.com",
+      "github.com",
+      "www.bitbucket.com",
+      "bitbucket.com",
+      "www.gitlab.com",
+      "gitlab.com",
+      "codeberg.org",
+    }
 
     def self.normalize_key_source(key : String, source : String) : {String, String}
       case key
@@ -120,6 +128,8 @@ module Shards
         end
       when "github", "bitbucket", "gitlab"
         {"git", "https://#{key}.com/#{source.downcase}.git"}
+      when "codeberg"
+        {"git", "https://#{key}.org/#{source.downcase}.git"}
       else
         raise "Unknown resolver #{key}"
       end
@@ -458,5 +468,6 @@ module Shards
     register_resolver "github", GitResolver
     register_resolver "gitlab", GitResolver
     register_resolver "bitbucket", GitResolver
+    register_resolver "codeberg", GitResolver
   end
 end

--- a/src/resolvers/git.cr
+++ b/src/resolvers/git.cr
@@ -107,6 +107,7 @@ module Shards
       "bitbucket.com",
       "www.gitlab.com",
       "gitlab.com",
+      "www.codeberg.org",
       "codeberg.org",
     }
 


### PR DESCRIPTION
Enhances the `shard.yml` configuration to support [Codeberg](https://codeberg.org/),
a popular Git hosting service in Germany, as a dependency source.

This allows developers to specify Codeberg repositories directly in their configuration.

Example usage:

```yaml
dependencies:
  foo:
    codeberg: repo/foo
```