### PR TITLE
Clarify tag name expectations for release tags

### DIFF
--- a/docs/shard.yml.adoc
+++ b/docs/shard.yml.adoc
@@ -295,7 +295,9 @@ The URL may be https://git-scm.com/docs/git-clone#_git_urls[any protocol]
 supported by Git, which includes SSH, GIT and HTTPS.
 +
 The Git repository will be cloned, the list of versions (and associated
-_shard.yml_) will be extracted from Git tags (e.g., _v1.2.3_).
+_shard.yml_) will be extracted from Git tags matching the release pattern
+`v<version>` (e.g., _v1.2.3_). Release tags without a leading `v` are ignored
+for version resolution.
 +
 One of the other attributes (_version_, _tag_, _branch_ or _commit_) is
 required. When missing, Shards will install the HEAD refs.
@@ -341,7 +343,9 @@ The URL may be https://www.mercurial-scm.org/repo/hg/help/clone[any protocol]
 supported by Mercurial, which includes SSH and HTTPS.
 +
 The Mercurial repository will be cloned, the list of versions (and associated
-_shard.yml_) will be extracted from Mercurial tags (e.g., _v1.2.3_).
+_shard.yml_) will be extracted from Mercurial tags matching the release pattern
+`v<version>` (e.g., _v1.2.3_). Release tags without a leading `v` are ignored
+for version resolution.
 +
 One of the other attributes (_version_, _tag_, _branch_, _bookmark_ or _commit_) is
 required. When missing, Shards will install the _@_ bookmark or _tip_.
@@ -356,7 +360,9 @@ The URL may be https://fossil-scm.org/home/help/clone[any protocol]
 supported by Fossil, which includes SSH and HTTPS.
 +
 The Fossil repository will be cloned, the list of versions (and associated
-_shard.yml_) will be extracted from Fossil tags (e.g., _v1.2.3_).
+_shard.yml_) will be extracted from Fossil tags matching the release pattern
+`v<version>` (e.g., _v1.2.3_). Release tags without a leading `v` are ignored
+for version resolution.
 +
 One of the other attributes (_version_, _tag_, _branch_, or _commit_) is
 required. When missing, Shards will install _trunk_.

--- a/man/shard.yml.5
+++ b/man/shard.yml.5
@@ -2,12 +2,12 @@
 .\"     Title: shard.yml
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.26
-.\"      Date: 2025-01-13
+.\"      Date: 2026-08-30
 .\"    Manual: File Formats
-.\"    Source: shards 0.20.0
+.\"    Source: shards 0.21.0-dev
 .\"  Language: English
 .\"
-.TH "SHARD.YML" "5" "2025-01-13" "shards 0.20.0" "File Formats"
+.TH "SHARD.YML" "5" "2026-08-30" "shards 0.21.0\-dev" "File Formats"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -552,7 +552,9 @@ The URL may be \c
 supported by Git, which includes SSH, GIT and HTTPS.
 .sp
 The Git repository will be cloned, the list of versions (and associated
-\fIshard.yml\fP) will be extracted from Git tags (e.g., \fIv1.2.3\fP).
+\fIshard.yml\fP) will be extracted from Git tags matching the release pattern
+\f(CRv<version>\fP (e.g., \fIv1.2.3\fP). Release tags without a leading \f(CRv\fP are ignored
+for version resolution.
 .sp
 One of the other attributes (\fIversion\fP, \fItag\fP, \fIbranch\fP or \fIcommit\fP) is
 required. When missing, Shards will install the HEAD refs.
@@ -608,7 +610,9 @@ The URL may be \c
 supported by Mercurial, which includes SSH and HTTPS.
 .sp
 The Mercurial repository will be cloned, the list of versions (and associated
-\fIshard.yml\fP) will be extracted from Mercurial tags (e.g., \fIv1.2.3\fP).
+\fIshard.yml\fP) will be extracted from Mercurial tags matching the release pattern
+\f(CRv<version>\fP (e.g., \fIv1.2.3\fP). Release tags without a leading \f(CRv\fP are ignored
+for version resolution.
 .sp
 One of the other attributes (\fIversion\fP, \fItag\fP, \fIbranch\fP, \fIbookmark\fP or \fIcommit\fP) is
 required. When missing, Shards will install the \fI@\fP bookmark or \fItip\fP.
@@ -628,7 +632,9 @@ The URL may be \c
 supported by Fossil, which includes SSH and HTTPS.
 .sp
 The Fossil repository will be cloned, the list of versions (and associated
-\fIshard.yml\fP) will be extracted from Fossil tags (e.g., \fIv1.2.3\fP).
+\fIshard.yml\fP) will be extracted from Fossil tags matching the release pattern
+\f(CRv<version>\fP (e.g., \fIv1.2.3\fP). Release tags without a leading \f(CRv\fP are ignored
+for version resolution.
 .sp
 One of the other attributes (\fIversion\fP, \fItag\fP, \fIbranch\fP, or \fIcommit\fP) is
 required. When missing, Shards will install \fItrunk\fP.


### PR DESCRIPTION
### Description

This PR updates `docs/shard.yml.adoc` (and rebuilds `man/shard.yml.5`) to explicitly document that:
* When resolving dependencies by version requirements (`version:`), Git, Mercurial, and Fossil tags must follow the `v<version>` naming pattern (e.g. `v1.2.3`); tags without a leading `v` are ignored by the SemVer resolver.

### Motivation & Verification

Addresses the documentation gap in #521 (note: solver CLI error diagnostics are separately tracked in #633).

Verified locally with:
- `crystal tool format --check`
- `make docs`
- `crystal spec spec/unit` (86 examples, 0 failures)

Co-authored-by: Gemini <gemini@google.com>