### PR TITLE
Dependency cli parsing

### DIFF
--- a/spec/unit/dependency_spec.cr
+++ b/spec/unit/dependency_spec.cr
@@ -71,6 +71,49 @@ module Shards
       parse_dependency({foo: {git: "", tag: "rc-1.0"}}).to_s.should eq("foo (tag rc-1.0)")
       parse_dependency({foo: {git: "", commit: "4478d8afe8c728f44b47d3582a270423cd7fc07d"}}).to_s.should eq("foo (commit 4478d8a)")
     end
+
+    it ".parts_from_cli" do
+      # GitHub short syntax
+      Dependency.parts_from_cli("github:foo/bar").should eq({resolver_key: "github", source: "foo/bar", requirement: Any})
+      Dependency.parts_from_cli("github:Foo/Bar@1.2.3").should eq({resolver_key: "github", source: "Foo/Bar", requirement: VersionReq.new("~> 1.2.3")})
+
+      # GitHub urls
+      Dependency.parts_from_cli("https://github.com/foo/bar").should eq({resolver_key: "github", source: "foo/bar", requirement: Any})
+      Dependency.parts_from_cli("https://github.com/Foo/Bar/commit/000000").should eq({resolver_key: "github", source: "Foo/Bar", requirement: GitCommitRef.new("000000")})
+      Dependency.parts_from_cli("https://github.com/Foo/Bar/tree/v1.2.3").should eq({resolver_key: "github", source: "Foo/Bar", requirement: GitTagRef.new("v1.2.3")})
+      Dependency.parts_from_cli("https://github.com/Foo/Bar/tree/some/branch").should eq({resolver_key: "github", source: "Foo/Bar", requirement: GitBranchRef.new("some/branch")})
+
+      # GitLab short syntax
+      Dependency.parts_from_cli("gitlab:foo/bar").should eq({resolver_key: "gitlab", source: "foo/bar", requirement: Any})
+
+      # GitLab urls
+      Dependency.parts_from_cli("https://gitlab.com/foo/bar").should eq({resolver_key: "gitlab", source: "foo/bar", requirement: Any})
+
+      # Bitbucket short syntax
+      Dependency.parts_from_cli("bitbucket:foo/bar").should eq({resolver_key: "bitbucket", source: "foo/bar", requirement: Any})
+
+      # bitbucket urls
+      Dependency.parts_from_cli("https://bitbucket.com/foo/bar").should eq({resolver_key: "bitbucket", source: "foo/bar", requirement: Any})
+
+      # Git convenient syntax since resolver matches scheme
+      Dependency.parts_from_cli("git://git.example.org/crystal-library.git").should eq({resolver_key: "git", source: "git://git.example.org/crystal-library.git", requirement: Any})
+
+      # Local paths
+      local_absolute = File.join(tmp_path, "local")
+      local_relative = File.join("spec", ".repositories", "local") # rel_path is relative to integration spec
+      Dir.mkdir_p(local_absolute)
+
+      # Path short syntax
+      Dependency.parts_from_cli(local_absolute).should eq({resolver_key: "path", source: local_absolute, requirement: Any})
+      Dependency.parts_from_cli(local_relative).should eq({resolver_key: "path", source: local_relative, requirement: Any})
+
+      # Path resolver syntax
+      Dependency.parts_from_cli("path:#{local_absolute}").should eq({resolver_key: "path", source: local_absolute, requirement: Any})
+      Dependency.parts_from_cli("path:#{local_relative}").should eq({resolver_key: "path", source: local_relative, requirement: Any})
+
+      # Other resolvers short
+      Dependency.parts_from_cli("git:git://git.example.org/crystal-library.git").should eq({resolver_key: "git", source: "git://git.example.org/crystal-library.git", requirement: Any})
+    end
   end
 end
 

