### PR TITLE
Fix: --help option

### DIFF
--- a/spec/integration/help_spec.cr
+++ b/spec/integration/help_spec.cr
@@ -3,10 +3,10 @@ require "./spec_helper"
 describe "--help" do
   it "prints help and doesn't invoke the command" do
     metadata = {
-      version: "1.0.0",
+      version:      "1.0.0",
       dependencies: {
-        mock: { git: git_path("mock") }
-      }
+        mock: {git: git_path("mock")},
+      },
     }
 
     [

--- a/spec/integration/help_spec.cr
+++ b/spec/integration/help_spec.cr
@@ -1,0 +1,29 @@
+require "./spec_helper"
+
+describe "--help" do
+  metadata = {
+    version: "1.0.0",
+    dependencies: {
+      mock: { git: git_path("mock") }
+    }
+  }
+
+  it "prints help and doesn't invoke the command" do
+    [
+      "shards --help",
+      "shards --local --help",
+      "shards update --help",
+    ].each do |command|
+      with_shard(metadata) do
+        output = run command
+
+        # it printed the help message
+        output.should contain("Commands:")
+        output.should contain("General options:")
+
+        # it didn't run the default command
+        output.should_not contain("Resolving dependencies")
+      end
+    end
+  end
+end

--- a/spec/integration/help_spec.cr
+++ b/spec/integration/help_spec.cr
@@ -1,14 +1,14 @@
 require "./spec_helper"
 
 describe "--help" do
-  metadata = {
-    version: "1.0.0",
-    dependencies: {
-      mock: { git: git_path("mock") }
-    }
-  }
-
   it "prints help and doesn't invoke the command" do
+    metadata = {
+      version: "1.0.0",
+      dependencies: {
+        mock: { git: git_path("mock") }
+      }
+    }
+
     [
       "shards --help",
       "shards --local --help",

--- a/spec/integration/help_spec.cr
+++ b/spec/integration/help_spec.cr
@@ -21,7 +21,7 @@ describe "--help" do
         output.should contain("Commands:")
         output.should contain("General options:")
 
-        # it didn't run the default command
+        # it didn't run the command (or default command)
         output.should_not contain("Resolving dependencies")
       end
     end

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -128,6 +128,8 @@ module Shards
             display_help_and_exit(opts)
           end
         end
+
+        exit
       end
     end
   end


### PR DESCRIPTION
Restores the behavior where `--help` would always skip the command to be invoked, while still allowing to pass the `--help` to external subcommands:

The following commands print the help message and exit:

- `shards --help`
- `shards --local --help`
- `shards update --help`

While the following tries to call `shards-unknown --help` then falls back to print the help message and exit:

- `shards unknown --help` 

Relies on a fixed list of the builtin command names to avoid having each `when` case starting with `display_help_and_exit(opts) if display_help`.

closes #649 