### PR TITLE
Fix make touch `shard.lock` when `SHARDS=false`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ lib: shard.lock
 	$(SHARDS) install || (curl -L $(MOLINILLO_URL) | tar -xzf - -C lib/molinillo --strip-components=1)
 
 shard.lock: shard.yml
-	[ $(SHARDS) = false ] || $(SHARDS) update
+	([ $(SHARDS) = false ] && touch $@) || $(SHARDS) update
 
 man/%.gz: man/%
 	gzip -c -9 $< > $@


### PR DESCRIPTION
The `shard.lock` recipe doesn't touch the target if `SHARDS=false` when bootstrapping by downloading `lib/molinillo` with curl.
This means `shard.lock` can be considered outdated, even though its up to date.

Ref https://github.com/crystal-lang/distribution-scripts/issues/330#issuecomment-2621878153