--- a/src/resolvers/resolver.cr
+++ b/src/resolvers/resolver.cr
@@ -103,6 +103,10 @@ module Shards
     private RESOLVER_CLASSES = {} of String => Resolver.class
     private RESOLVER_CACHE   = {} of ResolverCacheKey => Resolver
 
+    def self.resolver_keys
+      RESOLVER_CLASSES.keys
+    end
+
     def self.register_resolver(key, resolver)
       RESOLVER_CLASSES[key] = resolver
     end


### PR DESCRIPTION
Related to #672, this PR adds the logic to parse dependencies from the cli. Still not used, but worth discussing syntax and implementation.

The `Dependency` class unfortunately is not fit to generate the `shard.yaml`. Resolver key and source are normalized. I patched it to allow this, but the solution is not clean. We could use a separate type which would be cleaner, but is odd that the `Spec` would not use that new type when parsing the `shard.yaml`.

The added spec shows the various syntax supported.

To create a proper dependency, with the shard name, we need to actually fetch the shard to resolve that. This is done in `Dependency.from_cli` while the `Dependency.parts_from_cli` is just the parsing without side effects.

In general `{resolver}:{source}` syntax is supported, but there are some shorthands for convenience.

- `github:foo/bar`
- `github:Foo/Bar@1.2.3` (which will mean `~> 1.2.3`)
- `https://github.com/foo/bar` and other known hosts like gitlab, bitbucket, and codeberg
- `https://github.com/Foo/Bar/commit/000000`
- `https://github.com/Foo/Bar/tree/v1.2.3` (which is interpreted as a tag since it's prefixed with `v`)
- `https://github.com/Foo/Bar/tree/some/branch`
- relative and absolute paths

Some of these are maybe controversial, feel free to discuss. 

If you want to play around you can use the following code.

```crystal
require "./src/dependency"

def t(s)
  d = Shards::Dependency.from_cli(s)
  pp! d

  puts "\nshard.yaml"
  puts(YAML.build do |yaml|
    yaml.mapping do
      d.to_shard_yaml(yaml)
    end
  end)

  puts "\nshard.lock"
  puts(YAML.build do |yaml|
    yaml.mapping do
      d.to_yaml(yaml)
    end
  end)
end

t("github:crystal-lang/crystal-db")

t("github:crystal-lang/crystal-db@0.13.0")
```

which will output

```
Fetching https://github.com/crystal-lang/crystal-db.git
d # => #<Shards::Dependency:0x10482be60
 @name="db",
 @requirement=*,
 @resolver=
  #<Shards::GitResolver:0x104823200
   @local_path=
    "/Users/bcardiff/.cache/shards/github.com/crystal-lang/crystal-db.git",
   @name="unknown",
   @origin_url="https://github.com/crystal-lang/crystal-db.git",
   @source="https://github.com/crystal-lang/crystal-db.git",
   @updated_cache=true>,
 @resolver_key="github",
 @source="crystal-lang/crystal-db">

shard.yaml
---
db:
  github: crystal-lang/crystal-db

shard.lock
---
db:
  git: https://github.com/crystal-lang/crystal-db.git
d # => #<Shards::Dependency:0x10482b9b0
 @name="db",
 @requirement=Shards::VersionReq(@patterns=["~> 0.13.0"]),
 @resolver=
  #<Shards::GitResolver:0x104823200
   @local_path=
    "/Users/bcardiff/.cache/shards/github.com/crystal-lang/crystal-db.git",
   @name="unknown",
   @origin_url="https://github.com/crystal-lang/crystal-db.git",
   @source="https://github.com/crystal-lang/crystal-db.git",
   @updated_cache=true>,
 @resolver_key="github",
 @source="crystal-lang/crystal-db">

shard.yaml
---
db:
  github: crystal-lang/crystal-db
  version: ~> 0.13.0

shard.lock
---
db:
  git: https://github.com/crystal-lang/crystal-db.git
  version: ~> 0.13.0
```