### PR TITLE
[CI] Run docs check in separate workflow with path restriction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,15 +60,3 @@ jobs:
 
       - name: Check formatting
         run: crystal tool format --check src spec
-
-  docs:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Download source
-        uses: actions/checkout@v4
-      - name: Build manpages
-        uses: Analog-inc/asciidoctor-action@v1.3.2
-        with:
-          shellcommand: "make -B manpages SOURCE_DATE_EPOCH=\"$(date +%s --utc --date \"$(grep -m1 -o -E 'Date: .*' man/shard.yml.5 | cut -d' ' -f2)\")\""
-      - name: Ensure no changes
-        run: git diff --exit-code

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,4 +27,4 @@ jobs:
         with:
           shellcommand: "make -B manpages SOURCE_DATE_EPOCH=\"$(date +%s --utc --date \"$(grep -m1 -o -E 'Date: .*' man/shard.yml.5 | cut -d' ' -f2)\")\""
       - name: Ensure no changes
-        run: git diff --exit-code || echo "`make manpages` produced changes. Please rebuild them.'
+        run: git diff --exit-code || echo '`make manpages` produced changes. Please rebuild them.'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,4 +27,4 @@ jobs:
         with:
           shellcommand: "make -B manpages SOURCE_DATE_EPOCH=\"$(date +%s --utc --date \"$(grep -m1 -o -E 'Date: .*' man/shard.yml.5 | cut -d' ' -f2)\")\""
       - name: Ensure no changes
-        run: git diff --exit-code || echo '`make manpages` produced changes. Please rebuild them.'
+        run: git diff --exit-code || echo '`make manpages` produced changes. Please rebuild the docs.'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Docs
+
+on:
+  push:
+    paths:
+      - docs/*.adoc
+      - .github/workflows/docs.yml
+      - VERSION
+      - docs.mk
+  pull_request:
+    paths:
+      - docs/*.adoc
+      - .github/workflows/docs.yml
+      - VERSION
+      - docs.mk
+
+permissions: {}
+
+jobs:
+  docs:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download source
+        uses: actions/checkout@v4
+      - name: Build manpages
+        uses: Analog-inc/asciidoctor-action@v1.3.2
+        with:
+          shellcommand: "make -B manpages SOURCE_DATE_EPOCH=\"$(date +%s --utc --date \"$(grep -m1 -o -E 'Date: .*' man/shard.yml.5 | cut -d' ' -f2)\")\""
+      - name: Ensure no changes
+        run: git diff --exit-code

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,4 +27,4 @@ jobs:
         with:
           shellcommand: "make -B manpages SOURCE_DATE_EPOCH=\"$(date +%s --utc --date \"$(grep -m1 -o -E 'Date: .*' man/shard.yml.5 | cut -d' ' -f2)\")\""
       - name: Ensure no changes
-        run: git diff --exit-code
+        run: git diff --exit-code || echo "`make manpages` produced changes. Please rebuild them.'


### PR DESCRIPTION
The docs workflow only needs to run when there are changes to the docs or doc processing.